### PR TITLE
Refactor convolution.c.src

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,4 @@ wt.[ch]
 cythonize.dat
 pywt/__config__.py
 pywt/version.py
+build.log

--- a/pywt/src/_pywt.pyx
+++ b/pywt/src/_pywt.pyx
@@ -83,8 +83,6 @@ class _Modes(object):
     sp1 = c_wt.MODE_SMOOTH
     per = c_wt.MODE_PERIODIZATION
 
-    _asym = c_wt.MODE_ASYMMETRIC
-
     modes = ["zpd", "cpd", "sym", "ppd", "sp1", "per"]
 
     def from_object(self, mode):

--- a/pywt/src/c_wt.pxd
+++ b/pywt/src/c_wt.pxd
@@ -23,14 +23,14 @@ cdef extern from "common.h":
     # buffers lengths
     cdef size_t dwt_buffer_length(size_t input_len, size_t filter_len, MODE mode)
     cdef size_t upsampling_buffer_length(size_t coeffs_len, size_t filter_len,
-                                          MODE mode)
+                                         MODE mode)
+    cdef size_t reconstruction_buffer_length(size_t coeffs_len, size_t filter_len)
     cdef size_t idwt_buffer_length(size_t coeffs_len, size_t filter_len, MODE mode)
     cdef size_t swt_buffer_length(size_t coeffs_len)
-    cdef size_t reconstruction_buffer_length(size_t coeffs_len, size_t filter_len)
 
     # max dec levels
-    cdef int dwt_max_level(size_t input_len, size_t filter_len)
-    cdef int swt_max_level(size_t input_len)
+    cdef unsigned char dwt_max_level(size_t input_len, size_t filter_len)
+    cdef unsigned char swt_max_level(size_t input_len)
 
 
 cdef extern from "wavelets.h":

--- a/pywt/src/c_wt.pxd
+++ b/pywt/src/c_wt.pxd
@@ -41,7 +41,6 @@ cdef extern from "wavelets.h":
         SYMMETRIC
 
     ctypedef struct Wavelet:
-
         double* dec_hi_double      # highpass decomposition
         double* dec_lo_double      # lowpass   decomposition
         double* rec_hi_double      # highpass reconstruction
@@ -52,26 +51,18 @@ cdef extern from "wavelets.h":
         float* rec_hi_float
         float* rec_lo_float
 
-
         size_t dec_len         # length of decomposition filter
         size_t rec_len         # length of reconstruction filter
-
-        # FIXME: Are these used?
-        index_t dec_hi_offset
-        index_t dec_lo_offset
-        index_t rec_hi_offset
-        index_t rec_lo_offset
 
         int vanishing_moments_psi
         int vanishing_moments_phi
         index_t support_width
 
-        int orthogonal
-        int biorthogonal
+        unsigned int orthogonal
+        unsigned int biorthogonal
+        unsigned int compact_support
 
-        int symmetry
-
-        int compact_support
+        SYMMETRY symmetry
 
         int _builtin
 

--- a/pywt/src/c_wt.pxd
+++ b/pywt/src/c_wt.pxd
@@ -9,7 +9,7 @@ cdef extern from "common.h":
     cdef void* wtmalloc(long size)
     cdef void* wtcalloc(long len, long size)
     cdef void wtfree(void* ptr)
-    
+
     ctypedef enum MODE:
         MODE_INVALID = -1
         MODE_ZEROPAD = 0
@@ -24,7 +24,7 @@ cdef extern from "common.h":
 
     # buffers lengths
     cdef index_t dwt_buffer_length(index_t input_len, index_t filter_len, MODE mode)
-    cdef index_t upsampling_buffer_length(index_t coeffs_len, index_t filter_len,   
+    cdef index_t upsampling_buffer_length(index_t coeffs_len, index_t filter_len,
                                           MODE mode)
     cdef index_t idwt_buffer_length(index_t coeffs_len, index_t filter_len, MODE mode)
     cdef index_t swt_buffer_length(index_t coeffs_len)
@@ -48,13 +48,13 @@ cdef extern from "wavelets.h":
         double* dec_lo_double      # lowpass   decomposition
         double* rec_hi_double      # highpass reconstruction
         double* rec_lo_double      # lowpass   reconstruction
-        
+
         float* dec_hi_float
         float* dec_lo_float
         float* rec_hi_float
         float* rec_lo_float
-        
-        
+
+
         index_t dec_len         # length of decomposition filter
         index_t rec_len         # length of reconstruction filter
 
@@ -97,7 +97,7 @@ cdef extern from "wt.h":
     cdef int double_rec_d(double coeffs_d[], index_t coeffs_len, Wavelet* wavelet,
                           double output[], index_t output_len)
 
-    cdef int double_idwt(double coeffs_a[], index_t coeffs_a_len, 
+    cdef int double_idwt(double coeffs_a[], index_t coeffs_a_len,
                          double coeffs_d[], index_t coeffs_d_len,
                          Wavelet* wavelet, double output[], index_t output_len,
                          MODE mode, int correct_size)
@@ -118,7 +118,7 @@ cdef extern from "wt.h":
     cdef int float_rec_d(float coeffs_d[], index_t coeffs_len, Wavelet* wavelet,
                          float output[], index_t output_len)
 
-    cdef int float_idwt(float coeffs_a[], index_t coeffs_a_len, 
+    cdef int float_idwt(float coeffs_a[], index_t coeffs_a_len,
                         float coeffs_d[], index_t coeffs_d_len,
                         Wavelet* wavelet, float output[], index_t output_len,
                         MODE mode, int correct_size)
@@ -127,6 +127,3 @@ cdef extern from "wt.h":
                          float output[], index_t output_len, int level)
     cdef int float_swt_d(float input[], index_t input_len, Wavelet* wavelet,
                          float output[], index_t output_len, int level)
-
-
-

--- a/pywt/src/c_wt.pxd
+++ b/pywt/src/c_wt.pxd
@@ -13,7 +13,6 @@ cdef extern from "common.h":
         MODE_INVALID = -1
         MODE_ZEROPAD = 0
         MODE_SYMMETRIC
-        MODE_ASYMMETRIC
         MODE_CONSTANT_EDGE
         MODE_SMOOTH
         MODE_PERIODIC

--- a/pywt/src/c_wt.pxd
+++ b/pywt/src/c_wt.pxd
@@ -86,20 +86,28 @@ cdef extern from "wavelets.h":
 
 cdef extern from "wt.h":
 
-    cdef int double_dec_a(double input[], size_t input_len, Wavelet* wavelet,
-                          double output[], size_t output_len, MODE mode)
-    cdef int double_dec_d(double input[], size_t input_len, Wavelet* wavelet,
-                          double output[], size_t output_len, MODE mode)
+    # Cython does not know the 'restrict' keyword
+    cdef int double_dec_a(const double  * const input, const size_t input_len,
+                          const Wavelet * const wavelet,
+                          double  * const output, const size_t output_len,
+                          const MODE mode)
+    cdef int double_dec_d(const double  * const input, const size_t input_len,
+                          const Wavelet * const wavelet,
+                          double  * const output, const size_t output_len,
+                          const MODE mode)
 
-    cdef int double_rec_a(double coeffs_a[], size_t coeffs_len, Wavelet* wavelet,
-                          double output[], size_t output_len)
-    cdef int double_rec_d(double coeffs_d[], size_t coeffs_len, Wavelet* wavelet,
-                          double output[], size_t output_len)
+    cdef int double_rec_a(const double * const coeffs_a, const size_t coeffs_len,
+                          const Wavelet * const wavelet,
+                          double  * const output, const size_t output_len)
+    cdef int double_rec_d(const double * const coeffs_d, const size_t coeffs_len,
+                          const Wavelet * const wavelet,
+                          double  * const output, const size_t output_len)
 
-    cdef int double_idwt(double coeffs_a[], size_t coeffs_a_len,
-                         double coeffs_d[], size_t coeffs_d_len,
-                         Wavelet* wavelet, double output[], size_t output_len,
-                         MODE mode, int correct_size)
+    cdef int double_idwt(double * const coeffs_a, const size_t coeffs_a_len,
+                         double * const coeffs_d, const size_t coeffs_d_len,
+                         const Wavelet * const wavelet,
+                         double  * const output, const size_t output_len,
+                         const MODE mode, const int correct_size)
 
     cdef int double_swt_a(double input[], index_t input_len, Wavelet* wavelet,
                           double output[], index_t output_len, int level)
@@ -107,20 +115,27 @@ cdef extern from "wt.h":
                           double output[], index_t output_len, int level)
 
 
-    cdef int float_dec_a(float input[], size_t input_len, Wavelet* wavelet,
-                         float output[], size_t output_len, MODE mode)
-    cdef int float_dec_d(float input[], size_t input_len, Wavelet* wavelet,
-                         float output[], size_t output_len, MODE mode)
+    cdef int float_dec_a(const float  * const input, const size_t input_len,
+                         const Wavelet * const wavelet,
+                         float  * const output, const size_t output_len,
+                         const MODE mode)
+    cdef int float_dec_d(const float  * const input, const size_t input_len,
+                         const Wavelet * const wavelet,
+                         float  * const output, const size_t output_len,
+                         const MODE mode)
 
-    cdef int float_rec_a(float coeffs_a[], size_t coeffs_len, Wavelet* wavelet,
-                         float output[], size_t output_len)
-    cdef int float_rec_d(float coeffs_d[], size_t coeffs_len, Wavelet* wavelet,
-                         float output[], size_t output_len)
+    cdef int float_rec_a(const float * const coeffs_a, const size_t coeffs_len,
+                         const Wavelet * const wavelet,
+                         float  * const output, const size_t output_len)
+    cdef int float_rec_d(const float * const coeffs_d, const size_t coeffs_len,
+                         const Wavelet * const wavelet,
+                         float  * const output, const size_t output_len)
 
-    cdef int float_idwt(float coeffs_a[], size_t coeffs_a_len,
-                        float coeffs_d[], size_t coeffs_d_len,
-                        Wavelet* wavelet, float output[], size_t output_len,
-                        MODE mode, int correct_size)
+    cdef int float_idwt(const float * const coeffs_a, const size_t coeffs_a_len,
+                        const float * const coeffs_d, const size_t coeffs_d_len,
+                        const Wavelet * const wavelet,
+                        float  * const output, const size_t output_len,
+                        const MODE mode, const int correct_size)
 
     cdef int float_swt_a(float input[], index_t input_len, Wavelet* wavelet,
                          float output[], index_t output_len, int level)

--- a/pywt/src/c_wt.pxd
+++ b/pywt/src/c_wt.pxd
@@ -78,26 +78,26 @@ cdef extern from "wavelets.h":
 cdef extern from "wt.h":
 
     # Cython does not know the 'restrict' keyword
-    cdef int double_dec_a(const double  * const input, const size_t input_len,
+    cdef int double_dec_a(const double * const input, const size_t input_len,
                           const Wavelet * const wavelet,
-                          double  * const output, const size_t output_len,
+                          double * const output, const size_t output_len,
                           const MODE mode)
-    cdef int double_dec_d(const double  * const input, const size_t input_len,
+    cdef int double_dec_d(const double * const input, const size_t input_len,
                           const Wavelet * const wavelet,
-                          double  * const output, const size_t output_len,
+                          double * const output, const size_t output_len,
                           const MODE mode)
 
     cdef int double_rec_a(const double * const coeffs_a, const size_t coeffs_len,
                           const Wavelet * const wavelet,
-                          double  * const output, const size_t output_len)
+                          double * const output, const size_t output_len)
     cdef int double_rec_d(const double * const coeffs_d, const size_t coeffs_len,
                           const Wavelet * const wavelet,
-                          double  * const output, const size_t output_len)
+                          double * const output, const size_t output_len)
 
     cdef int double_idwt(double * const coeffs_a, const size_t coeffs_a_len,
                          double * const coeffs_d, const size_t coeffs_d_len,
                          const Wavelet * const wavelet,
-                         double  * const output, const size_t output_len,
+                         double * const output, const size_t output_len,
                          const MODE mode, const int correct_size)
 
     cdef int double_swt_a(double input[], index_t input_len, Wavelet* wavelet,
@@ -106,26 +106,26 @@ cdef extern from "wt.h":
                           double output[], index_t output_len, int level)
 
 
-    cdef int float_dec_a(const float  * const input, const size_t input_len,
+    cdef int float_dec_a(const float * const input, const size_t input_len,
                          const Wavelet * const wavelet,
-                         float  * const output, const size_t output_len,
+                         float * const output, const size_t output_len,
                          const MODE mode)
-    cdef int float_dec_d(const float  * const input, const size_t input_len,
+    cdef int float_dec_d(const float * const input, const size_t input_len,
                          const Wavelet * const wavelet,
-                         float  * const output, const size_t output_len,
+                         float * const output, const size_t output_len,
                          const MODE mode)
 
     cdef int float_rec_a(const float * const coeffs_a, const size_t coeffs_len,
                          const Wavelet * const wavelet,
-                         float  * const output, const size_t output_len)
+                         float * const output, const size_t output_len)
     cdef int float_rec_d(const float * const coeffs_d, const size_t coeffs_len,
                          const Wavelet * const wavelet,
-                         float  * const output, const size_t output_len)
+                         float * const output, const size_t output_len)
 
     cdef int float_idwt(const float * const coeffs_a, const size_t coeffs_a_len,
                         const float * const coeffs_d, const size_t coeffs_d_len,
                         const Wavelet * const wavelet,
-                        float  * const output, const size_t output_len,
+                        float * const output, const size_t output_len,
                         const MODE mode, const int correct_size)
 
     cdef int float_swt_a(float input[], index_t input_len, Wavelet* wavelet,

--- a/pywt/src/c_wt.pxd
+++ b/pywt/src/c_wt.pxd
@@ -21,16 +21,16 @@ cdef extern from "common.h":
 
 
     # buffers lengths
-    cdef index_t dwt_buffer_length(index_t input_len, index_t filter_len, MODE mode)
-    cdef index_t upsampling_buffer_length(index_t coeffs_len, index_t filter_len,
+    cdef size_t dwt_buffer_length(size_t input_len, size_t filter_len, MODE mode)
+    cdef size_t upsampling_buffer_length(size_t coeffs_len, size_t filter_len,
                                           MODE mode)
-    cdef index_t idwt_buffer_length(index_t coeffs_len, index_t filter_len, MODE mode)
-    cdef index_t swt_buffer_length(index_t coeffs_len)
-    cdef index_t reconstruction_buffer_length(index_t coeffs_len, index_t filter_len)
+    cdef size_t idwt_buffer_length(size_t coeffs_len, size_t filter_len, MODE mode)
+    cdef size_t swt_buffer_length(size_t coeffs_len)
+    cdef size_t reconstruction_buffer_length(size_t coeffs_len, size_t filter_len)
 
     # max dec levels
-    cdef int dwt_max_level(index_t input_len, index_t filter_len)
-    cdef int swt_max_level(index_t input_len)
+    cdef int dwt_max_level(size_t input_len, size_t filter_len)
+    cdef int swt_max_level(size_t input_len)
 
 
 cdef extern from "wavelets.h":
@@ -53,9 +53,10 @@ cdef extern from "wavelets.h":
         float* rec_lo_float
 
 
-        index_t dec_len         # length of decomposition filter
-        index_t rec_len         # length of reconstruction filter
+        size_t dec_len         # length of decomposition filter
+        size_t rec_len         # length of reconstruction filter
 
+        # FIXME: Are these used?
         index_t dec_hi_offset
         index_t dec_lo_offset
         index_t rec_hi_offset
@@ -79,25 +80,25 @@ cdef extern from "wavelets.h":
 
 
     cdef Wavelet* wavelet(char name, int type)
-    cdef Wavelet* blank_wavelet(index_t filter_length)
+    cdef Wavelet* blank_wavelet(size_t filter_length)
     cdef void free_wavelet(Wavelet* wavelet)
 
 
 cdef extern from "wt.h":
 
-    cdef int double_dec_a(double input[], index_t input_len, Wavelet* wavelet,
-                          double output[], index_t output_len, MODE mode)
-    cdef int double_dec_d(double input[], index_t input_len, Wavelet* wavelet,
-                          double output[], index_t output_len, MODE mode)
+    cdef int double_dec_a(double input[], size_t input_len, Wavelet* wavelet,
+                          double output[], size_t output_len, MODE mode)
+    cdef int double_dec_d(double input[], size_t input_len, Wavelet* wavelet,
+                          double output[], size_t output_len, MODE mode)
 
-    cdef int double_rec_a(double coeffs_a[], index_t coeffs_len, Wavelet* wavelet,
-                          double output[], index_t output_len)
-    cdef int double_rec_d(double coeffs_d[], index_t coeffs_len, Wavelet* wavelet,
-                          double output[], index_t output_len)
+    cdef int double_rec_a(double coeffs_a[], size_t coeffs_len, Wavelet* wavelet,
+                          double output[], size_t output_len)
+    cdef int double_rec_d(double coeffs_d[], size_t coeffs_len, Wavelet* wavelet,
+                          double output[], size_t output_len)
 
-    cdef int double_idwt(double coeffs_a[], index_t coeffs_a_len,
-                         double coeffs_d[], index_t coeffs_d_len,
-                         Wavelet* wavelet, double output[], index_t output_len,
+    cdef int double_idwt(double coeffs_a[], size_t coeffs_a_len,
+                         double coeffs_d[], size_t coeffs_d_len,
+                         Wavelet* wavelet, double output[], size_t output_len,
                          MODE mode, int correct_size)
 
     cdef int double_swt_a(double input[], index_t input_len, Wavelet* wavelet,
@@ -106,19 +107,19 @@ cdef extern from "wt.h":
                           double output[], index_t output_len, int level)
 
 
-    cdef int float_dec_a(float input[], index_t input_len, Wavelet* wavelet,
-                         float output[], index_t output_len, MODE mode)
-    cdef int float_dec_d(float input[], index_t input_len, Wavelet* wavelet,
-                         float output[], index_t output_len, MODE mode)
+    cdef int float_dec_a(float input[], size_t input_len, Wavelet* wavelet,
+                         float output[], size_t output_len, MODE mode)
+    cdef int float_dec_d(float input[], size_t input_len, Wavelet* wavelet,
+                         float output[], size_t output_len, MODE mode)
 
-    cdef int float_rec_a(float coeffs_a[], index_t coeffs_len, Wavelet* wavelet,
-                         float output[], index_t output_len)
-    cdef int float_rec_d(float coeffs_d[], index_t coeffs_len, Wavelet* wavelet,
-                         float output[], index_t output_len)
+    cdef int float_rec_a(float coeffs_a[], size_t coeffs_len, Wavelet* wavelet,
+                         float output[], size_t output_len)
+    cdef int float_rec_d(float coeffs_d[], size_t coeffs_len, Wavelet* wavelet,
+                         float output[], size_t output_len)
 
-    cdef int float_idwt(float coeffs_a[], index_t coeffs_a_len,
-                        float coeffs_d[], index_t coeffs_d_len,
-                        Wavelet* wavelet, float output[], index_t output_len,
+    cdef int float_idwt(float coeffs_a[], size_t coeffs_a_len,
+                        float coeffs_d[], size_t coeffs_d_len,
+                        Wavelet* wavelet, float output[], size_t output_len,
                         MODE mode, int correct_size)
 
     cdef int float_swt_a(float input[], index_t input_len, Wavelet* wavelet,

--- a/pywt/src/c_wt.pxd
+++ b/pywt/src/c_wt.pxd
@@ -4,7 +4,6 @@
 cdef extern from "common.h":
 
     ctypedef int index_t
-    ctypedef int const_index_t
 
     cdef void* wtmalloc(long size)
     cdef void* wtcalloc(long len, long size)

--- a/pywt/src/common.c
+++ b/pywt/src/common.c
@@ -12,6 +12,23 @@ void *wtcalloc(size_t len, size_t size){
 }
 #endif
 
+/* Returns the floor of the base-2 log of it's input
+ *
+ * x = 0
+ *    MSVC: returns 0
+ *    Undefined on GCC/clang
+ */
+unsigned char uint_log2(unsigned long x){
+#if defined(_MSC_VER)
+    unsigned long i;
+    _BitScanReverse(&i, x);
+    return i;
+#else
+    // GCC and clang
+    return sizeof(unsigned long) * 8 - __builtin_clzl(x) - 1;
+#endif
+}
+
 /* buffers and max levels params */
 
 size_t dwt_buffer_length(size_t input_len, size_t filter_len, MODE mode){
@@ -20,9 +37,9 @@ size_t dwt_buffer_length(size_t input_len, size_t filter_len, MODE mode){
 
     switch(mode){
             case MODE_PERIODIZATION:
-                return (index_t) ceil(input_len / 2.0);
+                return input_len / 2 + ((input_len%2) ? 1 : 0);
             default:
-                return (index_t) floor((input_len + filter_len - 1) / 2.0);
+                return (input_len + filter_len - 1) / 2;
     }
 }
 
@@ -34,9 +51,6 @@ size_t reconstruction_buffer_length(size_t coeffs_len, size_t filter_len){
 }
 
 size_t idwt_buffer_length(size_t coeffs_len, size_t filter_len, MODE mode){
-    if(coeffs_len < 0 || filter_len < 0)
-        return 0;
-
     switch(mode){
             case MODE_PERIODIZATION:
                 return 2*coeffs_len;
@@ -46,29 +60,24 @@ size_t idwt_buffer_length(size_t coeffs_len, size_t filter_len, MODE mode){
 }
 
 size_t swt_buffer_length(size_t input_len){
-    if(input_len < 0)
-        return 0;
     return input_len;
 }
 
-int dwt_max_level(size_t input_len, size_t filter_len){
+unsigned char dwt_max_level(size_t input_len, size_t filter_len){
     if(input_len < 1 || filter_len < 2)
         return 0;
 
-    int i;
-    i = (int) floor(log((double)input_len/(double)(filter_len-1)) /log(2.0));
-    return (i > 0) ? i : 0;
+    return uint_log2(input_len/(filter_len-1));
 }
 
-int swt_max_level(size_t input_len){
-    int i, j;
-    i = (int) floor(log((double) input_len)/log(2.0));
-
-    /* check how many times (maximum i times) input_len is divisible by 2 */
-    for(j=0; j <= i; ++j){
-        if((input_len & 0x1)==1)
+unsigned char swt_max_level(size_t input_len){
+    /* check how many times input_len is divisible by 2 */
+    unsigned char j = 0;
+    while (input_len > 0){
+        if (input_len % 2)
             return j;
-        input_len >>= 1;
+        input_len /= 2;
+        j++;
     }
-    return (i > 0) ? i : 0;
+    return j;
 }

--- a/pywt/src/common.c
+++ b/pywt/src/common.c
@@ -29,14 +29,14 @@ index_t dwt_buffer_length(index_t input_len, index_t filter_len, MODE mode){
 index_t reconstruction_buffer_length(index_t coeffs_len, index_t filter_len){
     if(coeffs_len < 1 || filter_len < 1)
         return 0;
-    
+
     return 2*coeffs_len+filter_len-2;
 }
 
 index_t idwt_buffer_length(index_t coeffs_len, index_t filter_len, MODE mode){
     if(coeffs_len < 0 || filter_len < 0)
         return 0;
-    
+
     switch(mode){
             case MODE_PERIODIZATION:
                 return 2*coeffs_len;
@@ -56,7 +56,7 @@ int dwt_max_level(index_t input_len, index_t filter_len){
     int i;
     if(input_len < 1 || filter_len < 2)
         return 0;
-    
+
     i = (int) floor(log((double)input_len/(double)(filter_len-1)) /log(2.0));
     return (i > 0) ? i : 0;
 }

--- a/pywt/src/common.c
+++ b/pywt/src/common.c
@@ -14,7 +14,7 @@ void *wtcalloc(size_t len, size_t size){
 
 /* buffers and max levels params */
 
-index_t dwt_buffer_length(index_t input_len, index_t filter_len, MODE mode){
+size_t dwt_buffer_length(size_t input_len, size_t filter_len, MODE mode){
     if(input_len < 1 || filter_len < 1)
         return 0;
 
@@ -26,14 +26,14 @@ index_t dwt_buffer_length(index_t input_len, index_t filter_len, MODE mode){
     }
 }
 
-index_t reconstruction_buffer_length(index_t coeffs_len, index_t filter_len){
+size_t reconstruction_buffer_length(size_t coeffs_len, size_t filter_len){
     if(coeffs_len < 1 || filter_len < 1)
         return 0;
 
     return 2*coeffs_len+filter_len-2;
 }
 
-index_t idwt_buffer_length(index_t coeffs_len, index_t filter_len, MODE mode){
+size_t idwt_buffer_length(size_t coeffs_len, size_t filter_len, MODE mode){
     if(coeffs_len < 0 || filter_len < 0)
         return 0;
 
@@ -45,23 +45,22 @@ index_t idwt_buffer_length(index_t coeffs_len, index_t filter_len, MODE mode){
     }
 }
 
-index_t swt_buffer_length(index_t input_len){
+size_t swt_buffer_length(size_t input_len){
     if(input_len < 0)
         return 0;
-
     return input_len;
 }
 
-int dwt_max_level(index_t input_len, index_t filter_len){
-    int i;
+int dwt_max_level(size_t input_len, size_t filter_len){
     if(input_len < 1 || filter_len < 2)
         return 0;
 
+    int i;
     i = (int) floor(log((double)input_len/(double)(filter_len-1)) /log(2.0));
     return (i > 0) ? i : 0;
 }
 
-int swt_max_level(index_t input_len){
+int swt_max_level(size_t input_len){
     int i, j;
     i = (int) floor(log((double) input_len)/log(2.0));
 

--- a/pywt/src/common.h
+++ b/pywt/src/common.h
@@ -3,8 +3,7 @@
 
 /* Common constants, typedefs and functions */
 
-#ifndef _COMMON_H_
-#define _COMMON_H_
+#pragma once
 
 #include <stdlib.h>
 #include <memory.h>
@@ -89,6 +88,3 @@ unsigned char dwt_max_level(size_t input_len, size_t filter_len);
 
 /* Maximum useful level of SWT decomposition. */
 unsigned char swt_max_level(size_t input_len);
-
-
-#endif

--- a/pywt/src/common.h
+++ b/pywt/src/common.h
@@ -47,11 +47,15 @@
 typedef enum {
        MODE_INVALID = -1,
        MODE_ZEROPAD = 0,   /* default, signal extended with zeros */
-       MODE_SYMMETRIC,     /* signal extended symmetrically (mirror) */
+       MODE_SYMMETRIC,     /* signal extended symmetrically (mirror)
+                            * For extensions greater than signal length,
+                            * mirror back and forth:
+                            * 2 3 3 2 1 | 1 2 3 | 3 2 1 1 2
+                            */
        MODE_CONSTANT_EDGE, /* signal extended with the border value */
        MODE_SMOOTH,        /* linear extrapolation (first derivative) */
        MODE_PERIODIC,      /* signal is treated as being periodic */
-       MODE_PERIODIZATION, /* signal is treated as being periodic, minimal output lenght */
+       MODE_PERIODIZATION, /* signal is treated as being periodic, minimal output length */
        MODE_MAX,
 } MODE;
 

--- a/pywt/src/common.h
+++ b/pywt/src/common.h
@@ -7,9 +7,7 @@
 #define _COMMON_H_
 
 #include <stdlib.h>
-#include <math.h>
 #include <memory.h>
-
 
 /* ##### Typedefs ##### */
 
@@ -38,6 +36,10 @@
     #define wtmalloc(size)      malloc(size)
     #define wtfree(ptr)         free(ptr)
     #define wtcalloc(len, size) calloc(len, size)
+#endif
+
+#ifdef _MSC_VER
+    #include <intrin.h>
 #endif
 
 
@@ -79,10 +81,10 @@ size_t idwt_buffer_length(size_t coeffs_len, size_t filter_len, MODE mode);
 size_t swt_buffer_length(size_t input_len);
 
 /* Maximum useful level of DWT decomposition. */
-int dwt_max_level(size_t input_len, size_t filter_len);
+unsigned char dwt_max_level(size_t input_len, size_t filter_len);
 
 /* Maximum useful level of SWT decomposition. */
-int swt_max_level(size_t input_len);
+unsigned char swt_max_level(size_t input_len);
 
 
 #endif

--- a/pywt/src/common.h
+++ b/pywt/src/common.h
@@ -60,29 +60,29 @@ typedef enum {
  * Length of DWT coeffs for specified input data length, filter length and
  * signal extension mode.
  */
-index_t dwt_buffer_length(index_t input_len, index_t filter_len, MODE mode);
+size_t dwt_buffer_length(size_t input_len, size_t filter_len, MODE mode);
 
 /*
  * Length of reconstructed signal for specified input coeffs length and filter
  * length. It is used for direct reconstruction from coefficients (normal
  * convolution of upsampled coeffs with filter).
  */
-index_t reconstruction_buffer_length(index_t coeffs_len, index_t filter_len);
+size_t reconstruction_buffer_length(size_t coeffs_len, size_t filter_len);
 
 /*
  * Length of IDWT reconstructed signal for specified input coeffs length, filter
  * length and extension mode.
  */
-index_t idwt_buffer_length(index_t coeffs_len, index_t filter_len, MODE mode);
+size_t idwt_buffer_length(size_t coeffs_len, size_t filter_len, MODE mode);
 
 /* Length of SWT coefficients for specified input signal length (== input_len) */
-index_t swt_buffer_length(index_t input_len);
+size_t swt_buffer_length(size_t input_len);
 
 /* Maximum useful level of DWT decomposition. */
-int dwt_max_level(index_t input_len, index_t filter_len);
+int dwt_max_level(size_t input_len, size_t filter_len);
 
 /* Maximum useful level of SWT decomposition. */
-int swt_max_level(index_t input_len);
+int swt_max_level(size_t input_len);
 
 
 #endif

--- a/pywt/src/common.h
+++ b/pywt/src/common.h
@@ -51,7 +51,6 @@ typedef enum {
        MODE_PERIODIC,      /* signal is treated as being periodic */
        MODE_PERIODIZATION, /* signal is treated as being periodic, minimal output lenght */
        MODE_MAX,
-       MODE_ASYMMETRIC /* TODO */
 } MODE;
 
 

--- a/pywt/src/common.h
+++ b/pywt/src/common.h
@@ -25,7 +25,7 @@
     #else
         #include "Python.h"
     #endif
-    
+
     typedef Py_ssize_t index_t;
 
     /* using Python's memory manager */
@@ -33,7 +33,7 @@
     #define wtfree(ptr)         PyMem_Free(ptr)
     void *wtcalloc(size_t, size_t);
 #else
-    typedef int index_t; 
+    typedef int index_t;
     /* standard c memory management */
     #define wtmalloc(size)      malloc(size)
     #define wtfree(ptr)         free(ptr)
@@ -66,14 +66,14 @@ typedef enum {
  */
 index_t dwt_buffer_length(index_t input_len, index_t filter_len, MODE mode);
 
-/* 
+/*
  * Length of reconstructed signal for specified input coeffs length and filter
  * length. It is used for direct reconstruction from coefficients (normal
  * convolution of upsampled coeffs with filter).
  */
 index_t reconstruction_buffer_length(index_t coeffs_len, index_t filter_len);
 
-/* 
+/*
  * Length of IDWT reconstructed signal for specified input coeffs length, filter
  * length and extension mode.
  */

--- a/pywt/src/common.h
+++ b/pywt/src/common.h
@@ -41,9 +41,6 @@
 #endif
 
 
-typedef const index_t const_index_t;
-
-
 /* Signal extension modes */
 typedef enum {
        MODE_INVALID = -1,

--- a/pywt/src/convolution.c.src
+++ b/pywt/src/convolution.c.src
@@ -38,9 +38,10 @@ int @type@_downsampling_convolution_periodization(const @type@ * const restrict 
         for (j = 0; j <= i; ++j)
             sum += filter[j] * input[i-j];
         while (j < F){
-            for (size_t k = 0; k < padding && j < F; ++k, ++j)
+            size_t k;
+            for (k = 0; k < padding && j < F; ++k, ++j)
                 sum += filter[j] * input[N-1];
-            for (size_t k = 0; k < N && j < F; ++k, ++j)
+            for (k = 0; k < N && j < F; ++k, ++j)
                 sum += filter[j] * input[N-1-k];
         }
         output[o] = sum;
@@ -48,7 +49,8 @@ int @type@_downsampling_convolution_periodization(const @type@ * const restrict 
 
     for(; i < N; i+=step, ++o){
         @type@ sum = 0;
-        for(size_t j = 0; j < F; ++j)
+        size_t j;
+        for(j = 0; j < F; ++j)
             sum += input[i-j]*filter[j];
         output[o] = sum;
     }
@@ -58,17 +60,19 @@ int @type@_downsampling_convolution_periodization(const @type@ * const restrict 
         size_t j = 0;
 
         while (i-j >= N){
-            for (size_t k = 0; k < padding && i-j >= N; ++k, ++j)
+            size_t k;
+            for (k = 0; k < padding && i-j >= N; ++k, ++j)
                 sum += filter[i-N-j] * input[N-1];
-            for (size_t k = 0; k < N && i-j >= N; ++k, ++j)
+            for (k = 0; k < N && i-j >= N; ++k, ++j)
                 sum += filter[i-N-j] * input[k];
         }
         for (; j <= i; ++j)
             sum += filter[j] * input[i-j];
         while (j < F){
-            for (size_t k = 0; k < padding && j < F; ++k, ++j)
+            size_t k;
+            for (k = 0; k < padding && j < F; ++k, ++j)
                 sum += filter[j] * input[N-1];
-            for (size_t k = 0; k < N && j < F; ++k, ++j)
+            for (k = 0; k < N && j < F; ++k, ++j)
                 sum += filter[j] * input[N-1-k];
         }
         output[o] = sum;
@@ -78,9 +82,10 @@ int @type@_downsampling_convolution_periodization(const @type@ * const restrict 
         @type@ sum = 0;
         size_t j = 0;
         while (i-j >= N){
-            for (size_t k = 0; k < padding && i-j >= N; ++k, ++j)
+            size_t k;
+            for (k = 0; k < padding && i-j >= N; ++k, ++j)
                 sum += filter[i-N-j] * input[N-1];
-            for (size_t k = 0; k < N && i-j >= N; ++k, ++j)
+            for (k = 0; k < N && i-j >= N; ++k, ++j)
                 sum += filter[i-N-j] * input[k];
         }
         for (; j < F; ++j)
@@ -118,9 +123,10 @@ int @type@_downsampling_convolution(const @type@ * const restrict input, const s
         switch(mode) {
         case MODE_SYMMETRIC:
             while (j < F){
-                for(size_t k = 0; k < N && j < F; ++j, ++k)
+                size_t k;
+                for(k = 0; k < N && j < F; ++j, ++k)
                     sum += filter[j]*input[k];
-                for(size_t k = 0; k < N && j < F; ++k, ++j)
+                for(k = 0; k < N && j < F; ++k, ++j)
                     sum += filter[j] * input[N-1-k];
             }
             break;
@@ -128,14 +134,18 @@ int @type@_downsampling_convolution(const @type@ * const restrict input, const s
             for(; j < F; ++j)
                 sum += filter[j]*input[0];
             break;
-        case MODE_SMOOTH:
-            for(size_t k = 1; j < F; ++j, ++k)
+        case MODE_SMOOTH:{
+            size_t k;
+            for(k = 1; j < F; ++j, ++k)
                 sum += filter[j]*(input[0] + k * (input[0] - input[1]));
             break;
+        }
         case MODE_PERIODIC:
-            while (j < F)
-                for(size_t k = 0; k < N && j < F; ++k, ++j)
+            while (j < F){
+                size_t k;
+                for(k = 0; k < N && j < F; ++k, ++j)
                     sum += filter[j]*input[N-1-k];
+            }
             break;
         case MODE_ZEROPAD:
         default:
@@ -146,8 +156,8 @@ int @type@_downsampling_convolution(const @type@ * const restrict input, const s
 
     for(; i < N; i+=step, ++o){
         @type@ sum = 0;
-
-        for(size_t j = 0; j < F; ++j)
+        size_t j;
+        for(j = 0; j < F; ++j)
             sum += input[i-j]*filter[j];
         output[o] = sum;
     }
@@ -163,9 +173,10 @@ int @type@_downsampling_convolution(const @type@ * const restrict input, const s
              * data. This gives a known first input element to process (N-1)
              */
             while (i - j >= N){
-                for(size_t k = 0; k < N && i-j >= N; ++j, ++k)
+                size_t k;
+                for(k = 0; k < N && i-j >= N; ++j, ++k)
                     sum += filter[i-N-j]*input[N-1-k];
-                for(size_t k = 0; k < N && i-j >= N; ++j, ++k)
+                for(k = 0; k < N && i-j >= N; ++j, ++k)
                     sum += filter[i-N-j]*input[k];
             }
             break;
@@ -173,14 +184,18 @@ int @type@_downsampling_convolution(const @type@ * const restrict input, const s
             for(; i-j >= N; ++j)
                 sum += filter[j]*input[N-1];
             break;
-        case MODE_SMOOTH:
-            for(size_t k = i - N + 1; i-j >= N; ++j, --k)
+        case MODE_SMOOTH:{
+            size_t k;
+            for(k = i - N + 1; i-j >= N; ++j, --k)
                 sum += filter[j]*(input[N-1] + k * (input[N-1] - input[N-2]));
             break;
+        }
         case MODE_PERIODIC:
-            while (i-j >= N)
-                for (size_t k = 0; k < N && i-j >= N; ++j, ++k)
+            while (i-j >= N){
+                size_t k;
+                for (k = 0; k < N && i-j >= N; ++j, ++k)
                     sum += filter[i-N-j]*input[k];
+            }
             break;
         case MODE_ZEROPAD:
         default:
@@ -194,9 +209,10 @@ int @type@_downsampling_convolution(const @type@ * const restrict input, const s
         switch(mode) {
         case MODE_SYMMETRIC:
             while (j < F){
-                for(size_t k = 0; k < N && j < F; ++j, ++k)
+                size_t k;
+                for(k = 0; k < N && j < F; ++j, ++k)
                     sum += filter[j]*input[k];
-                for(size_t k = 0; k < N && j < F; ++k, ++j)
+                for(k = 0; k < N && j < F; ++k, ++j)
                     sum += filter[j] * input[N-1-k];
             }
             break;
@@ -204,14 +220,18 @@ int @type@_downsampling_convolution(const @type@ * const restrict input, const s
             for(; j < F; ++j)
                 sum += filter[j]*input[0];
             break;
-        case MODE_SMOOTH:
-            for(size_t k = 1; j < F; ++j, ++k)
+        case MODE_SMOOTH:{
+            size_t k;
+            for(k = 1; j < F; ++j, ++k)
                 sum += filter[j]*(input[0] + k * (input[0] - input[1]));
             break;
+        }
         case MODE_PERIODIC:
-            while (j < F)
-                for(size_t k = 0; k < N && j < F; ++k, ++j)
+            while (j < F){
+                size_t k;
+                for(k = 0; k < N && j < F; ++k, ++j)
                     sum += filter[j]*input[N-1-k];
+            }
             break;
         case MODE_ZEROPAD:
         default:
@@ -227,9 +247,10 @@ int @type@_downsampling_convolution(const @type@ * const restrict input, const s
         case MODE_SYMMETRIC:
             // Included from original: TODO: j < F-_offset
             while (i - j >= N){
-                for(size_t k = 0; k < N && i-j >= N; ++j, ++k)
+                size_t k;
+                for(k = 0; k < N && i-j >= N; ++j, ++k)
                     sum += filter[i-N-j]*input[N-1-k];
-                for(size_t k = 0; k < N && i-j >= N; ++j, ++k)
+                for(k = 0; k < N && i-j >= N; ++j, ++k)
                     sum += filter[i-N-j]*input[k];
             }
             break;
@@ -237,14 +258,18 @@ int @type@_downsampling_convolution(const @type@ * const restrict input, const s
             for(; i-j >= N; ++j)
                 sum += filter[j]*input[N-1];
             break;
-        case MODE_SMOOTH:
-            for(size_t k = i - N + 1; i-j >= N; ++j, --k)
+        case MODE_SMOOTH:{
+            size_t k;
+            for(k = i - N + 1; i-j >= N; ++j, --k)
                 sum += filter[j]*(input[N-1] + k * (input[N-1] - input[N-2]));
             break;
+        }
         case MODE_PERIODIC:
-            while (i-j >= N)
-                for (size_t k = 0; k < N && i-j >= N; ++j, ++k)
+            while (i-j >= N){
+                size_t k;
+                for (k = 0; k < N && i-j >= N; ++j, ++k)
                     sum += filter[i-N-j]*input[k];
+            }
             break;
         case MODE_ZEROPAD:
         default:
@@ -273,34 +298,42 @@ int @type@_upsampling_convolution_full(const @type@ * const restrict input, cons
     // FIXME? Return a valid result for i%2 != 0? Not for idwt, but could be useful.
 
     // If check omitted, this function would be a no-op for F<2
+    size_t i = 0, o = 0;
+
     if(F<2)
         return -1;
 
-    size_t i = 0, o = 0;
-
-    for(; i < N && i < F/2; ++i, o += 2)
-        for(size_t j = 0; j <= i; ++j){
+    for(; i < N && i < F/2; ++i, o += 2){
+        size_t j;
+        for(j = 0; j <= i; ++j){
             output[o] += filter[j*2] * input[i-j];
             output[o+1] += filter[j*2+1] * input[i-j];
         }
+    }
 
-    for(; i < N; ++i, o += 2)
-        for(size_t j = 0; j < F/2; ++j){
+    for(; i < N; ++i, o += 2){
+        size_t j;
+        for(j = 0; j < F/2; ++j){
             output[o] += filter[j*2] * input[i-j];
             output[o+1] += filter[j*2+1] * input[i-j];
         }
+    }
 
-    for(; i < F/2; ++i, o += 2)
-        for(size_t j = i-(N-1); j <= i; ++j){
+    for(; i < F/2; ++i, o += 2){
+        size_t j;
+        for(j = i-(N-1); j <= i; ++j){
             output[o] += filter[j*2] * input[i-j];
             output[o+1] += filter[j*2+1] * input[i-j];
         }
+    }
 
-    for(; i < N+F/2; ++i, o += 2)
-        for(size_t j = i-(N-1); j < F/2; ++j){
+    for(; i < N+F/2; ++i, o += 2){
+        size_t j;
+        for(j = i-(N-1); j < F/2; ++j){
             output[o] += filter[j*2] * input[i-j];
             output[o+1] += filter[j*2+1] * input[i-j];
         }
+    }
     return 0;
 }
 
@@ -311,12 +344,12 @@ int @type@_upsampling_convolution_valid_sf_periodization(const @type@ * const re
 {
     // TODO? Allow for non-2 step
 
-    if(F%2) return -3; /* Filter must have even-length. */
-
     size_t const start = F/4;
     size_t i = start;
     size_t const end = N + start - (((F/2)%2) ? 0 : 1);
     size_t o = 0;
+
+    if(F%2) return -3; /* Filter must have even-length. */
 
     if ((F/2)%2 == 0){
         // Shift output one element right. This is necessary for perfect reconstruction.
@@ -324,7 +357,8 @@ int @type@_upsampling_convolution_valid_sf_periodization(const @type@ * const re
         // i = N-1; even element goes to output[O-1], odd element goes to output[0]
         size_t j = 0;
         while(j <= start-1){
-            for (size_t k = 0; k < N && j <= start-1; ++k, ++j){
+            size_t k;
+            for (k = 0; k < N && j <= start-1; ++k, ++j){
                 output[2*N-1] += filter[2*(start-1-j)] * input[k];
                 output[0] += filter[2*(start-1-j)+1] * input[k];
             }
@@ -334,7 +368,8 @@ int @type@_upsampling_convolution_valid_sf_periodization(const @type@ * const re
             output[0] += filter[2*j+1] * input[N+start-1-j];
         }
         while (j < F / 2){
-            for (size_t k = 0; k < N && j < F/2; ++k, ++j){
+            size_t k;
+            for (k = 0; k < N && j < F/2; ++k, ++j){
                 output[2*N-1] += filter[2*j] * input[N-1-k];
                 output[0] += filter[2*j+1] * input[N-1-k];
             }
@@ -350,7 +385,8 @@ int @type@_upsampling_convolution_valid_sf_periodization(const @type@ * const re
             output[o+1] += filter[2*j+1] * input[i-j];
         }
         while (j < F/2){
-            for(size_t k = 0; k < N && j < F/2; ++k, ++j){
+            size_t k;
+            for(k = 0; k < N && j < F/2; ++k, ++j){
                 output[o] += filter[2*j] * input[N-1-k];
                 output[o+1] += filter[2*j+1] * input[N-1-k];
             }
@@ -358,7 +394,8 @@ int @type@_upsampling_convolution_valid_sf_periodization(const @type@ * const re
     }
 
     for (; i < N; ++i, o += 2){
-        for(size_t j = 0; j < F/2; ++j){
+        size_t j;
+        for(j = 0; j < F/2; ++j){
             output[o] += filter[2*j] * input[i-j];
             output[o+1] += filter[2*j+1] * input[i-j];
         }
@@ -367,7 +404,8 @@ int @type@_upsampling_convolution_valid_sf_periodization(const @type@ * const re
     for (; i < F/2 && i < end; ++i, o += 2){
         size_t j = 0;
         while(i-j >= N){
-            for (size_t k = 0; k < N && i-j >= N; ++k, ++j){
+            size_t k;
+            for (k = 0; k < N && i-j >= N; ++k, ++j){
                 output[o] += filter[2*(i-N-j)] * input[k];
                 output[o+1] += filter[2*(i-N-j)+1] * input[k];
             }
@@ -377,7 +415,8 @@ int @type@_upsampling_convolution_valid_sf_periodization(const @type@ * const re
             output[o+1] += filter[2*j+1] * input[i-j];
         }
         while (j < F / 2){
-            for (size_t k = 0; k < N && j < F/2; ++k, ++j){
+            size_t k;
+            for (k = 0; k < N && j < F/2; ++k, ++j){
                 output[o] += filter[2*j] * input[N-1-k];
                 output[o+1] += filter[2*j+1] * input[N-1-k];
             }
@@ -387,7 +426,8 @@ int @type@_upsampling_convolution_valid_sf_periodization(const @type@ * const re
     for (; i < end; ++i, o += 2){
         size_t j = 0;
         while(i-j >= N){
-            for (size_t k = 0; k < N && i-j >= N; ++k, ++j){
+            size_t k;
+            for (k = 0; k < N && i-j >= N; ++k, ++j){
                 output[o] += filter[2*(i-N-j)] * input[k];
                 output[o+1] += filter[2*(i-N-j)+1] * input[k];
             }
@@ -424,16 +464,19 @@ int @type@_upsampling_convolution_valid_sf(const @type@ * const restrict input, 
         return -1;
 
     // Perform only stage 2 - all elements in the filter overlap an input element.
-    for(size_t o = 0, i = F/2 - 1; i < N; ++i, o += 2){
-        @type@ sum_even = 0;
-        @type@ sum_odd = 0;
-
-        for(size_t j = 0; j < F/2; ++j){
-            sum_even += filter[j*2] * input[i-j];
-            sum_odd += filter[j*2+1] * input[i-j];
+    {
+        size_t o, i;
+        for(o = 0, i = F/2 - 1; i < N; ++i, o += 2){
+            @type@ sum_even = 0;
+            @type@ sum_odd = 0;
+            size_t j;
+            for(j = 0; j < F/2; ++j){
+                sum_even += filter[j*2] * input[i-j];
+                sum_odd += filter[j*2+1] * input[i-j];
+            }
+            output[o] += sum_even;
+            output[o+1] += sum_odd;
         }
-        output[o] += sum_even;
-        output[o+1] += sum_odd;
     }
     return 0;
 }

--- a/pywt/src/convolution.c.src
+++ b/pywt/src/convolution.c.src
@@ -7,25 +7,30 @@
  * #type = double, float#
  */
 
+/* This file contains several functions for computing the convolution of a
+ * signal with a filter. The general scheme is:
+ *   output[o] = sum(filter[j] * input[i-j] for j = [0..F) and i = [0..N))
+ * where 'o', 'i' and 'j' may progress at different rates.
+ *
+ * Most of the code deals with different edge extension modes. Values are
+ * computed on-demand, in four steps:
+ * 1. Filter extends past signal on the left.
+ * 2. Filter completely contained within signal (no extension).
+ * 3. Filter extends past signal on both sides (only if F > N).
+ * 4. Filter extends past signal on the right.
+ *
+ * MODE_PERIODIZATION produces different output lengths to other modes, so is
+ * implemented as a separate function for each case.
+ *
+ * See 'common.h' for descriptions of the extension modes.
+ */
+
 int @type@_downsampling_convolution_periodization(const @type@ * const restrict input, const size_t N,
                                                   const @type@ * const restrict filter, const size_t F,
                                                   @type@ * const restrict output, const size_t step)
 {
-    /*
-    * Should it be an error to call this mode with signal lengths
-    * not divisible by the step? Not really periodic if padded.
-    *
-    * If it is exactly divisible, can it be replaced by one loop?
-    *   for (i=0; i < N; i += step){
-    *     @type@ sum = 0;
-    *     for (j=0; j < F; j++){
-    *       sum += filter[j] * input[(i-j+N) % N];
-    *     *(ptr_w++) = sum;
-    *   }
-    */
-
     size_t i = F/2, o = 0;
-    const size_t padding = N % 2; // Should be N%step for larger steps?
+    const size_t padding = N % 2; // FIXME: Should be N%step for larger steps?
 
     for (; i < F && i < N; i += step, ++o) {
         @type@ sum = 0;
@@ -41,8 +46,7 @@ int @type@_downsampling_convolution_periodization(const @type@ * const restrict 
         output[o] = sum;
     }
 
-    /* F - N-1 : filter in input range.  Most time is spent in this loop */
-    for(; i < N; i+=step, ++o){    /* input elements, */
+    for(; i < N; i+=step, ++o){
         @type@ sum = 0;
         for(size_t j = 0; j < F; ++j)
             sum += input[i-j]*filter[j];
@@ -70,7 +74,7 @@ int @type@_downsampling_convolution_periodization(const @type@ * const restrict 
         output[o] = sum;
     }
 
-    for(; i < N + F/2; i += step, ++o){   /* input elements */
+    for(; i < N + F/2; i += step, ++o){
         @type@ sum = 0;
         size_t j = 0;
         while (i-j >= N){
@@ -92,24 +96,9 @@ int @type@_downsampling_convolution(const @type@ * const restrict input, const s
                                     @type@ * const restrict output,
                                     const size_t step, MODE mode)
 {
-    /*
-     * This convolution performs efficient downsampling by computing every
+    /* This convolution performs efficient downsampling by computing every
      * step'th element of normal convolution (currently tested only for step=1
      * and step=2).
-     *
-     * It also implements several different strategies of dealing with border
-     * distortion problem (the problem of computing convolution for not
-     * existing elements of signal). To handle this the signal has to be
-     * "extended" on both sides by computing the missing values.
-     *
-     * General schema is as follows:
-     * 1. Handle extended on the left, convolve filter with samples computed for
-     *    time < 0
-     * 2. Do the normal decimated convolution of filter with signal samples
-     * 3. Handle case where filter extends beyond signal to both the left and
-     *    right (only applies if F > N)
-     * 4. Handle extended on the right, convolve filter with samples computed
-     *    for time > n-1
      */
 
     size_t i = step - 1, o = 0;
@@ -120,8 +109,6 @@ int @type@_downsampling_convolution(const @type@ * const restrict input, const s
     if (mode == MODE_SMOOTH && N < 2)
         mode = MODE_CONSTANT_EDGE;
 
-    /* Other signal extension modes */
-    /* 0 - F-1 : sliding in filter */
     for(; i < F && i < N; i+=step, ++o){
         @type@ sum = 0;
         size_t j;
@@ -157,11 +144,7 @@ int @type@_downsampling_convolution(const @type@ * const restrict input, const s
         output[o] = sum;
     }
 
-    /*
-     * F - N-1 : filter in input range - simple convolution
-     * Most time is spent in this loop.
-     */
-    for(; i < N; i+=step, ++o){  /* input elements, */
+    for(; i < N; i+=step, ++o){
         @type@ sum = 0;
 
         for(size_t j = 0; j < F; ++j)
@@ -175,8 +158,10 @@ int @type@_downsampling_convolution(const @type@ * const restrict input, const s
 
         switch(mode) {
         case MODE_SYMMETRIC:
-            /* TODO: add offset to j? Inherited, not sure what this means */
-            // Process elements beyond end in reverse (i.e. away from data)
+            // Included from original: TODO: j < F-_offset
+            /* Iterate over filter in reverse to process elements away from
+             * data. This gives a known first input element to process (N-1)
+             */
             while (i - j >= N){
                 for(size_t k = 0; k < N && i-j >= N; ++j, ++k)
                     sum += filter[i-N-j]*input[N-1-k];
@@ -235,14 +220,12 @@ int @type@_downsampling_convolution(const @type@ * const restrict input, const s
         output[o] = sum;
     }
 
-    /* N - N+F-1 : sliding out filter */
     for(; i < N+F-1; i += step, ++o){
         @type@ sum = 0;
         size_t j = 0;
         switch(mode) {
         case MODE_SYMMETRIC:
-            /* TODO: add offset to j? Inherited, not sure what this means */
-            // Process elements beyond end in reverse (i.e. away from data)
+            // Included from original: TODO: j < F-_offset
             while (i - j >= N){
                 for(size_t k = 0; k < N && i-j >= N; ++j, ++k)
                     sum += filter[i-N-j]*input[N-1-k];
@@ -275,42 +258,44 @@ int @type@_downsampling_convolution(const @type@ * const restrict input, const s
     return 0;
 }
 
-/*
- * Requires zero-filled output buffer output is larger than input
- * performs "normal" convolution of "upsampled" input coeffs array with filter
- */
-
 int @type@_upsampling_convolution_full(const @type@ * const restrict input, const size_t N,
                                        const @type@ * const restrict filter, const size_t F,
                                        @type@ * const restrict output, const size_t O)
 {
+    /* Performs a zero-padded convolution, using each input element for two
+     * consecutive filter elements. This simulates an upsampled input.
+     *
+     * In contrast to downsampling_convolution, this adds to the output. This
+     * allows multiple runs with different inputs and the same output to be used
+     * for idwt.
+     */
+
+    // FIXME? Return a valid result for i%2 != 0? Not for idwt, but could be useful.
+
+    // If check omitted, this function would be a no-op for F<2
     if(F<2)
         return -1;
 
     size_t i = 0, o = 0;
 
-    // Sliding filter in
     for(; i < N && i < F/2; ++i, o += 2)
         for(size_t j = 0; j <= i; ++j){
             output[o] += filter[j*2] * input[i-j];
             output[o+1] += filter[j*2+1] * input[i-j];
         }
 
-    // Equivalent to upsampling_convolution_valid_sf
     for(; i < N; ++i, o += 2)
         for(size_t j = 0; j < F/2; ++j){
             output[o] += filter[j*2] * input[i-j];
             output[o+1] += filter[j*2+1] * input[i-j];
         }
 
-    // Overlap at both ends, if N < F/2
     for(; i < F/2; ++i, o += 2)
         for(size_t j = i-(N-1); j <= i; ++j){
             output[o] += filter[j*2] * input[i-j];
             output[o+1] += filter[j*2+1] * input[i-j];
         }
 
-    // Sliding filter out
     for(; i < N+F/2; ++i, o += 2)
         for(size_t j = i-(N-1); j < F/2; ++j){
             output[o] += filter[j*2] * input[i-j];
@@ -319,36 +304,24 @@ int @type@_upsampling_convolution_full(const @type@ * const restrict input, cons
     return 0;
 }
 
-/*
- * performs IDWT for PERIODIZATION mode only
- * (refactored from the upsampling_convolution_valid_sf function)
- *
- * The upsampling is performed by splitting filters to even and odd elements
- * and performing 2 convolutions
- *
- * The input data has to be periodically extended for this mode.
- */
 
 int @type@_upsampling_convolution_valid_sf_periodization(const @type@ * const restrict input, const size_t N,
                                                          const @type@ * const restrict filter, const size_t F,
                                                          @type@ * const restrict output, const size_t O)
 {
+    // TODO? Allow for non-2 step
+
     if(F%2) return -3; /* Filter must have even-length. */
 
-    /*
-     * Handle special situation when input coeff data is shorter than half of
-     * the filter's length. The coeff array has to be extended periodically.
-     * This can be only valid for PERIODIZATION_MODE
-     */
     size_t const start = F/4;
     size_t i = start;
     size_t const end = N + start - (((F/2)%2) ? 0 : 1);
     size_t o = 0;
 
     if ((F/2)%2 == 0){
-        // Shift everything one element right
+        // Shift output one element right. This is necessary for perfect reconstruction.
 
-        // i = N-1; even element goes to output[O-1], odd element goes to output[o]
+        // i = N-1; even element goes to output[O-1], odd element goes to output[0]
         size_t j = 0;
         while(j <= start-1){
             for (size_t k = 0; k < N && j <= start-1; ++k, ++j){
@@ -442,19 +415,15 @@ int @type@_upsampling_convolution_valid_sf(const @type@ * const restrict input, 
                                            @type@ * const restrict output, const size_t O,
                                            MODE mode)
 {
-    if(mode == MODE_PERIODIZATION) /* Special case */
-        return @type@_upsampling_convolution_valid_sf_periodization(input, N,
-                                                                    filter, F,
-                                                                    output, O);
+    // TODO: Allow non-2 step?
 
-    if((F%2) || (N < F/2)) /* Filter must have even length. */
+    if(mode == MODE_PERIODIZATION)
+        return @type@_upsampling_convolution_valid_sf_periodization(input, N, filter, F, output, O);
+
+    if((F%2) || (N < F/2))
         return -1;
 
-    /* Perform _valid_ convolution (only when all filter_even and filter_odd elements
-     * are in range of input data).
-     *
-     * This part is simple, no extra hacks, just two convolutions in one loop
-     */
+    // Perform only stage 2 - all elements in the filter overlap an input element.
     for(size_t o = 0, i = F/2 - 1; i < N; ++i, o += 2){
         @type@ sum_even = 0;
         @type@ sum_odd = 0;

--- a/pywt/src/convolution.c.src
+++ b/pywt/src/convolution.c.src
@@ -7,9 +7,9 @@
  * #type = double, float#
  */
 
-int @type@_downsampling_convolution_periodization(const @type@* input, const_index_t N,
-                             const @type@* filter, const_index_t F,
-                             @type@* output, const_index_t step)
+int @type@_downsampling_convolution_periodization(const @type@* input, const index_t N,
+                             const @type@* filter, const index_t F,
+                             @type@* output, const index_t step)
 
 {
     /*
@@ -67,10 +67,10 @@ int @type@_downsampling_convolution_periodization(const @type@* input, const_ind
 }
 
 
-int @type@_downsampling_convolution(const @type@* input, const_index_t N,
-                             const @type@* filter, const_index_t F,
+int @type@_downsampling_convolution(const @type@* input, const index_t N,
+                             const @type@* filter, const index_t F,
                              @type@* output,
-                             const_index_t step, MODE mode)
+                             const index_t step, MODE mode)
 {
     /*
      * This convolution performs efficient downsampling by computing every
@@ -297,10 +297,10 @@ int @type@_downsampling_convolution(const @type@* input, const_index_t N,
  * ### like downsampling_convolution, but with memory allocation ###
  */
 
-int @type@_allocating_downsampling_convolution(const @type@* input, const_index_t N,
-                                        const @type@* filter, const_index_t F,
+int @type@_allocating_downsampling_convolution(const @type@* input, const index_t N,
+                                        const @type@* filter, const index_t F,
                                         @type@* output,
-                                        const_index_t step, MODE mode)
+                                        const index_t step, MODE mode)
 {
     index_t N_extended_right_start, start, stop;
     @type@ *buffer;
@@ -438,9 +438,9 @@ int @type@_allocating_downsampling_convolution(const @type@* input, const_index_
  * performs "normal" convolution of "upsampled" input coeffs array with filter
  */
 
-int @type@_upsampling_convolution_full(const @type@* input, const_index_t N,
-                                const @type@* filter, const_index_t F,
-                                @type@* output, const_index_t O)
+int @type@_upsampling_convolution_full(const @type@* input, const index_t N,
+                                const @type@* filter, const index_t F,
+                                @type@* output, const index_t O)
 {
     register index_t i;
     register index_t j;
@@ -478,11 +478,11 @@ int @type@_upsampling_convolution_full(const @type@* input, const_index_t N,
  */
 
 int @type@_upsampling_convolution_valid_sf_periodization(const @type@* input,
-                                                         const_index_t N,
+                                                         const index_t N,
                                                          const @type@*
-                                                         filter, const_index_t
+                                                         filter, const index_t
                                                          F, @type@* output,
-                                                         const_index_t O)
+                                                         const index_t O)
 {
 
     @type@ *ptr_out = output;
@@ -738,9 +738,9 @@ int @type@_upsampling_convolution_valid_sf_periodization(const @type@* input,
  */
 
 int @type@_upsampling_convolution_valid_sf(const @type@* input,
-                                           const_index_t N, const @type@*
-                                           filter, const_index_t F, @type@*
-                                           output, const_index_t O, MODE
+                                           const index_t N, const @type@*
+                                           filter, const index_t F, @type@*
+                                           output, const index_t O, MODE
                                            mode)
 {
 
@@ -806,9 +806,9 @@ int @type@_upsampling_convolution_valid_sf(const @type@* input,
 
 /* -> swt - todo */
 int @type@_upsampled_filter_convolution(const @type@* input,
-                                        const_index_t N, const @type@*
-                                        filter, const_index_t F, @type@*
-                                        output, const_index_t step, MODE mode)
+                                        const index_t N, const @type@*
+                                        filter, const index_t F, @type@*
+                                        output, const index_t step, MODE mode)
 {
     return -1;
 }

--- a/pywt/src/convolution.c.src
+++ b/pywt/src/convolution.c.src
@@ -95,19 +95,15 @@ int @type@_downsampling_convolution(const @type@* input, const index_t N,
 
     @type@* ptr_w = output;
 
-    if (F > N) {
-        /* reallocating memory for short signals (shorter than filter) is cheap */
-        return @type@_allocating_downsampling_convolution(input, N, filter, F,
-                                                           output, step, mode);
-    }
-
     if(mode == MODE_PERIODIZATION){
+        if (F > N)
+            return @type@_allocating_downsampling_convolution_periodization(input, N, filter, F, output, step);
         return @type@_downsampling_convolution_periodization(input, N, filter, F, output, step);
     }
 
     /* Other signal extension modes */
     /* 0 - F-1 : sliding in filter */
-    for(i=start; i < F; i+=step){
+    for(i=start; i < F && i < N; i+=step){
         @type@ sum = 0;
         index_t j;
         for(j = 0; j <= i; ++j)
@@ -115,8 +111,12 @@ int @type@_downsampling_convolution(const @type@* input, const index_t N,
 
         switch(mode) {
         case MODE_SYMMETRIC:
-            for(index_t k = 0; j < F; ++j, ++k)
-                sum += filter[j]*input[k];
+            while (j < F){
+                for(index_t k = 0; k < N && j < F; ++j, ++k)
+                    sum += filter[j]*input[k];
+                for(index_t k = 0; k < N && j < F; ++k, ++j)
+                    sum += filter[j] * input[N-1-k];
+            }
             break;
         case MODE_CONSTANT_EDGE:
             for(; j < F; ++j)
@@ -127,8 +127,9 @@ int @type@_downsampling_convolution(const @type@* input, const index_t N,
                 sum += filter[j]*(input[0] + k * (input[0] - input[1]));
             break;
         case MODE_PERIODIC:
-            for(index_t k = N-1; j < F; ++j, --k)
-                sum += filter[j]*input[k];
+            while (j < F)
+                for(index_t k = 0; k < N && j < F; ++k, ++j)
+                    sum += filter[j]*input[N-1-k];
             break;
         case MODE_ZEROPAD:
         default:
@@ -149,16 +150,19 @@ int @type@_downsampling_convolution(const @type@* input, const index_t N,
         *(ptr_w++) = sum;
     }
 
-    /* N - N+F-1 : sliding out filter */
-    for(; i < N+F-1; i += step){  /* input elements */
+    for(; i < F; i+=step){
         @type@ sum = 0;
         index_t j = 0;
         switch(mode) {
         case MODE_SYMMETRIC:
             /* TODO: add offset to j? Inherited, not sure what this means */
             // Process elements beyond end in reverse (i.e. away from data)
-            for(index_t k = N-1; i-j >= N; ++j, --k)
-                sum += filter[i-N-j]*input[k];
+            while (i - j >= N){
+                for(index_t k = 0; k < N && i-j >= N; ++j, ++k)
+                    sum += filter[i-N-j]*input[N-1-k];
+                for(index_t k = 0; k < N && i-j >= N; ++j, ++k)
+                    sum += filter[i-N-j]*input[k];
+            }
             break;
         case MODE_CONSTANT_EDGE:
             for(; i-j >= N; ++j)
@@ -169,8 +173,73 @@ int @type@_downsampling_convolution(const @type@* input, const index_t N,
                 sum += filter[j]*(input[N-1] + k * (input[N-1] - input[N-2]));
             break;
         case MODE_PERIODIC:
-            for (index_t k = 0; i-j >= N; ++j, ++k)
-                sum += filter[i-N-j]*input[k];
+            while (i-j >= N)
+                for (index_t k = 0; k < N && i-j >= N; ++j, ++k)
+                    sum += filter[i-N-j]*input[k];
+            break;
+        case MODE_ZEROPAD:
+        default:
+            j = i - N + 1;
+            break;
+        }
+        for(; j <= i; ++j)
+            sum += filter[j]*input[i-j];
+        switch(mode) {
+        case MODE_SYMMETRIC:
+            while (j < F){
+                for(index_t k = 0; k < N && j < F; ++j, ++k)
+                    sum += filter[j]*input[k];
+                for(index_t k = 0; k < N && j < F; ++k, ++j)
+                    sum += filter[j] * input[N-1-k];
+            }
+            break;
+        case MODE_CONSTANT_EDGE:
+            for(; j < F; ++j)
+                sum += filter[j]*input[0];
+            break;
+        case MODE_SMOOTH:
+            for(index_t k = 1; j < F; ++j, ++k)
+                sum += filter[j]*(input[0] + k * (input[0] - input[1]));
+            break;
+        case MODE_PERIODIC:
+            while (j < F)
+                for(index_t k = 0; k < N && j < F; ++k, ++j)
+                    sum += filter[j]*input[N-1-k];
+            break;
+        case MODE_ZEROPAD:
+        default:
+            break;
+        }
+        *(ptr_w++) = sum;
+    }
+
+    /* N - N+F-1 : sliding out filter */
+    for(; i < N+F-1; i += step){  /* input elements */
+        @type@ sum = 0;
+        index_t j = 0;
+        switch(mode) {
+        case MODE_SYMMETRIC:
+            /* TODO: add offset to j? Inherited, not sure what this means */
+            // Process elements beyond end in reverse (i.e. away from data)
+            while (i - j >= N){
+                for(index_t k = 0; k < N && i-j >= N; ++j, ++k)
+                    sum += filter[i-N-j]*input[N-1-k];
+                for(index_t k = 0; k < N && i-j >= N; ++j, ++k)
+                    sum += filter[i-N-j]*input[k];
+            }
+            break;
+        case MODE_CONSTANT_EDGE:
+            for(; i-j >= N; ++j)
+                sum += filter[j]*input[N-1];
+            break;
+        case MODE_SMOOTH:
+            for(index_t k = i - N + 1; i-j >= N; ++j, --k)
+                sum += filter[j]*(input[N-1] + k * (input[N-1] - input[N-2]));
+            break;
+        case MODE_PERIODIC:
+            while (i-j >= N)
+                for (index_t k = 0; k < N && i-j >= N; ++j, ++k)
+                    sum += filter[i-N-j]*input[k];
             break;
         case MODE_ZEROPAD:
         default:
@@ -188,110 +257,40 @@ int @type@_downsampling_convolution(const @type@* input, const index_t N,
  * ### like downsampling_convolution, but with memory allocation ###
  */
 
-int @type@_allocating_downsampling_convolution(const @type@* input, const index_t N,
-                                        const @type@* filter, const index_t F,
-                                        @type@* output,
-                                        const index_t step, MODE mode)
+int @type@_allocating_downsampling_convolution_periodization(const @type@* input, const index_t N,
+                                                             const @type@* filter, const index_t F,
+                                                             @type@* output, const index_t step)
 {
     index_t N_extended_right_start, start, stop;
     @type@ *buffer;
 
-    /* allocate memory and copy input */
-    if(mode != MODE_PERIODIZATION){
+    index_t N_extended_len = N + F-1;
+    N_extended_right_start = N-1 + F/2;
 
-        index_t N_extended_len = N + 2*(F-1);
-        N_extended_right_start = N + (F-1);
+    buffer = wtcalloc(N_extended_len, sizeof(@type@));
+    if(buffer == NULL)
+        return -1;
 
-        buffer = wtcalloc(N_extended_len, sizeof(@type@));
-        if(buffer == NULL)
-            return -1;
+    memcpy(buffer+F/2-1, input, sizeof(@type@) * N);
 
-        memcpy(buffer+(F-1), input, sizeof(@type@) * N);
-        start = (F-1) + step - 1;
+    start = (F-1) + step - 2;
+    if(step == 1)
+        stop = N_extended_len-1;
+    else /* step == 2 */
         stop = N_extended_len;
 
+    if(N%2){ /* odd - repeat last element */
+        buffer[N_extended_right_start] = input[N-1];
+        for(index_t j = 1; j < F/2; ++j)
+            buffer[N_extended_right_start+j] = buffer[F/2-2 + j]; /* copy from beginning of `input` to right */
+        for(index_t j = 0; j < F/2-1; ++j)   /* copy from 'buffer' to left */
+            buffer[F/2-2-j] =  buffer[N_extended_right_start-j];
     } else {
-        index_t N_extended_len = N + F-1;
-        N_extended_right_start = N-1 + F/2;
-
-        buffer = wtcalloc(N_extended_len, sizeof(@type@));
-        if(buffer == NULL)
-            return -1;
-
-        memcpy(buffer+F/2-1, input, sizeof(@type@) * N);
-
-        start = (F-1) + step - 2;
-        if(step == 1)
-            stop = N_extended_len-1;
-        else /* step == 2 */
-            stop = N_extended_len;
+        for(index_t j = 0; j < F/2; ++j)
+            buffer[N_extended_right_start+j] = input[j%N]; /* copy from beginning of `input` to right */
+        for(index_t j = 0; j < F/2-1; ++j)   /* copy from 'buffer' to left */
+            buffer[F/2-2-j] =  buffer[N_extended_right_start-1-j];
     }
-
-    /* copy extended signal elements */
-    switch(mode){
-
-        case MODE_PERIODIZATION:
-            if(N%2){ /* odd - repeat last element */
-                buffer[N_extended_right_start] = input[N-1];
-                for(index_t j = 1; j < F/2; ++j)
-                    buffer[N_extended_right_start+j] = buffer[F/2-2 + j]; /* copy from beginning of `input` to right */
-                for(index_t j = 0; j < F/2-1; ++j)   /* copy from 'buffer' to left */
-                    buffer[F/2-2-j] =  buffer[N_extended_right_start-j];
-            } else {
-                for(index_t j = 0; j < F/2; ++j)
-                    buffer[N_extended_right_start+j] = input[j%N]; /* copy from beginning of `input` to right */
-                for(index_t j = 0; j < F/2-1; ++j)   /* copy from 'buffer' to left */
-                    buffer[F/2-2-j] =  buffer[N_extended_right_start-1-j];
-            }
-            break;
-
-        case MODE_SYMMETRIC:{
-            index_t j;
-            for(j = 0; j < N; ++j){
-                buffer[(F-1)-1-j] = input[j%N];
-                buffer[N_extended_right_start+j] = input[N-1-(j%N)];
-            }
-            index_t i = j;
-            /* use `buffer` as source */
-            for(; j < (F-1); ++j){
-                buffer[(F-1)-1-j] =  buffer[N_extended_right_start-1+i-j];
-                buffer[N_extended_right_start+j] = buffer[(F-1)+j-i];
-            }
-            break;
-        }
-
-        case MODE_SMOOTH:
-            if(N>1){
-                @type@ tmp = input[0]-input[1];
-                for(index_t j = 0; j < (F-1); ++j)
-                    buffer[j] = input[0] +    (tmp * ((F-1)-j));
-                tmp = input[N-1]-input[N-2];
-                for(index_t j = 0; j < (F-1); ++j)
-                    buffer[N_extended_right_start+j] = input[N-1] + (tmp*j);
-                break;
-            }
-
-        case MODE_CONSTANT_EDGE:
-            for(index_t j = 0; j < (F-1); ++j){
-                buffer[j] = input[0];
-                buffer[N_extended_right_start+j] = input[N-1];
-            }
-            break;
-
-        case MODE_PERIODIC:
-            for(index_t j = 0; j < F-1; ++j)
-                buffer[N_extended_right_start+j] = input[j%N]; /* copy from beginning of `input` to right */
-
-            for(index_t j = 0; j < F-1; ++j)   /* copy from 'buffer' to left */
-                buffer[(F-1)-1-j] =  buffer[N_extended_right_start-1-j];
-            break;
-
-        case MODE_ZEROPAD:
-        default:
-            break;
-    }
-
-
     /*
      * F - N-1 : filter in input range, perform convolution with decimation
      */

--- a/pywt/src/convolution.c.src
+++ b/pywt/src/convolution.c.src
@@ -378,40 +378,19 @@ int @type@_upsampling_convolution_valid_sf_periodization(const @type@* input,
 
     } else {
         /* Otherwise (N >= F_2) */
-        @type@ *ptr_out = output;
-        @type@ * periodization_buf = NULL;
-        @type@ *periodization_buf_rear = NULL;
-        @type@ *ptr_base;
-        @type@ sum_even, sum_odd;
-        index_t i, j, k, N_p = 0;
-        index_t F_2 = F/2;
-
-        /* Allocate memory for even and odd elements of the filter */
-        @type@ * filter_even = wtmalloc(F_2 * sizeof(@type@));
-        @type@ * filter_odd = wtmalloc(F_2 * sizeof(@type@));
-
-        if(filter_odd == NULL || filter_even == NULL){
-            if(filter_odd == NULL) wtfree(filter_odd);
-            if(filter_even == NULL) wtfree(filter_even);
-            return -1;
-        }
-
-        /* split filter to even and odd values */
-        for(i = 0; i < F_2; ++i){
-            filter_even[i] = filter[i << 1];
-            filter_odd[i] = filter[(i << 1) + 1];
-        }
+        @type@ * ptr_out = output;
+        @type@ * periodization_buf_front = NULL, * periodization_buf_rear = NULL;
 
         /*
          * ############################################################
          * This part is quite complicated and has some wild checking to
          * get results similar to those from Matlab(TM) Wavelet Toolbox
          */
-        k = F_2-1;
+        index_t k = F/2-1; // NOT const
 
         /* Check if extending is really needed */
         /* split filter len correct + extra samples*/
-        N_p = F_2-1 + (index_t) ceil(k/2.);
+        const index_t N_p = k + (index_t) ceil(k/2.);
 
         /*
          * ok, if is then do:
@@ -421,34 +400,31 @@ int @type@_upsampling_convolution_valid_sf_periodization(const @type@* input,
          *    elements of the filter (this results in upsampling)
          * 4. Free memory
          */
-
         if(N_p > 0){
             /*
              * Allocate memory only for the front and rear extension parts, not
              * the whole input
              */
-            periodization_buf = wtcalloc(N_p, sizeof(@type@));
+            periodization_buf_front = wtcalloc(N_p, sizeof(@type@));
             periodization_buf_rear = wtcalloc(N_p, sizeof(@type@));
 
             /* Memory checking */
-            if(periodization_buf == NULL || periodization_buf_rear == NULL){
-                if(periodization_buf == NULL) wtfree(periodization_buf);
+            if(periodization_buf_front == NULL || periodization_buf_rear == NULL){
+                if(periodization_buf_front == NULL) wtfree(periodization_buf_front);
                 if(periodization_buf_rear == NULL) wtfree(periodization_buf_rear);
-                wtfree(filter_odd);
-                wtfree(filter_even);
                 return -1;
             }
 
             /* Fill buffers with appropriate elements */
 
             /* copy from beginning of input to end of buffer */
-            memcpy(periodization_buf + N_p - k, input, k * sizeof(@type@));
-            for(i = 1; i <= (N_p - k); ++i)
-                periodization_buf[(N_p - k) - i] = input[N - (i%N)];
+            memcpy(periodization_buf_front + N_p - k, input, k * sizeof(@type@));
+            for(index_t i = 1; i <= (N_p - k); ++i)
+                periodization_buf_front[(N_p - k) - i] = input[N - (i%N)];
 
             /* copy from end of input to beginning of buffer */
             memcpy(periodization_buf_rear, input + N - k, k * sizeof(@type@));
-            for(i = 0; i < (N_p - k); ++i)
+            for(index_t i = 0; i < (N_p - k); ++i)
                 periodization_buf_rear[k + i] = input[i%N];
 
             /*
@@ -456,23 +432,22 @@ int @type@_upsampling_convolution_valid_sf_periodization(const @type@* input,
              * the first part of output
              */
 
-            ptr_base = periodization_buf + F_2 - 1;
-
             if(k%2 == 1){
-                sum_odd = 0;
+                @type@ sum_odd = 0;
 
-                for(j = 0; j < F_2; ++j)
-                    sum_odd += filter_odd[j] * ptr_base[-j];
+                for(index_t j = 0; j < F/2; ++j)
+                    sum_odd += filter[j*2+1] * periodization_buf_front[F/2-1-j];
                 *(ptr_out++) += sum_odd;
 
                 --k;
                 if(k)
-                    @type@_upsampling_convolution_valid_sf(periodization_buf + 1, N_p-1, filter, F, ptr_out, O-1, MODE_ZEROPAD);
+                    @type@_upsampling_convolution_valid_sf(periodization_buf_front + 1, N_p-1,
+                                                           filter, F, ptr_out, O-1, MODE_ZEROPAD);
 
                 ptr_out += k; /* k0 - 1, really move backward by 1 */
 
             } else if(k){
-                @type@_upsampling_convolution_valid_sf(periodization_buf, N_p,
+                @type@_upsampling_convolution_valid_sf(periodization_buf_front, N_p,
                                                         filter, F, ptr_out, O,
                                                         MODE_ZEROPAD);
                 ptr_out += k;
@@ -487,15 +462,13 @@ int @type@_upsampling_convolution_valid_sf_periodization(const @type@* input,
          * loop
          */
 
-        ptr_base = (@type@*)input + F_2 - 1;
-        for(i = 0; i < N-(F_2-1); ++i){ /* sliding over signal from left to right */
+        for(index_t i = F/2 - 1; i < N; ++i){ /* sliding over signal from left to right */
+            @type@ sum_even = 0;
+            @type@ sum_odd = 0;
 
-            sum_even = 0;
-            sum_odd = 0;
-
-            for(j = 0; j < F_2; ++j){
-                sum_even += filter_even[j] * ptr_base[i-j];
-                sum_odd += filter_odd[j] * ptr_base[i-j];
+            for(index_t j = 0; j < F/2; ++j){
+                sum_even += filter[j*2] * input[i-j];
+                sum_odd += filter[j*2+1] * input[i-j];
             }
 
             *(ptr_out++) += sum_even;
@@ -503,37 +476,31 @@ int @type@_upsampling_convolution_valid_sf_periodization(const @type@* input,
         }
 
         if(N_p > 0){
-            k = F_2-1;
+            k = F/2-1;
             if(k%2 == 1){
                 if(F/2 <= N_p - 1){ /* k > 1 ? */
-                    @type@_upsampling_convolution_valid_sf(periodization_buf_rear , N_p-1, filter, F, ptr_out, O-1, MODE_ZEROPAD);
+                    @type@_upsampling_convolution_valid_sf(periodization_buf_rear, N_p-1,
+                                                           filter, F, ptr_out, O-1,
+                                                           MODE_ZEROPAD);
                 }
 
                 ptr_out += k; /* move forward anyway -> see lower */
 
-                if(F_2%2 == 0){ /* remaining one element */
-                    ptr_base = periodization_buf_rear + N_p - 1;
-
-                    sum_even = 0;
-                    for(j = 0; j < F_2; ++j){
-                        sum_even += filter_even[j] * ptr_base[-j];
+                if((F/2)%2 == 0){ /* remaining one element */
+                    @type@ sum_even = 0;
+                    for(index_t j = 0; j < F/2; ++j){
+                        sum_even += filter[j*2] * periodization_buf_rear[N_p-1-j];
                     }
                     *(--ptr_out) += sum_even; /* move backward first */
                 }
-            } else {
-                if(k){
-                    @type@_upsampling_convolution_valid_sf(periodization_buf_rear,
-                                                            N_p, filter, F,
-                                                            ptr_out, O,
-                                                            MODE_ZEROPAD);
-                }
+            } else if (k) {
+                @type@_upsampling_convolution_valid_sf(periodization_buf_rear, N_p,
+                                                       filter, F, ptr_out, O,
+                                                       MODE_ZEROPAD);
             }
         }
-        if(periodization_buf != NULL) wtfree(periodization_buf);
+        if(periodization_buf_front != NULL) wtfree(periodization_buf_front);
         if(periodization_buf_rear != NULL) wtfree(periodization_buf_rear);
-
-        wtfree(filter_even);
-        wtfree(filter_odd);
 
     }
     return 0;

--- a/pywt/src/convolution.c.src
+++ b/pywt/src/convolution.c.src
@@ -319,9 +319,9 @@ int @type@_upsampling_convolution_full(const @type@ * const restrict input, cons
  * The input data has to be periodically extended for this mode.
  */
 
-int @type@_upsampling_convolution_valid_sf_periodization(const @type@* input, const index_t N,
-                                                         const @type@* filter, const index_t F,
-                                                         @type@* output, const index_t O)
+int @type@_upsampling_convolution_valid_sf_periodization(const @type@ * const restrict input, const index_t N,
+                                                         const @type@ * const restrict filter, const index_t F,
+                                                         @type@ * const restrict output, const index_t O)
 {
     if(F%2) return -3; /* Filter must have even-length. */
 

--- a/pywt/src/convolution.c.src
+++ b/pywt/src/convolution.c.src
@@ -330,196 +330,91 @@ int @type@_upsampling_convolution_valid_sf_periodization(const @type@* input, co
      * the filter's length. The coeff array has to be extended periodically.
      * This can be only valid for PERIODIZATION_MODE
      */
-    if(N < F/2) {
-        index_t const start = F/4;
-        index_t i = start;
-        index_t const end = ((F/2)%2) ? N + F/4 : N + F/4 - 1;
-        index_t o = ((F/2)%2) ? 0 : 1;
+    index_t const start = F/4;
+    index_t i = start;
+    index_t const end = ((F/2)%2) ? N + F/4 : N + F/4 - 1;
+    index_t o = 0;
 
-        if ((F/2)%2 == 0){
-            // Shift everything one element right
+    if ((F/2)%2 == 0){
+        // Shift everything one element right
 
-            // i = N-1; even element goes to output[O-1], odd element goes to output[o]
-            index_t j = 0;
-            while(N+start-1-j >= N){
-                for (index_t k = 0; k < N && N+start-1-j >= N; ++k, ++j){
-                    output[2*N-1] += filter[2*(N+start-1-N-j)] * input[k];
-                    output[0] += filter[2*(N+start-1-N-j)+1] * input[k];
-                }
+        // i = N-1; even element goes to output[O-1], odd element goes to output[o]
+        index_t j = 0;
+        while(N+start-1-j >= N){
+            for (index_t k = 0; k < N && N+start-1-j >= N; ++k, ++j){
+                output[2*N-1] += filter[2*(N+start-1-N-j)] * input[k];
+                output[0] += filter[2*(N+start-1-N-j)+1] * input[k];
             }
-            for (; j <= N+start-1 && j < F/2; ++j){
-                output[2*N-1] += filter[2*j] * input[N+start-1-j];
-                output[0] += filter[2*j+1] * input[N+start-1-j];
-            }
-            while (j < F / 2){
-                for (index_t k = 0; k < N && j < F/2; ++k, ++j){
-                    output[2*N-1] += filter[2*j] * input[N-1-k];
-                    output[0] += filter[2*j+1] * input[N-1-k];
-                }
+        }
+        for (; j <= N+start-1 && j < F/2; ++j){
+            output[2*N-1] += filter[2*j] * input[N+start-1-j];
+            output[0] += filter[2*j+1] * input[N+start-1-j];
+        }
+        while (j < F / 2){
+            for (index_t k = 0; k < N && j < F/2; ++k, ++j){
+                output[2*N-1] += filter[2*j] * input[N-1-k];
+                output[0] += filter[2*j+1] * input[N-1-k];
             }
         }
 
-        for (; i < N; ++i, o += 2){
-            index_t j = 0;
-            for(; j <= i; ++j){
-                output[o] += filter[2*j] * input[i-j];
-                output[o+1] += filter[2*j+1] * input[i-j];
-            }
-            while (j < F/2){
-                for(index_t k = 0; k < N && j < F/2; ++k, ++j){
-                    output[o] += filter[2*j] * input[N-1-k];
-                    output[o+1] += filter[2*j+1] * input[N-1-k];
-                }
-            }
-        }
-
-        for (; i < end; ++i, o += 2){
-            index_t j = 0;
-            while(i-j >= N){
-                for (index_t k = 0; k < N && i-j >= N; ++k, ++j){
-                    output[o] += filter[2*(i-N-j)] * input[k];
-                    output[o+1] += filter[2*(i-N-j)+1] * input[k];
-                }
-            }
-            for (; j <= i && j < F/2; ++j){
-                output[o] += filter[2*j] * input[i-j];
-                output[o+1] += filter[2*j+1] * input[i-j];
-            }
-            while (j < F / 2){
-                for (index_t k = 0; k < N && j < F/2; ++k, ++j){
-                    output[o] += filter[2*j] * input[N-1-k];
-                    output[o+1] += filter[2*j+1] * input[N-1-k];
-                }
-            }
-        }
-
-    } else {
-        /* Otherwise (N >= F_2) */
-        @type@ * ptr_out = output;
-        @type@ * periodization_buf_front = NULL, * periodization_buf_rear = NULL;
-
-        /*
-         * ############################################################
-         * This part is quite complicated and has some wild checking to
-         * get results similar to those from Matlab(TM) Wavelet Toolbox
-         */
-        index_t k = F/2-1; // NOT const
-
-        /* Check if extending is really needed */
-        /* split filter len correct + extra samples*/
-        const index_t N_p = k + (index_t) ceil(k/2.);
-
-        /*
-         * ok, if is then do:
-         * 1. Allocate buffers for front and rear parts of extended input
-         * 2. Copy periodically appropriate elements from input to the buffers
-         * 3. Convolve front buffer, input and rear buffer with even and odd
-         *    elements of the filter (this results in upsampling)
-         * 4. Free memory
-         */
-        if(N_p > 0){
-            /*
-             * Allocate memory only for the front and rear extension parts, not
-             * the whole input
-             */
-            periodization_buf_front = wtcalloc(N_p, sizeof(@type@));
-            periodization_buf_rear = wtcalloc(N_p, sizeof(@type@));
-
-            /* Memory checking */
-            if(periodization_buf_front == NULL || periodization_buf_rear == NULL){
-                if(periodization_buf_front == NULL) wtfree(periodization_buf_front);
-                if(periodization_buf_rear == NULL) wtfree(periodization_buf_rear);
-                return -1;
-            }
-
-            /* Fill buffers with appropriate elements */
-
-            /* copy from beginning of input to end of buffer */
-            memcpy(periodization_buf_front + N_p - k, input, k * sizeof(@type@));
-            for(index_t i = 1; i <= (N_p - k); ++i)
-                periodization_buf_front[(N_p - k) - i] = input[N - (i%N)];
-
-            /* copy from end of input to beginning of buffer */
-            memcpy(periodization_buf_rear, input + N - k, k * sizeof(@type@));
-            for(index_t i = 0; i < (N_p - k); ++i)
-                periodization_buf_rear[k + i] = input[i%N];
-
-            /*
-             * Convolve filters with the (front) periodization_buf and compute
-             * the first part of output
-             */
-
-            if(k%2 == 1){
-                @type@ sum_odd = 0;
-
-                for(index_t j = 0; j < F/2; ++j)
-                    sum_odd += filter[j*2+1] * periodization_buf_front[F/2-1-j];
-                *(ptr_out++) += sum_odd;
-
-                --k;
-                if(k)
-                    @type@_upsampling_convolution_valid_sf(periodization_buf_front + 1, N_p-1,
-                                                           filter, F, ptr_out, O-1, MODE_ZEROPAD);
-
-                ptr_out += k; /* k0 - 1, really move backward by 1 */
-
-            } else if(k){
-                @type@_upsampling_convolution_valid_sf(periodization_buf_front, N_p,
-                                                        filter, F, ptr_out, O,
-                                                        MODE_ZEROPAD);
-                ptr_out += k;
-            }
-        }
-
-        /*
-         * Perform _valid_ convolution (only when all filter_even and
-         * filter_odd elements are in range of input data).
-         *
-         * This part is simple, no extra hacks, just two convolutions in one
-         * loop
-         */
-
-        for(index_t i = F/2 - 1; i < N; ++i){ /* sliding over signal from left to right */
-            @type@ sum_even = 0;
-            @type@ sum_odd = 0;
-
-            for(index_t j = 0; j < F/2; ++j){
-                sum_even += filter[j*2] * input[i-j];
-                sum_odd += filter[j*2+1] * input[i-j];
-            }
-
-            *(ptr_out++) += sum_even;
-            *(ptr_out++) += sum_odd;
-        }
-
-        if(N_p > 0){
-            k = F/2-1;
-            if(k%2 == 1){
-                if(F/2 <= N_p - 1){ /* k > 1 ? */
-                    @type@_upsampling_convolution_valid_sf(periodization_buf_rear, N_p-1,
-                                                           filter, F, ptr_out, O-1,
-                                                           MODE_ZEROPAD);
-                }
-
-                ptr_out += k; /* move forward anyway -> see lower */
-
-                if((F/2)%2 == 0){ /* remaining one element */
-                    @type@ sum_even = 0;
-                    for(index_t j = 0; j < F/2; ++j){
-                        sum_even += filter[j*2] * periodization_buf_rear[N_p-1-j];
-                    }
-                    *(--ptr_out) += sum_even; /* move backward first */
-                }
-            } else if (k) {
-                @type@_upsampling_convolution_valid_sf(periodization_buf_rear, N_p,
-                                                       filter, F, ptr_out, O,
-                                                       MODE_ZEROPAD);
-            }
-        }
-        if(periodization_buf_front != NULL) wtfree(periodization_buf_front);
-        if(periodization_buf_rear != NULL) wtfree(periodization_buf_rear);
-
+        o += 1;
     }
+
+    for (; i < F/2 && i < N; ++i, o += 2){
+        index_t j = 0;
+        for(; j <= i; ++j){
+            output[o] += filter[2*j] * input[i-j];
+            output[o+1] += filter[2*j+1] * input[i-j];
+        }
+        while (j < F/2){
+            for(index_t k = 0; k < N && j < F/2; ++k, ++j){
+                output[o] += filter[2*j] * input[N-1-k];
+                output[o+1] += filter[2*j+1] * input[N-1-k];
+            }
+        }
+    }
+
+    for (; i < N; ++i, o += 2){
+        for(index_t j = 0; j < F/2; ++j){
+            output[o] += filter[2*j] * input[i-j];
+            output[o+1] += filter[2*j+1] * input[i-j];
+        }
+    }
+
+    for (; i < F/2 && i < end; ++i, o += 2){
+        index_t j = 0;
+        while(i-j >= N){
+            for (index_t k = 0; k < N && i-j >= N; ++k, ++j){
+                output[o] += filter[2*(i-N-j)] * input[k];
+                output[o+1] += filter[2*(i-N-j)+1] * input[k];
+            }
+        }
+        for (; j <= i && j < F/2; ++j){
+            output[o] += filter[2*j] * input[i-j];
+            output[o+1] += filter[2*j+1] * input[i-j];
+        }
+        while (j < F / 2){
+            for (index_t k = 0; k < N && j < F/2; ++k, ++j){
+                output[o] += filter[2*j] * input[N-1-k];
+                output[o+1] += filter[2*j+1] * input[N-1-k];
+            }
+        }
+    }
+
+    for (; i < end; ++i, o += 2){
+        index_t j = 0;
+        while(i-j >= N){
+            for (index_t k = 0; k < N && i-j >= N; ++k, ++j){
+                output[o] += filter[2*(i-N-j)] * input[k];
+                output[o+1] += filter[2*(i-N-j)+1] * input[k];
+            }
+        }
+        for (; j <= i && j < F/2; ++j){
+            output[o] += filter[2*j] * input[i-j];
+            output[o+1] += filter[2*j+1] * input[i-j];
+        }
+    }
+
     return 0;
 }
 

--- a/pywt/src/convolution.c.src
+++ b/pywt/src/convolution.c.src
@@ -277,9 +277,9 @@ int @type@_downsampling_convolution(const @type@ * const restrict input, const i
  * performs "normal" convolution of "upsampled" input coeffs array with filter
  */
 
-int @type@_upsampling_convolution_full(const @type@* input, const index_t N,
-                                       const @type@* filter, const index_t F,
-                                       @type@* output, const index_t O)
+int @type@_upsampling_convolution_full(const @type@ * const restrict input, const index_t N,
+                                       const @type@ * const restrict filter, const index_t F,
+                                       @type@ * const restrict output, const index_t O)
 {
     if(F<2)
         return -1;

--- a/pywt/src/convolution.c.src
+++ b/pywt/src/convolution.c.src
@@ -84,24 +84,17 @@ int @type@_downsampling_convolution(const @type@* input, const_index_t N,
      * existing elements of signal). To handle this the signal has to be
      * "extended" on both sides by computing the missing values.
      *
-     * General schema is as follows: 1. Handle extended on the left, convolve
-     * filter with samples computed for time < 0 2. Do the normal decimated
-     * convolution of filter with signal samples 3. Handle extended on the
-     * right, convolve filter with samples computed for time > n-1
+     * General schema is as follows:
+     * 1. Handle extended on the left, convolve filter with samples computed for
+     *    time < 0
+     * 2. Do the normal decimated convolution of filter with signal samples
+     * 3. Handle extended on the right, convolve filter with samples computed
+     *    for time > n-1
      */
 
     index_t i, j, k;
     index_t start;
     @type@ sum, tmp;
-    #ifdef OPT_UNROLL2
-        @type@ sum2;
-    #endif
-    #ifdef OPT_UNROLL4
-        #ifndef OPT_UNROLL2
-            @type@ sum2;
-        #endif
-        @type@ sum3, sum4;
-    #endif
 
     @type@* ptr_w = output;
 
@@ -198,43 +191,6 @@ int @type@_downsampling_convolution(const @type@* input, const_index_t N,
              * F - N-1 : filter in input range - simple convolution
              * Most time is spent in this loop.
              */
-            #ifdef OPT_UNROLL4
-            /* manually unroll the loop a bit */
-            if((N - F)/step > 4) {
-                for(; i < (N - (3*step)); i += 4*step){  /* input elements */
-                    sum  = input[i]          * filter[0];
-                    sum2 = input[i+step]     * filter[0];
-                    sum3 = input[i+(2*step)] * filter[0];
-                    sum4 = input[i+(3*step)] * filter[0];
-                    for(j = 1; j < F; ++j){
-                        sum += input[i-j]           * filter[j];
-                        sum2 += input[(step+i)-j]   * filter[j];
-                        sum3 += input[(2*step+i)-j] * filter[j];
-                        sum4 += input[(3*step+i)-j] * filter[j];
-                    }
-                    *(ptr_w++) = sum;
-                    *(ptr_w++) = sum2;
-                    *(ptr_w++) = sum3;
-                    *(ptr_w++) = sum4;
-                }
-            }
-            #endif
-
-            #ifdef OPT_UNROLL2
-            if((N - F)/step > 2) {
-                for(; i < (N - step); i += 2*step){  /* input elements, */
-                    sum  = input[i]   * filter[0];
-                    sum2 = input[i+step] * filter[0];
-                    for(j = 1; j < F; ++j){
-                        sum += input[i-j]         * filter[j];
-                        sum2 += input[(step+i)-j] * filter[j];
-                    }
-                    *(ptr_w++) = sum;
-                    *(ptr_w++) = sum2;
-                }
-            }
-            #endif
-
             for(; i < N; i+=step){  /* input elements, */
                 sum = input[i] * filter[0];
                 for(j = 1; j < F; ++j){
@@ -791,16 +747,6 @@ int @type@_upsampling_convolution_valid_sf(const @type@* input,
     @type@ *filter_even, *filter_odd;
     @type@ *ptr_base;
     @type@ sum_even, sum_odd;
-    #ifdef OPT_UNROLL2
-        @type@ sum_even2, sum_odd2;
-    #endif
-    #ifdef OPT_UNROLL4
-        #ifndef OPT_UNROLL2
-            @type@ sum_even2, sum_odd2;
-        #endif
-        @type@ sum_even3, sum_odd3;
-        @type@ sum_even4, sum_odd4;
-    #endif
 
     index_t i, j;
     index_t F_2 = F/2;
@@ -838,66 +784,6 @@ int @type@_upsampling_convolution_valid_sf(const @type@* input,
 
     ptr_base = (@type@*)input + F_2 - 1;
     i = 0;
-
-    #ifdef OPT_UNROLL4
-    /* manually unroll the loop a bit */
-    for(; i < N-(F_2-1+8); i+=4){    /* sliding over signal from left to right */
-        sum_even  = filter_even[0] * ptr_base[i];
-        sum_even2 = filter_even[0] * ptr_base[i+1];
-        sum_even3 = filter_even[0] * ptr_base[i+2];
-        sum_even4 = filter_even[0] * ptr_base[i+3];
-
-        sum_odd   = filter_odd[0] * ptr_base[i];
-        sum_odd2  = filter_odd[0] * ptr_base[i+1];
-        sum_odd3  = filter_odd[0] * ptr_base[i+2];
-        sum_odd4  = filter_odd[0] * ptr_base[i+3];
-
-        for(j = 1; j < F_2; ++j){
-            sum_even  += filter_even[j] * ptr_base[i-j];
-            sum_even2 += filter_even[j] * ptr_base[(i+1)-j];
-            sum_even3 += filter_even[j] * ptr_base[(i+2)-j];
-            sum_even4 += filter_even[j] * ptr_base[(i+3)-j];
-
-            sum_odd  += filter_odd[j] * ptr_base[i-j];
-            sum_odd2 += filter_odd[j] * ptr_base[(i+1)-j];
-            sum_odd3 += filter_odd[j] * ptr_base[(i+2)-j];
-            sum_odd4 += filter_odd[j] * ptr_base[(i+3)-j];
-        }
-
-        *(ptr_out++) += sum_even;
-        *(ptr_out++) += sum_odd;
-        *(ptr_out++) += sum_even2;
-        *(ptr_out++) += sum_odd2;
-        *(ptr_out++) += sum_even3;
-        *(ptr_out++) += sum_odd3;
-        *(ptr_out++) += sum_even4;
-        *(ptr_out++) += sum_odd4;
-    }
-    #endif
-
-    #ifdef OPT_UNROLL2
-    /* manually unroll the loop a bit */
-    for(; i < N-(F_2+1); i+=2){    /* sliding over signal from left to right */
-        sum_even = filter_even[0] * ptr_base[i];
-        sum_even2 = filter_even[0] * ptr_base[i+1];
-
-        sum_odd  = filter_odd[0] * ptr_base[i];
-        sum_odd2  = filter_odd[0] * ptr_base[i+1];
-
-        for(j = 1; j < F_2; ++j){
-            sum_even += filter_even[j] * ptr_base[i-j];
-            sum_even2 += filter_even[j] * ptr_base[(i+1)-j];
-
-            sum_odd += filter_odd[j] * ptr_base[i-j];
-            sum_odd2 += filter_odd[j] * ptr_base[(i+1)-j];
-        }
-
-        *(ptr_out++) += sum_even;
-        *(ptr_out++) += sum_odd;
-        *(ptr_out++) += sum_even2;
-        *(ptr_out++) += sum_odd2;
-    }
-    #endif
 
     for(; i < N-(F_2-1); ++i){    /* sliding over signal from left to right */
         sum_even = filter_even[0] * ptr_base[i];

--- a/pywt/src/convolution.c.src
+++ b/pywt/src/convolution.c.src
@@ -568,9 +568,9 @@ int @type@_upsampling_convolution_valid_sf_periodization(const @type@* input,
  * case to separate function this looks much clearer now.
  */
 
-int @type@_upsampling_convolution_valid_sf(const @type@* input, const index_t N,
-                                           const @type@* filter, const index_t F,
-                                           @type@* output, const index_t O,
+int @type@_upsampling_convolution_valid_sf(const @type@ * const restrict input, const index_t N,
+                                           const @type@ * const restrict filter, const index_t F,
+                                           @type@ * const restrict output, const index_t O,
                                            MODE mode)
 {
     if(mode == MODE_PERIODIZATION) /* Special case */

--- a/pywt/src/convolution.c.src
+++ b/pywt/src/convolution.c.src
@@ -118,34 +118,18 @@ int @type@_downsampling_convolution(const @type@* input, const index_t N,
             for(index_t k = 0; j < F; ++j, ++k)
                 sum += filter[j]*input[k];
             break;
-
-        case MODE_ASYMMETRIC:
-            /* Not documented or tested.
-             *
-             * The `n`th element past the edge is the first element of the
-             * sequence minus the `n`th element, as illustrated below:
-             *
-             * ... (0 - 2) (0 - 1) (0 - 0) | 0 1 2 ...
-             */
-            for(index_t k = 0; j < F; ++j, ++k)
-                sum += filter[j]*(input[0] - input[k]);
-            break;
-
         case MODE_CONSTANT_EDGE:
             for(; j < F; ++j)
                 sum += filter[j]*input[0];
             break;
-
         case MODE_SMOOTH:
             for(index_t k = 1; j < F; ++j, ++k)
                 sum += filter[j]*(input[0] + k * (input[0] - input[1]));
             break;
-
         case MODE_PERIODIC:
             for(index_t k = N-1; j < F; ++j, --k)
                 sum += filter[j]*input[k];
             break;
-
         case MODE_ZEROPAD:
         default:
             break;
@@ -176,10 +160,6 @@ int @type@_downsampling_convolution(const @type@* input, const index_t N,
             /* TODO: add offset to j? Inherited, not sure what this means */
             for(index_t k = N-1; j >= 0; --j, --k)
                 sum += filter[j]*input[k];
-            break;
-        case MODE_ASYMMETRIC:
-            for(index_t k = N-1; j >= 0; --j, --k)
-                sum += filter[j]*(input[N-1] - input[k]);
             break;
         case MODE_CONSTANT_EDGE:
             for(; j >= 0; --j)   /* overlapped elements */
@@ -268,21 +248,6 @@ int @type@_allocating_downsampling_convolution(const @type@* input, const index_
             for(j = 0; j < N; ++j){
                 buffer[(F-1)-1-j] = input[j%N];
                 buffer[N_extended_right_start+j] = input[N-1-(j%N)];
-            }
-            index_t i = j;
-            /* use `buffer` as source */
-            for(; j < (F-1); ++j){
-                buffer[(F-1)-1-j] =  buffer[N_extended_right_start-1+i-j];
-                buffer[N_extended_right_start+j] = buffer[(F-1)+j-i];
-            }
-            break;
-        }
-
-        case MODE_ASYMMETRIC:{
-            index_t j;
-            for(j = 0; j < N; ++j){
-                buffer[(F-1)-1-j] = input[0] - input[j%N];
-                buffer[N_extended_right_start+j] = (input[N-1] - input[N-1-(j%N)]);
             }
             index_t i = j;
             /* use `buffer` as source */

--- a/pywt/src/convolution.c.src
+++ b/pywt/src/convolution.c.src
@@ -302,31 +302,25 @@ int @type@_allocating_downsampling_convolution(const @type@* input, const_index_
                                         @type@* output,
                                         const_index_t step, MODE mode)
 {
-    index_t i, j, F_minus_1, N_extended_len, N_extended_right_start;
-    index_t start, stop;
-    @type@ sum, tmp;
+    index_t N_extended_right_start, start, stop;
     @type@ *buffer;
-    @type@* ptr_w = output;
-
-    F_minus_1 = F - 1;
-    start = F_minus_1+step-1;
 
     /* allocate memory and copy input */
     if(mode != MODE_PERIODIZATION){
 
-        N_extended_len = N + 2*F_minus_1;
-        N_extended_right_start = N + F_minus_1;
+        index_t N_extended_len = N + 2*(F-1);
+        N_extended_right_start = N + (F-1);
 
         buffer = wtcalloc(N_extended_len, sizeof(@type@));
         if(buffer == NULL)
             return -1;
 
-        memcpy(buffer+F_minus_1, input, sizeof(@type@) * N);
+        memcpy(buffer+(F-1), input, sizeof(@type@) * N);
+        start = (F-1) + step - 1;
         stop = N_extended_len;
 
     } else {
-
-        N_extended_len = N + F-1;
+        index_t N_extended_len = N + F-1;
         N_extended_right_start = N-1 + F/2;
 
         buffer = wtcalloc(N_extended_len, sizeof(@type@));
@@ -335,8 +329,7 @@ int @type@_allocating_downsampling_convolution(const @type@* input, const_index_
 
         memcpy(buffer+F/2-1, input, sizeof(@type@) * N);
 
-        start -= 1;
-
+        start = (F-1) + step - 2;
         if(step == 1)
             stop = N_extended_len-1;
         else /* step == 2 */
@@ -349,68 +342,72 @@ int @type@_allocating_downsampling_convolution(const @type@* input, const_index_
         case MODE_PERIODIZATION:
             if(N%2){ /* odd - repeat last element */
                 buffer[N_extended_right_start] = input[N-1];
-                for(j = 1; j < F/2; ++j)
+                for(index_t j = 1; j < F/2; ++j)
                     buffer[N_extended_right_start+j] = buffer[F/2-2 + j]; /* copy from beginning of `input` to right */
-                for(j = 0; j < F/2-1; ++j)   /* copy from 'buffer' to left */
+                for(index_t j = 0; j < F/2-1; ++j)   /* copy from 'buffer' to left */
                     buffer[F/2-2-j] =  buffer[N_extended_right_start-j];
             } else {
-                for(j = 0; j < F/2; ++j)
+                for(index_t j = 0; j < F/2; ++j)
                     buffer[N_extended_right_start+j] = input[j%N]; /* copy from beginning of `input` to right */
-                for(j = 0; j < F/2-1; ++j)   /* copy from 'buffer' to left */
+                for(index_t j = 0; j < F/2-1; ++j)   /* copy from 'buffer' to left */
                     buffer[F/2-2-j] =  buffer[N_extended_right_start-1-j];
             }
             break;
 
-        case MODE_SYMMETRIC:
+        case MODE_SYMMETRIC:{
+            index_t j;
             for(j = 0; j < N; ++j){
-                buffer[F_minus_1-1-j] = input[j%N];
+                buffer[(F-1)-1-j] = input[j%N];
                 buffer[N_extended_right_start+j] = input[N-1-(j%N)];
             }
-            i=j;
+            index_t i = j;
             /* use `buffer` as source */
-            for(; j < F_minus_1; ++j){
-                buffer[F_minus_1-1-j] =  buffer[N_extended_right_start-1+i-j];
-                buffer[N_extended_right_start+j] = buffer[F_minus_1+j-i];
+            for(; j < (F-1); ++j){
+                buffer[(F-1)-1-j] =  buffer[N_extended_right_start-1+i-j];
+                buffer[N_extended_right_start+j] = buffer[(F-1)+j-i];
             }
             break;
+        }
 
-        case MODE_ASYMMETRIC:
+        case MODE_ASYMMETRIC:{
+            index_t j;
             for(j = 0; j < N; ++j){
-                buffer[F_minus_1-1-j] = input[0] - input[j%N];
+                buffer[(F-1)-1-j] = input[0] - input[j%N];
                 buffer[N_extended_right_start+j] = (input[N-1] - input[N-1-(j%N)]);
             }
-            i=j;
+            index_t i = j;
             /* use `buffer` as source */
-            for(; j < F_minus_1; ++j){
-                buffer[F_minus_1-1-j] =  buffer[N_extended_right_start-1+i-j];
-                buffer[N_extended_right_start+j] = buffer[F_minus_1+j-i];
+            for(; j < (F-1); ++j){
+                buffer[(F-1)-1-j] =  buffer[N_extended_right_start-1+i-j];
+                buffer[N_extended_right_start+j] = buffer[(F-1)+j-i];
             }
             break;
+        }
 
         case MODE_SMOOTH:
             if(N>1){
-                tmp = input[0]-input[1];
-                for(j = 0; j < F_minus_1; ++j)
-                    buffer[j] = input[0] +    (tmp * (F_minus_1-j));
+                @type@ tmp = input[0]-input[1];
+                for(index_t j = 0; j < (F-1); ++j)
+                    buffer[j] = input[0] +    (tmp * ((F-1)-j));
                 tmp = input[N-1]-input[N-2];
-                for(j = 0; j < F_minus_1; ++j)
+                for(index_t j = 0; j < (F-1); ++j)
                     buffer[N_extended_right_start+j] = input[N-1] + (tmp*j);
                 break;
             }
 
         case MODE_CONSTANT_EDGE:
-            for(j = 0; j < F_minus_1; ++j){
+            for(index_t j = 0; j < (F-1); ++j){
                 buffer[j] = input[0];
                 buffer[N_extended_right_start+j] = input[N-1];
             }
             break;
 
         case MODE_PERIODIC:
-            for(j = 0; j < F_minus_1; ++j)
+            for(index_t j = 0; j < F-1; ++j)
                 buffer[N_extended_right_start+j] = input[j%N]; /* copy from beginning of `input` to right */
 
-            for(j = 0; j < F_minus_1; ++j)   /* copy from 'buffer' to left */
-                buffer[F_minus_1-1-j] =  buffer[N_extended_right_start-1-j];
+            for(index_t j = 0; j < F-1; ++j)   /* copy from 'buffer' to left */
+                buffer[(F-1)-1-j] =  buffer[N_extended_right_start-1-j];
             break;
 
         case MODE_ZEROPAD:
@@ -422,12 +419,13 @@ int @type@_allocating_downsampling_convolution(const @type@* input, const_index_
     /*
      * F - N-1 : filter in input range, perform convolution with decimation
      */
-    for(i=start; i < stop; i+=step){  /* input elements */
-        sum = 0;
-        for(j = 0; j < F; ++j){
+    for(index_t i=start, o=0; i < stop; i+=step, ++o){  /* input elements */
+        @type@ sum = 0;
+
+        for(index_t j = 0; j < F; ++j){
             sum += buffer[i-j]*filter[j];
         }
-        *(ptr_w++) = sum;
+        output[o] = sum;
     }
 
     /* free memory */

--- a/pywt/src/convolution.c.src
+++ b/pywt/src/convolution.c.src
@@ -315,16 +315,6 @@ int @type@_upsampling_convolution_valid_sf_periodization(const @type@* input,
                                                          F, @type@* output,
                                                          const index_t O)
 {
-
-    @type@ *ptr_out = output;
-    @type@ *filter_even, *filter_odd;
-    @type@ *periodization_buf = NULL;
-    @type@ *periodization_buf_rear = NULL;
-    @type@ *ptr_base;
-    @type@ sum_even, sum_odd;
-    index_t i, j, k, N_p = 0;
-    index_t F_2 = F/2;
-
     if(F%2) return -3; /* Filter must have even-length. */
 
     /*
@@ -332,47 +322,30 @@ int @type@_upsampling_convolution_valid_sf_periodization(const @type@* input,
      * the filter's length. The coeff array has to be extended periodically.
      * This can be only valid for PERIODIZATION_MODE
      */
-    if(N < F_2)
-    {
+    if(N < F/2) {
         /* Input data for periodization mode has to be periodically extended */
 
         /* New length for temporary input */
-        N_p = F_2-1 +N;
+        const index_t N_p = F/2 - 1 + N;
 
         /* periodization_buf will hold periodically copied input coeffs values */
-        periodization_buf = wtcalloc(N_p, sizeof(@type@));
+        @type@ * periodization_buf = wtcalloc(N_p, sizeof(*periodization_buf));
 
         if(periodization_buf == NULL)
             return -1;
 
-        /* Copy input data to its place in the periodization_buf */
-        /* -> [0 0 0 i1 i2 i3 0 0 0] */
-        k = (F_2-1)/2;
-        for(i=k; i < k+N; ++i)
-            periodization_buf[i] = input[(i-k)%N];
-
-        /* if(N%2)
-         *     periodization_buf[i++] = input[N-1];
-         *
-         * [0 0 0 i1 i2 i3 0 0 0]
-         *  points here ^^
-         */
-        periodization_buf_rear = periodization_buf+i-1;
-
-        /* copy cyclically () to right   [0 0 0 i1 i2 i3 i1 i2 ...] */
-        j = i-k;
-        for(; i < N_p; ++i)
-            periodization_buf[i] = periodization_buf[i-j];
+        /* Copy input data to its place in the periodization_buf
+         * -> [0 0 0 | i1 i2 i3 | i1 i2 ...] */
+        const index_t k = (F/2-1)/2;
+        for(index_t i=0, o=k; o < N_p; ++i, ++o)
+            periodization_buf[o] = input[i%N];
 
         /* copy cyclically () to left    [... i2 i3 i1 i2 i3 i1 i2 i3] */
-        j = 0;
-        for(i=k-1; i >= 0; --i){
-            periodization_buf[i] = periodization_buf_rear[j];
-            --j;
-        }
+        for(index_t i=k-1; i >= 0; --i)
+            periodization_buf[i] = periodization_buf[N+i];
 
         /* Now perform the valid convolution */
-        if(F_2%2){
+        if((F/2)%2){
             @type@_upsampling_convolution_valid_sf(periodization_buf, N_p, filter, F, output, O, MODE_ZEROPAD);
 
         /* The F_2%2==0 case needs special result fix (oh my, another one..) */
@@ -383,8 +356,8 @@ int @type@_upsampling_convolution_valid_sf_periodization(const @type@* input,
              * Memory allocation for temporary output is done.
              * Computed temporary result is copied to output*
              */
-            ptr_out = wtcalloc(idwt_buffer_length(N, F, MODE_PERIODIZATION),
-                                                  sizeof(@type@));
+            @type@ * ptr_out = wtcalloc(idwt_buffer_length(N, F, MODE_PERIODIZATION),
+                                        sizeof(@type@));
             if(ptr_out == NULL){
                 wtfree(periodization_buf);
                 return -1;
@@ -394,7 +367,7 @@ int @type@_upsampling_convolution_valid_sf_periodization(const @type@* input,
             @type@_upsampling_convolution_valid_sf(periodization_buf, N_p, filter, F, ptr_out, O, MODE_ZEROPAD);
 
             /* rewrite result to output */
-            for(i=2*N-1; i > 0; --i){
+            for(index_t i=1; i < 2*N; ++i){
                 output[i] += ptr_out[i-1];
             }
             /* and the first element */
@@ -404,7 +377,15 @@ int @type@_upsampling_convolution_valid_sf_periodization(const @type@* input,
         }
 
     } else {
-    /* Otherwise (N >= F_2) */
+        /* Otherwise (N >= F_2) */
+        @type@ *ptr_out = output;
+        @type@ *filter_even, *filter_odd;
+        @type@ * periodization_buf = NULL;
+        @type@ *periodization_buf_rear = NULL;
+        @type@ *ptr_base;
+        @type@ sum_even, sum_odd;
+        index_t i, j, k, N_p = 0;
+        index_t F_2 = F/2;
 
         /* Allocate memory for even and odd elements of the filter */
         filter_even = wtmalloc(F_2 * sizeof(@type@));

--- a/pywt/src/convolution.c.src
+++ b/pywt/src/convolution.c.src
@@ -7,10 +7,9 @@
  * #type = double, float#
  */
 
-int @type@_downsampling_convolution_periodization(const @type@* input, const index_t N,
-                             const @type@* filter, const index_t F,
-                             @type@* output, const index_t step)
-
+int @type@_downsampling_convolution_periodization(const @type@ * const restrict input, const index_t N,
+                                                  const @type@ * const restrict filter, const index_t F,
+                                                  @type@ * const restrict output, const index_t step)
 {
     /*
     * Should it be an error to call this mode with signal lengths
@@ -25,11 +24,10 @@ int @type@_downsampling_convolution_periodization(const @type@* input, const ind
     *   }
     */
 
-    index_t i;
-    @type@* ptr_w = output;
+    index_t i = F/2, o = 0;
     const index_t padding = N % 2; // Should be N%step for larger steps?
 
-    for (i=F/2; i < F && i < N; i += step) {
+    for (; i < F && i < N; i += step, ++o) {
         @type@ sum = 0;
         index_t j;
         for (j = 0; j <= i; ++j)
@@ -40,18 +38,18 @@ int @type@_downsampling_convolution_periodization(const @type@* input, const ind
             for (index_t k = 0; k < N && j < F; ++k, ++j)
                 sum += filter[j] * input[N-1-k];
         }
-        *(ptr_w++) = sum;
+        output[o] = sum;
     }
 
     /* F - N-1 : filter in input range.  Most time is spent in this loop */
-    for(; i < N; i+=step){    /* input elements, */
+    for(; i < N; i+=step, ++o){    /* input elements, */
         @type@ sum = 0;
         for(index_t j = 0; j < F; ++j)
             sum += input[i-j]*filter[j];
-        *(ptr_w++) = sum;
+        output[o] = sum;
     }
 
-    for (; i < F && i < N + F/2; i += step) {
+    for (; i < F && i < N + F/2; i += step, ++o) {
         @type@ sum = 0;
         index_t j = 0;
 
@@ -69,10 +67,10 @@ int @type@_downsampling_convolution_periodization(const @type@* input, const ind
             for (index_t k = 0; k < N && j < F; ++k, ++j)
                 sum += filter[j] * input[N-1-k];
         }
-        *(ptr_w++) = sum;
+        output[o] = sum;
     }
 
-    for(; i < N + F/2; i += step){   /* input elements */
+    for(; i < N + F/2; i += step, ++o){   /* input elements */
         @type@ sum = 0;
         index_t j = 0;
         while (i-j >= N){
@@ -83,16 +81,16 @@ int @type@_downsampling_convolution_periodization(const @type@* input, const ind
         }
         for (; j < F; ++j)
             sum += filter[j] * input[i-j];
-        *(ptr_w++) = sum;
+        output[o] = sum;
     }
     return 0;
 }
 
 
-int @type@_downsampling_convolution(const @type@* input, const index_t N,
-                             const @type@* filter, const index_t F,
-                             @type@* output,
-                             const index_t step, MODE mode)
+int @type@_downsampling_convolution(const @type@ * const restrict input, const index_t N,
+                                    const @type@ * const restrict filter, const index_t F,
+                                    @type@ * const restrict output,
+                                    const index_t step, MODE mode)
 {
     /*
      * This convolution performs efficient downsampling by computing every
@@ -114,10 +112,7 @@ int @type@_downsampling_convolution(const @type@* input, const index_t N,
      *    for time > n-1
      */
 
-    index_t i;
-    index_t start = step-1; /* first element taken from input is input[step-1] */
-
-    @type@* ptr_w = output;
+    index_t i = step - 1, o = 0;
 
     if(mode == MODE_PERIODIZATION){
         return @type@_downsampling_convolution_periodization(input, N, filter, F, output, step);
@@ -125,7 +120,7 @@ int @type@_downsampling_convolution(const @type@* input, const index_t N,
 
     /* Other signal extension modes */
     /* 0 - F-1 : sliding in filter */
-    for(i=start; i < F && i < N; i+=step){
+    for(; i < F && i < N; i+=step, ++o){
         @type@ sum = 0;
         index_t j;
         for(j = 0; j <= i; ++j)
@@ -157,22 +152,22 @@ int @type@_downsampling_convolution(const @type@* input, const index_t N,
         default:
             break;
         }
-        *(ptr_w++) = sum;
+        output[o] = sum;
     }
 
     /*
      * F - N-1 : filter in input range - simple convolution
      * Most time is spent in this loop.
      */
-    for(; i < N; i+=step){  /* input elements, */
+    for(; i < N; i+=step, ++o){  /* input elements, */
         @type@ sum = 0;
 
         for(index_t j = 0; j < F; ++j)
             sum += input[i-j]*filter[j];
-        *(ptr_w++) = sum;
+        output[o] = sum;
     }
 
-    for(; i < F; i+=step){
+    for(; i < F; i+=step, ++o){
         @type@ sum = 0;
         index_t j = 0;
         switch(mode) {
@@ -232,11 +227,11 @@ int @type@_downsampling_convolution(const @type@* input, const index_t N,
         default:
             break;
         }
-        *(ptr_w++) = sum;
+        output[o] = sum;
     }
 
     /* N - N+F-1 : sliding out filter */
-    for(; i < N+F-1; i += step){  /* input elements */
+    for(; i < N+F-1; i += step, ++o){
         @type@ sum = 0;
         index_t j = 0;
         switch(mode) {
@@ -270,7 +265,7 @@ int @type@_downsampling_convolution(const @type@* input, const index_t N,
         }
         for(; j < F; ++j)
             sum += filter[j]*input[i-j];
-        *(ptr_w++) = sum;
+        output[o] = sum;
     }
     return 0;
 }

--- a/pywt/src/convolution.c.src
+++ b/pywt/src/convolution.c.src
@@ -308,12 +308,9 @@ int @type@_upsampling_convolution_full(const @type@ * const restrict input, cons
  * The input data has to be periodically extended for this mode.
  */
 
-int @type@_upsampling_convolution_valid_sf_periodization(const @type@* input,
-                                                         const index_t N,
-                                                         const @type@*
-                                                         filter, const index_t
-                                                         F, @type@* output,
-                                                         const index_t O)
+int @type@_upsampling_convolution_valid_sf_periodization(const @type@* input, const index_t N,
+                                                         const @type@* filter, const index_t F,
+                                                         @type@* output, const index_t O)
 {
     if(F%2) return -3; /* Filter must have even-length. */
 

--- a/pywt/src/convolution.c.src
+++ b/pywt/src/convolution.c.src
@@ -331,59 +331,55 @@ int @type@_upsampling_convolution_valid_sf_periodization(const @type@* input, co
      * This can be only valid for PERIODIZATION_MODE
      */
     if(N < F/2) {
-        /* Input data for periodization mode has to be periodically extended */
+        @type@ * const restrict ptr_out = wtcalloc(idwt_buffer_length(N, F, MODE_PERIODIZATION),
+                                                   sizeof(@type@));
+        const index_t start = F/4;
+        index_t i = start, o = 0;
 
-        /* New length for temporary input */
-        const index_t N_p = F/2 - 1 + N;
-
-        /* periodization_buf will hold periodically copied input coeffs values */
-        @type@ * periodization_buf = wtcalloc(N_p, sizeof(*periodization_buf));
-
-        if(periodization_buf == NULL)
-            return -1;
-
-        /* Copy input data to its place in the periodization_buf
-         * -> [0 0 0 | i1 i2 i3 | i1 i2 ...] */
-        const index_t k = (F/2-1)/2;
-        for(index_t i=0, o=k; o < N_p; ++i, ++o)
-            periodization_buf[o] = input[i%N];
-
-        /* copy cyclically () to left    [... i2 i3 i1 i2 i3 i1 i2 i3] */
-        for(index_t i=k-1; i >= 0; --i)
-            periodization_buf[i] = periodization_buf[N+i];
-
-        /* Now perform the valid convolution */
-        if((F/2)%2){
-            @type@_upsampling_convolution_valid_sf(periodization_buf, N_p, filter, F, output, O, MODE_ZEROPAD);
-
-        /* The F_2%2==0 case needs special result fix (oh my, another one..) */
-        } else {
-
-            /*
-             * Cheap result fix for short inputs
-             * Memory allocation for temporary output is done.
-             * Computed temporary result is copied to output*
-             */
-            @type@ * ptr_out = wtcalloc(idwt_buffer_length(N, F, MODE_PERIODIZATION),
-                                        sizeof(@type@));
-            if(ptr_out == NULL){
-                wtfree(periodization_buf);
-                return -1;
+        for (; i < N; ++i, o += 2){
+            index_t j = 0;
+            for(; j <= i; ++j){
+                ptr_out[o] += filter[2*j] * input[i-j];
+                ptr_out[o+1] += filter[2*j+1] * input[i-j];
             }
-
-            /* Convolve here as for (F_2%2) branch above */
-            @type@_upsampling_convolution_valid_sf(periodization_buf, N_p, filter, F, ptr_out, O, MODE_ZEROPAD);
-
-            /* rewrite result to output */
-            for(index_t i=1; i < 2*N; ++i){
-                output[i] += ptr_out[i-1];
+            while (j < F/2){
+                for(index_t k = 0; k < N && j < F/2; ++k, ++j){
+                    ptr_out[o] += filter[2*j] * input[N-1-k];
+                    ptr_out[o+1] += filter[2*j+1] * input[N-1-k];
+                }
             }
-            /* and the first element */
-            output[0] += ptr_out[2*N-1];
-            wtfree(ptr_out);
-            /* and voila!, ugh */
         }
 
+        for (; i < N + start; ++i, o += 2){
+            index_t j = 0;
+            while(i-j >= N){
+                for (index_t k = 0; k < N && i-j >= N; ++k, ++j){
+                    ptr_out[o] += filter[2*(i-N-j)] * input[k];
+                    ptr_out[o+1] += filter[2*(i-N-j)+1] * input[k];
+                }
+            }
+            for (; j <= i && j < F/2; ++j){
+                ptr_out[o] += filter[2*j] * input[i-j];
+                ptr_out[o+1] += filter[2*j+1] * input[i-j];
+            }
+            while (j < F / 2){
+                for (index_t k = 0; k < N && j < F/2; ++k, ++j){
+                    ptr_out[o] += filter[2*j] * input[N-1-k];
+                    ptr_out[o+1] += filter[2*j+1] * input[N-1-k];
+                }
+            }
+        }
+
+        if ((F/2)%2 == 0){
+            // Shift everything one element right
+            for(index_t i = 1; i < 2*N; ++i)
+                output[i] += ptr_out[i-1];
+            output[0] += ptr_out[2*N-1];
+        } else {
+            for (index_t i = 0; i < 2*N; ++i)
+                output[i] += ptr_out[i];
+        }
+        wtfree(ptr_out);
     } else {
         /* Otherwise (N >= F_2) */
         @type@ * ptr_out = output;

--- a/pywt/src/convolution.c.src
+++ b/pywt/src/convolution.c.src
@@ -100,194 +100,190 @@ int @type@_downsampling_convolution(const @type@* input, const_index_t N,
 
     i = start = step-1; /* first element taken from input is input[step-1] */
 
-    if(F <= N){
-
-        if(mode == MODE_PERIODIZATION){
-            return @type@_downsampling_convolution_periodization(input, N, filter, F, output, step);
-
-        /* Other signal extension modes */
-        } else {
-
-            /* 0 - F-1 : sliding in filter */
-            switch(mode)
-            {
-                case MODE_SYMMETRIC:
-                    for(i=start; i < F; i+=step){
-                        sum = 0;
-                        for(j = 0; j <= i; ++j)
-                            sum += filter[j]*input[i-j];
-                        k = i+1;
-                        for(j = i+1; j < F; ++j)
-                            sum += filter[j] * input[j-k];
-                        *(ptr_w++) = sum;
-                    }
-                    break;
-
-                case MODE_ASYMMETRIC:
-                    for(i=start; i < F; i+=step){
-                        sum = 0;
-                        for(j = 0; j <= i; ++j)
-                            sum += filter[j]*input[i-j];
-                        k = i+1;
-                        for(j = i+1; j < F; ++j)
-                            sum += filter[j] * (input[0] - input[j-k]);
-                        *(ptr_w++) = sum;
-                    }
-                    break;
-
-                case MODE_CONSTANT_EDGE:
-                    for(i=start; i < F; i+=step){
-                        sum = 0;
-                        for(j = 0; j <= i; ++j)
-                            sum += filter[j]*input[i-j];
-
-                        k = i+1;
-                        for(j = i+1; j < F; ++j)
-                            sum += filter[j] * input[0];
-
-                        *(ptr_w++) = sum;
-                    }
-                    break;
-
-                case MODE_SMOOTH:
-                    for(i=start; i < F; i+=step){
-                        sum = 0;
-                        for(j = 0; j <= i; ++j)
-                            sum += filter[j]*input[i-j];
-                        tmp = input[0]-input[1];
-                        for(j = i+1; j < F; ++j){
-                            sum += filter[j] * (input[0] + tmp * (j-i));
-                        }
-                        *(ptr_w++) = sum;
-                    }
-                    break;
-
-                case MODE_PERIODIC:
-                    for(i=start; i < F; i+=step){
-                        sum = 0;
-                        for(j = 0; j <= i; ++j)
-                            sum += filter[j]*input[i-j];
-
-                        k = N+i;
-                        for(j = i+1; j < F; ++j)
-                            sum += filter[j] * input[k-j];
-
-                        *(ptr_w++) = sum;
-                    }
-                    break;
-
-                case MODE_ZEROPAD:
-                default:
-                    for(i=start; i < F; i+=step){
-                        sum = 0;
-                        for(j = 0; j <= i; ++j)
-                            sum += filter[j]*input[i-j];
-                        *(ptr_w++) = sum;
-                    }
-                    break;
-            }
-
-            /*
-             * F - N-1 : filter in input range - simple convolution
-             * Most time is spent in this loop.
-             */
-            for(; i < N; i+=step){  /* input elements, */
-                sum = input[i] * filter[0];
-                for(j = 1; j < F; ++j){
-                    sum += input[i-j]*filter[j];
-                }
-                *(ptr_w++) = sum;
-            }
-
-            /* N - N+F-1 : sliding out filter */
-            switch(mode)
-            {
-                case MODE_SYMMETRIC:
-                    for(; i < N+F-1; i += step){  /* input elements */
-                        sum = 0;
-                        k = i-N+1;   /* 1, 2, 3 : overlapped elements */
-                        for(j = k; j < F; ++j)   /*TODO: j < F-_offset */
-                            sum += filter[j]*input[i-j];
-
-                        for(j = 0; j < k; ++j)  /* out of boundary (TODO: j = _offset) */
-                            /* j-i-1      0*(N-1), 0*(N-2) 1*(N-1) */
-                            sum += filter[j]*input[N-k+j];
-
-                        *(ptr_w++) = sum;
-                    }
-                    break;
-
-                case MODE_ASYMMETRIC:
-                    for(; i < N+F-1; i += step){  /* input elements */
-                        sum = 0;
-                        k = i-N+1;
-                        for(j = k; j < F; ++j)   /* overlapped elements */
-                            sum += filter[j]*input[i-j];
-
-                        for(j = 0; j < k; ++j)   /* out of boundary */
-                            sum += filter[j]*(input[N-1]-input[N-k-1+j]); /* -= j-i-1 */
-                        *(ptr_w++) = sum;
-                    }
-                    break;
-
-                case MODE_CONSTANT_EDGE:
-                    for(; i < N+F-1; i += step){  /* input elements */
-                        sum = 0;
-                        k = i-N+1;
-                        for(j = k; j < F; ++j)   /* overlapped elements */
-                            sum += filter[j]*input[i-j];
-
-                        for(j = 0; j < k; ++j)  /* out of boundary (filter elements [0, k-1]) */
-                            sum += filter[j]*input[N-1]; /* input[N-1] = const */
-
-                        *(ptr_w++) = sum;
-                    }
-                    break;
-
-                case MODE_SMOOTH:
-                    for(; i < N+F-1; i += step){  /* input elements */
-                        sum = 0;
-                        k = i-N+1;
-                        for(j = k; j < F; ++j)  /* overlapped elements */
-                            sum += filter[j]*input[i-j];
-
-                        tmp = input[N-1]-input[N-2];
-                        for(j = 0; j < k; ++j)  /* out of boundary (filter elements [0, k-1]) */
-                            sum += filter[j] * (input[N-1] + tmp * (k-j));
-                        *(ptr_w++) = sum;
-                    }
-                    break;
-
-                case MODE_PERIODIC:
-                    for(; i < N+F-1; i += step){  /* input elements */
-                        sum = 0;
-                        k = i-N+1;
-                        for(j = k; j < F; ++j)   /* overlapped elements */
-                            sum += filter[j]*input[i-j];
-                        for(j = 0; j < k; ++j)  /* out of boundary (filter elements [0, k-1]) */
-                            sum += filter[j]*input[k-1-j];
-                        *(ptr_w++) = sum;
-                    }
-                    break;
-
-                case MODE_ZEROPAD:
-                default:
-                    for(; i < N+F-1; i += step){
-                        sum = 0;
-                        for(j = i-(N-1); j < F; ++j)
-                            sum += input[i-j]*filter[j];
-                        *(ptr_w++) = sum;
-                    }
-                    break;
-            }
-        }
-        return 0;
-
-    } else {
+    if (F > N) {
         /* reallocating memory for short signals (shorter than filter) is cheap */
         return @type@_allocating_downsampling_convolution(input, N, filter, F,
                                                            output, step, mode);
     }
+
+    if(mode == MODE_PERIODIZATION){
+        return @type@_downsampling_convolution_periodization(input, N, filter, F, output, step);
+    }
+
+    /* Other signal extension modes */
+    /* 0 - F-1 : sliding in filter */
+    switch(mode)
+    {
+        case MODE_SYMMETRIC:
+            for(i=start; i < F; i+=step){
+                sum = 0;
+                for(j = 0; j <= i; ++j)
+                    sum += filter[j]*input[i-j];
+                k = i+1;
+                for(j = i+1; j < F; ++j)
+                    sum += filter[j] * input[j-k];
+                *(ptr_w++) = sum;
+            }
+            break;
+
+        case MODE_ASYMMETRIC:
+            for(i=start; i < F; i+=step){
+                sum = 0;
+                for(j = 0; j <= i; ++j)
+                    sum += filter[j]*input[i-j];
+                k = i+1;
+                for(j = i+1; j < F; ++j)
+                    sum += filter[j] * (input[0] - input[j-k]);
+                *(ptr_w++) = sum;
+            }
+            break;
+
+        case MODE_CONSTANT_EDGE:
+            for(i=start; i < F; i+=step){
+                sum = 0;
+                for(j = 0; j <= i; ++j)
+                    sum += filter[j]*input[i-j];
+
+                k = i+1;
+                for(j = i+1; j < F; ++j)
+                    sum += filter[j] * input[0];
+
+                *(ptr_w++) = sum;
+            }
+            break;
+
+        case MODE_SMOOTH:
+            for(i=start; i < F; i+=step){
+                sum = 0;
+                for(j = 0; j <= i; ++j)
+                    sum += filter[j]*input[i-j];
+                tmp = input[0]-input[1];
+                for(j = i+1; j < F; ++j){
+                    sum += filter[j] * (input[0] + tmp * (j-i));
+                }
+                *(ptr_w++) = sum;
+            }
+            break;
+
+        case MODE_PERIODIC:
+            for(i=start; i < F; i+=step){
+                sum = 0;
+                for(j = 0; j <= i; ++j)
+                    sum += filter[j]*input[i-j];
+
+                k = N+i;
+                for(j = i+1; j < F; ++j)
+                    sum += filter[j] * input[k-j];
+
+                *(ptr_w++) = sum;
+            }
+            break;
+
+        case MODE_ZEROPAD:
+        default:
+            for(i=start; i < F; i+=step){
+                sum = 0;
+                for(j = 0; j <= i; ++j)
+                    sum += filter[j]*input[i-j];
+                *(ptr_w++) = sum;
+            }
+            break;
+    }
+
+    /*
+     * F - N-1 : filter in input range - simple convolution
+     * Most time is spent in this loop.
+     */
+    for(; i < N; i+=step){  /* input elements, */
+        sum = input[i] * filter[0];
+        for(j = 1; j < F; ++j){
+            sum += input[i-j]*filter[j];
+        }
+        *(ptr_w++) = sum;
+    }
+
+    /* N - N+F-1 : sliding out filter */
+    switch(mode)
+    {
+        case MODE_SYMMETRIC:
+            for(; i < N+F-1; i += step){  /* input elements */
+                sum = 0;
+                k = i-N+1;   /* 1, 2, 3 : overlapped elements */
+                for(j = k; j < F; ++j)   /*TODO: j < F-_offset */
+                    sum += filter[j]*input[i-j];
+
+                for(j = 0; j < k; ++j)  /* out of boundary (TODO: j = _offset) */
+                    /* j-i-1      0*(N-1), 0*(N-2) 1*(N-1) */
+                    sum += filter[j]*input[N-k+j];
+
+                *(ptr_w++) = sum;
+            }
+            break;
+
+        case MODE_ASYMMETRIC:
+            for(; i < N+F-1; i += step){  /* input elements */
+                sum = 0;
+                k = i-N+1;
+                for(j = k; j < F; ++j)   /* overlapped elements */
+                    sum += filter[j]*input[i-j];
+
+                for(j = 0; j < k; ++j)   /* out of boundary */
+                    sum += filter[j]*(input[N-1]-input[N-k-1+j]); /* -= j-i-1 */
+                *(ptr_w++) = sum;
+            }
+            break;
+
+        case MODE_CONSTANT_EDGE:
+            for(; i < N+F-1; i += step){  /* input elements */
+                sum = 0;
+                k = i-N+1;
+                for(j = k; j < F; ++j)   /* overlapped elements */
+                    sum += filter[j]*input[i-j];
+
+                for(j = 0; j < k; ++j)  /* out of boundary (filter elements [0, k-1]) */
+                    sum += filter[j]*input[N-1]; /* input[N-1] = const */
+
+                *(ptr_w++) = sum;
+            }
+            break;
+
+        case MODE_SMOOTH:
+            for(; i < N+F-1; i += step){  /* input elements */
+                sum = 0;
+                k = i-N+1;
+                for(j = k; j < F; ++j)  /* overlapped elements */
+                    sum += filter[j]*input[i-j];
+
+                tmp = input[N-1]-input[N-2];
+                for(j = 0; j < k; ++j)  /* out of boundary (filter elements [0, k-1]) */
+                    sum += filter[j] * (input[N-1] + tmp * (k-j));
+                *(ptr_w++) = sum;
+            }
+            break;
+
+        case MODE_PERIODIC:
+            for(; i < N+F-1; i += step){  /* input elements */
+                sum = 0;
+                k = i-N+1;
+                for(j = k; j < F; ++j)   /* overlapped elements */
+                    sum += filter[j]*input[i-j];
+                for(j = 0; j < k; ++j)  /* out of boundary (filter elements [0, k-1]) */
+                    sum += filter[j]*input[k-1-j];
+                *(ptr_w++) = sum;
+            }
+            break;
+
+        case MODE_ZEROPAD:
+        default:
+            for(; i < N+F-1; i += step){
+                sum = 0;
+                for(j = i-(N-1); j < F; ++j)
+                    sum += input[i-j]*filter[j];
+                *(ptr_w++) = sum;
+            }
+            break;
+    }
+    return 0;
 }
 
 /*

--- a/pywt/src/convolution.c.src
+++ b/pywt/src/convolution.c.src
@@ -111,28 +111,33 @@ int @type@_downsampling_convolution(const @type@* input, const_index_t N,
     {
         case MODE_SYMMETRIC:
             for(i=start; i < F; i+=step){
-                index_t k = i+1;
                 @type@ sum = 0;
                 index_t j;
 
                 for(j = 0; j <= i; ++j)
                     sum += filter[j]*input[i-j];
-                for(; j < F; ++j)
-                    sum += filter[j] * input[j-k];
+                for(index_t k = 0; j < F; ++j, ++k)
+                    sum += filter[j]*input[k];
                 *(ptr_w++) = sum;
             }
             break;
 
         case MODE_ASYMMETRIC:
+            /* Not documented or tested.
+             *
+             * The `n`th element past the edge is the first element of the
+             * sequence minus the `n`th element, as illustrated below:
+             *
+             * ... (0 - 2) (0 - 1) (0 - 0) | 0 1 2 ...
+             */
             for(i=start; i < F; i+=step){
-                index_t k = i+1;
                 @type@ sum = 0;
                 index_t j;
 
                 for(j = 0; j <= i; ++j)
                     sum += filter[j]*input[i-j];
-                for(; j < F; ++j)
-                    sum += filter[j] * (input[0] - input[j-k]);
+                for(index_t k = 0; j < F; ++j, ++k)
+                    sum += filter[j]*(input[0] - input[k]);
                 *(ptr_w++) = sum;
             }
             break;
@@ -140,41 +145,40 @@ int @type@_downsampling_convolution(const @type@* input, const_index_t N,
         case MODE_CONSTANT_EDGE:
             for(i=start; i < F; i+=step){
                 @type@ sum = 0;
-                index_t k = i+1;
                 index_t j;
 
                 for(j = 0; j <= i; ++j)
                     sum += filter[j]*input[i-j];
                 for(; j < F; ++j)
-                    sum += filter[j] * input[0];
+                    sum += filter[j]*input[0];
                 *(ptr_w++) = sum;
             }
             break;
 
-        case MODE_SMOOTH:
+        case MODE_SMOOTH:{
+            @type@ gradient = input[0]-input[1];
             for(i=start; i < F; i+=step){
                 @type@ sum = 0;
-                @type@ tmp = input[0]-input[1];
                 index_t j;
 
                 for(j = 0; j <= i; ++j)
                     sum += filter[j]*input[i-j];
-                for(; j < F; ++j)
-                    sum += filter[j] * (input[0] + tmp * (j-i));
+                for(index_t k = 1; j < F; ++j, ++k)
+                    sum += filter[j]*(input[0] + gradient * k);
                 *(ptr_w++) = sum;
             }
             break;
+        }
 
         case MODE_PERIODIC:
             for(i=start; i < F; i+=step){
                 @type@ sum = 0;
-                index_t k = N+i;
                 index_t j;
 
                 for(j = 0; j <= i; ++j)
                     sum += filter[j]*input[i-j];
-                for(; j < F; ++j)
-                    sum += filter[j] * input[k-j];
+                for(index_t k = N-1; j < F; ++j, --k)
+                    sum += filter[j]*input[k];
                 *(ptr_w++) = sum;
             }
             break;
@@ -210,14 +214,13 @@ int @type@_downsampling_convolution(const @type@* input, const_index_t N,
         case MODE_SYMMETRIC:
             for(; i < N+F-1; i += step){  /* input elements */
                 @type@ sum = 0;
-                index_t k = i-N+1;   /* 1, 2, 3 : overlapped elements */
                 index_t j;
 
-                for(j = 0; j < k; ++j)  /* out of boundary (TODO: j = _offset) */
-                    /* j-i-1      0*(N-1), 0*(N-2) 1*(N-1) */
-                    sum += filter[j]*input[N-k+j];
-                for(; j < F; ++j)   /*TODO: j < F-_offset */
+                /* TODO: add offset to j? Inherited, not sure what this means */
+                for(j = F - 1; i-j < N; --j)
                     sum += filter[j]*input[i-j];
+                for(index_t k = N-1; j >= 0; --j, --k)
+                    sum += filter[j]*input[k];
                 *(ptr_w++) = sum;
             }
             break;
@@ -225,13 +228,12 @@ int @type@_downsampling_convolution(const @type@* input, const_index_t N,
         case MODE_ASYMMETRIC:
             for(; i < N+F-1; i += step){  /* input elements */
                 @type@ sum = 0;
-                index_t k = i-N+1;
                 index_t j;
 
-                for(j = 0; j < k; ++j)   /* out of boundary */
-                    sum += filter[j]*(input[N-1]-input[N-k-1+j]); /* -= j-i-1 */
-                for(; j < F; ++j)   /* overlapped elements */
+                for(j = F - 1; i-j < N; --j)
                     sum += filter[j]*input[i-j];
+                for(index_t k = N-1; j >= 0; --j, --k)
+                    sum += filter[j]*(input[N-1] - input[k]);
                 *(ptr_w++) = sum;
             }
             break;
@@ -239,42 +241,40 @@ int @type@_downsampling_convolution(const @type@* input, const_index_t N,
         case MODE_CONSTANT_EDGE:
             for(; i < N+F-1; i += step){  /* input elements */
                 @type@ sum = 0;
-                index_t k = i-N+1;
                 index_t j;
 
-                for(j = 0; j < k; ++j)  /* out of boundary (filter elements [0, k-1]) */
-                    sum += filter[j]*input[N-1]; /* input[N-1] = const */
-                for(; j < F; ++j)   /* overlapped elements */
+                for(j = F - 1; i-j < N; --j)  /* out of boundary (filter elements [0, k-1]) */
                     sum += filter[j]*input[i-j];
+                for(; j >= 0; --j)   /* overlapped elements */
+                    sum += filter[j]*input[N-1]; /* input[N-1] = const */
                 *(ptr_w++) = sum;
             }
             break;
 
-        case MODE_SMOOTH:
+        case MODE_SMOOTH:{
+            @type@ gradient = input[N-1]-input[N-2];
             for(; i < N+F-1; i += step){  /* input elements */
                 @type@ sum = 0;
-                @type@ tmp = input[N-1]-input[N-2];
-                index_t k = i-N+1;
                 index_t j;
 
-                for(j = 0; j < k; ++j)  /* out of boundary (filter elements [0, k-1]) */
-                    sum += filter[j] * (input[N-1] + tmp * (k-j));
-                for(; j < F; ++j)  /* overlapped elements */
+                for(j = F - 1; i - j < N; --j)  /* overlapped elements */
                     sum += filter[j]*input[i-j];
+                for(index_t k = 1; j >= 0; --j, ++k)  /* out of boundary (filter elements [0, k-1]) */
+                    sum += filter[j]*(input[N-1] + gradient * k);
                 *(ptr_w++) = sum;
             }
             break;
+        }
 
         case MODE_PERIODIC:
             for(; i < N+F-1; i += step){  /* input elements */
                 @type@ sum = 0;
-                index_t k = i-N+1;
                 index_t j;
 
-                for(j = 0; j < k; ++j)  /* out of boundary (filter elements [0, k-1]) */
-                    sum += filter[j]*input[k-1-j];
-                for(; j < F; ++j)   /* overlapped elements */
+                for (j = F - 1; i - j < N; --j)
                     sum += filter[j]*input[i-j];
+                for (index_t k = 0; j >= 0; --j, ++k)
+                    sum += filter[j]*input[k];
                 *(ptr_w++) = sum;
             }
             break;
@@ -283,10 +283,9 @@ int @type@_downsampling_convolution(const @type@* input, const_index_t N,
         default:
             for(; i < N+F-1; i += step){
                 @type@ sum = 0;
-                index_t j;
 
-                for(j = i-(N-1); j < F; ++j)
-                    sum += input[i-j]*filter[j];
+                for(index_t j = F - 1; i - j < N; --j)
+                    sum += filter[j]*input[i-j];
                 *(ptr_w++) = sum;
             }
             break;

--- a/pywt/src/convolution.c.src
+++ b/pywt/src/convolution.c.src
@@ -379,7 +379,6 @@ int @type@_upsampling_convolution_valid_sf_periodization(const @type@* input,
     } else {
         /* Otherwise (N >= F_2) */
         @type@ *ptr_out = output;
-        @type@ *filter_even, *filter_odd;
         @type@ * periodization_buf = NULL;
         @type@ *periodization_buf_rear = NULL;
         @type@ *ptr_base;
@@ -388,10 +387,10 @@ int @type@_upsampling_convolution_valid_sf_periodization(const @type@* input,
         index_t F_2 = F/2;
 
         /* Allocate memory for even and odd elements of the filter */
-        filter_even = wtmalloc(F_2 * sizeof(@type@));
-        filter_odd = wtmalloc(F_2 * sizeof(@type@));
+        @type@ * filter_even = wtmalloc(F_2 * sizeof(@type@));
+        @type@ * filter_odd = wtmalloc(F_2 * sizeof(@type@));
 
-        if(filter_odd == NULL || filter_odd == NULL){
+        if(filter_odd == NULL || filter_even == NULL){
             if(filter_odd == NULL) wtfree(filter_odd);
             if(filter_even == NULL) wtfree(filter_even);
             return -1;

--- a/pywt/src/convolution.c.src
+++ b/pywt/src/convolution.c.src
@@ -7,9 +7,9 @@
  * #type = double, float#
  */
 
-int @type@_downsampling_convolution_periodization(const @type@ * const restrict input, const index_t N,
-                                                  const @type@ * const restrict filter, const index_t F,
-                                                  @type@ * const restrict output, const index_t step)
+int @type@_downsampling_convolution_periodization(const @type@ * const restrict input, const size_t N,
+                                                  const @type@ * const restrict filter, const size_t F,
+                                                  @type@ * const restrict output, const size_t step)
 {
     /*
     * Should it be an error to call this mode with signal lengths
@@ -24,18 +24,18 @@ int @type@_downsampling_convolution_periodization(const @type@ * const restrict 
     *   }
     */
 
-    index_t i = F/2, o = 0;
-    const index_t padding = N % 2; // Should be N%step for larger steps?
+    size_t i = F/2, o = 0;
+    const size_t padding = N % 2; // Should be N%step for larger steps?
 
     for (; i < F && i < N; i += step, ++o) {
         @type@ sum = 0;
-        index_t j;
+        size_t j;
         for (j = 0; j <= i; ++j)
             sum += filter[j] * input[i-j];
         while (j < F){
-            for (index_t k = 0; k < padding && j < F; ++k, ++j)
+            for (size_t k = 0; k < padding && j < F; ++k, ++j)
                 sum += filter[j] * input[N-1];
-            for (index_t k = 0; k < N && j < F; ++k, ++j)
+            for (size_t k = 0; k < N && j < F; ++k, ++j)
                 sum += filter[j] * input[N-1-k];
         }
         output[o] = sum;
@@ -44,27 +44,27 @@ int @type@_downsampling_convolution_periodization(const @type@ * const restrict 
     /* F - N-1 : filter in input range.  Most time is spent in this loop */
     for(; i < N; i+=step, ++o){    /* input elements, */
         @type@ sum = 0;
-        for(index_t j = 0; j < F; ++j)
+        for(size_t j = 0; j < F; ++j)
             sum += input[i-j]*filter[j];
         output[o] = sum;
     }
 
     for (; i < F && i < N + F/2; i += step, ++o) {
         @type@ sum = 0;
-        index_t j = 0;
+        size_t j = 0;
 
         while (i-j >= N){
-            for (index_t k = 0; k < padding && i-j >= N; ++k, ++j)
+            for (size_t k = 0; k < padding && i-j >= N; ++k, ++j)
                 sum += filter[i-N-j] * input[N-1];
-            for (index_t k = 0; k < N && i-j >= N; ++k, ++j)
+            for (size_t k = 0; k < N && i-j >= N; ++k, ++j)
                 sum += filter[i-N-j] * input[k];
         }
         for (; j <= i; ++j)
             sum += filter[j] * input[i-j];
         while (j < F){
-            for (index_t k = 0; k < padding && j < F; ++k, ++j)
+            for (size_t k = 0; k < padding && j < F; ++k, ++j)
                 sum += filter[j] * input[N-1];
-            for (index_t k = 0; k < N && j < F; ++k, ++j)
+            for (size_t k = 0; k < N && j < F; ++k, ++j)
                 sum += filter[j] * input[N-1-k];
         }
         output[o] = sum;
@@ -72,11 +72,11 @@ int @type@_downsampling_convolution_periodization(const @type@ * const restrict 
 
     for(; i < N + F/2; i += step, ++o){   /* input elements */
         @type@ sum = 0;
-        index_t j = 0;
+        size_t j = 0;
         while (i-j >= N){
-            for (index_t k = 0; k < padding && i-j >= N; ++k, ++j)
+            for (size_t k = 0; k < padding && i-j >= N; ++k, ++j)
                 sum += filter[i-N-j] * input[N-1];
-            for (index_t k = 0; k < N && i-j >= N; ++k, ++j)
+            for (size_t k = 0; k < N && i-j >= N; ++k, ++j)
                 sum += filter[i-N-j] * input[k];
         }
         for (; j < F; ++j)
@@ -87,10 +87,10 @@ int @type@_downsampling_convolution_periodization(const @type@ * const restrict 
 }
 
 
-int @type@_downsampling_convolution(const @type@ * const restrict input, const index_t N,
-                                    const @type@ * const restrict filter, const index_t F,
+int @type@_downsampling_convolution(const @type@ * const restrict input, const size_t N,
+                                    const @type@ * const restrict filter, const size_t F,
                                     @type@ * const restrict output,
-                                    const index_t step, MODE mode)
+                                    const size_t step, MODE mode)
 {
     /*
      * This convolution performs efficient downsampling by computing every
@@ -112,7 +112,7 @@ int @type@_downsampling_convolution(const @type@ * const restrict input, const i
      *    for time > n-1
      */
 
-    index_t i = step - 1, o = 0;
+    size_t i = step - 1, o = 0;
 
     if(mode == MODE_PERIODIZATION)
         return @type@_downsampling_convolution_periodization(input, N, filter, F, output, step);
@@ -124,16 +124,16 @@ int @type@_downsampling_convolution(const @type@ * const restrict input, const i
     /* 0 - F-1 : sliding in filter */
     for(; i < F && i < N; i+=step, ++o){
         @type@ sum = 0;
-        index_t j;
+        size_t j;
         for(j = 0; j <= i; ++j)
             sum += filter[j]*input[i-j];
 
         switch(mode) {
         case MODE_SYMMETRIC:
             while (j < F){
-                for(index_t k = 0; k < N && j < F; ++j, ++k)
+                for(size_t k = 0; k < N && j < F; ++j, ++k)
                     sum += filter[j]*input[k];
-                for(index_t k = 0; k < N && j < F; ++k, ++j)
+                for(size_t k = 0; k < N && j < F; ++k, ++j)
                     sum += filter[j] * input[N-1-k];
             }
             break;
@@ -142,12 +142,12 @@ int @type@_downsampling_convolution(const @type@ * const restrict input, const i
                 sum += filter[j]*input[0];
             break;
         case MODE_SMOOTH:
-            for(index_t k = 1; j < F; ++j, ++k)
+            for(size_t k = 1; j < F; ++j, ++k)
                 sum += filter[j]*(input[0] + k * (input[0] - input[1]));
             break;
         case MODE_PERIODIC:
             while (j < F)
-                for(index_t k = 0; k < N && j < F; ++k, ++j)
+                for(size_t k = 0; k < N && j < F; ++k, ++j)
                     sum += filter[j]*input[N-1-k];
             break;
         case MODE_ZEROPAD:
@@ -164,22 +164,23 @@ int @type@_downsampling_convolution(const @type@ * const restrict input, const i
     for(; i < N; i+=step, ++o){  /* input elements, */
         @type@ sum = 0;
 
-        for(index_t j = 0; j < F; ++j)
+        for(size_t j = 0; j < F; ++j)
             sum += input[i-j]*filter[j];
         output[o] = sum;
     }
 
     for(; i < F; i+=step, ++o){
         @type@ sum = 0;
-        index_t j = 0;
+        size_t j = 0;
+
         switch(mode) {
         case MODE_SYMMETRIC:
             /* TODO: add offset to j? Inherited, not sure what this means */
             // Process elements beyond end in reverse (i.e. away from data)
             while (i - j >= N){
-                for(index_t k = 0; k < N && i-j >= N; ++j, ++k)
+                for(size_t k = 0; k < N && i-j >= N; ++j, ++k)
                     sum += filter[i-N-j]*input[N-1-k];
-                for(index_t k = 0; k < N && i-j >= N; ++j, ++k)
+                for(size_t k = 0; k < N && i-j >= N; ++j, ++k)
                     sum += filter[i-N-j]*input[k];
             }
             break;
@@ -188,12 +189,12 @@ int @type@_downsampling_convolution(const @type@ * const restrict input, const i
                 sum += filter[j]*input[N-1];
             break;
         case MODE_SMOOTH:
-            for(index_t k = i - N + 1; i-j >= N; ++j, --k)
+            for(size_t k = i - N + 1; i-j >= N; ++j, --k)
                 sum += filter[j]*(input[N-1] + k * (input[N-1] - input[N-2]));
             break;
         case MODE_PERIODIC:
             while (i-j >= N)
-                for (index_t k = 0; k < N && i-j >= N; ++j, ++k)
+                for (size_t k = 0; k < N && i-j >= N; ++j, ++k)
                     sum += filter[i-N-j]*input[k];
             break;
         case MODE_ZEROPAD:
@@ -201,14 +202,16 @@ int @type@_downsampling_convolution(const @type@ * const restrict input, const i
             j = i - N + 1;
             break;
         }
+
         for(; j <= i; ++j)
             sum += filter[j]*input[i-j];
+
         switch(mode) {
         case MODE_SYMMETRIC:
             while (j < F){
-                for(index_t k = 0; k < N && j < F; ++j, ++k)
+                for(size_t k = 0; k < N && j < F; ++j, ++k)
                     sum += filter[j]*input[k];
-                for(index_t k = 0; k < N && j < F; ++k, ++j)
+                for(size_t k = 0; k < N && j < F; ++k, ++j)
                     sum += filter[j] * input[N-1-k];
             }
             break;
@@ -217,12 +220,12 @@ int @type@_downsampling_convolution(const @type@ * const restrict input, const i
                 sum += filter[j]*input[0];
             break;
         case MODE_SMOOTH:
-            for(index_t k = 1; j < F; ++j, ++k)
+            for(size_t k = 1; j < F; ++j, ++k)
                 sum += filter[j]*(input[0] + k * (input[0] - input[1]));
             break;
         case MODE_PERIODIC:
             while (j < F)
-                for(index_t k = 0; k < N && j < F; ++k, ++j)
+                for(size_t k = 0; k < N && j < F; ++k, ++j)
                     sum += filter[j]*input[N-1-k];
             break;
         case MODE_ZEROPAD:
@@ -235,15 +238,15 @@ int @type@_downsampling_convolution(const @type@ * const restrict input, const i
     /* N - N+F-1 : sliding out filter */
     for(; i < N+F-1; i += step, ++o){
         @type@ sum = 0;
-        index_t j = 0;
+        size_t j = 0;
         switch(mode) {
         case MODE_SYMMETRIC:
             /* TODO: add offset to j? Inherited, not sure what this means */
             // Process elements beyond end in reverse (i.e. away from data)
             while (i - j >= N){
-                for(index_t k = 0; k < N && i-j >= N; ++j, ++k)
+                for(size_t k = 0; k < N && i-j >= N; ++j, ++k)
                     sum += filter[i-N-j]*input[N-1-k];
-                for(index_t k = 0; k < N && i-j >= N; ++j, ++k)
+                for(size_t k = 0; k < N && i-j >= N; ++j, ++k)
                     sum += filter[i-N-j]*input[k];
             }
             break;
@@ -252,12 +255,12 @@ int @type@_downsampling_convolution(const @type@ * const restrict input, const i
                 sum += filter[j]*input[N-1];
             break;
         case MODE_SMOOTH:
-            for(index_t k = i - N + 1; i-j >= N; ++j, --k)
+            for(size_t k = i - N + 1; i-j >= N; ++j, --k)
                 sum += filter[j]*(input[N-1] + k * (input[N-1] - input[N-2]));
             break;
         case MODE_PERIODIC:
             while (i-j >= N)
-                for (index_t k = 0; k < N && i-j >= N; ++j, ++k)
+                for (size_t k = 0; k < N && i-j >= N; ++j, ++k)
                     sum += filter[i-N-j]*input[k];
             break;
         case MODE_ZEROPAD:
@@ -277,32 +280,32 @@ int @type@_downsampling_convolution(const @type@ * const restrict input, const i
  * performs "normal" convolution of "upsampled" input coeffs array with filter
  */
 
-int @type@_upsampling_convolution_full(const @type@ * const restrict input, const index_t N,
-                                       const @type@ * const restrict filter, const index_t F,
-                                       @type@ * const restrict output, const index_t O)
+int @type@_upsampling_convolution_full(const @type@ * const restrict input, const size_t N,
+                                       const @type@ * const restrict filter, const size_t F,
+                                       @type@ * const restrict output, const size_t O)
 {
     if(F<2)
         return -1;
 
-    index_t i = 0, o = 0;
+    size_t i = 0, o = 0;
 
     // Sliding filter in
     for(; i < N && i < F/2; ++i, o += 2)
-        for(index_t j = 0; j <= i; ++j){
+        for(size_t j = 0; j <= i; ++j){
             output[o] += filter[j*2] * input[i-j];
             output[o+1] += filter[j*2+1] * input[i-j];
         }
 
     // Equivalent to upsampling_convolution_valid_sf
     for(; i < N; ++i, o += 2)
-        for(index_t j = 0; j < F/2; ++j){
+        for(size_t j = 0; j < F/2; ++j){
             output[o] += filter[j*2] * input[i-j];
             output[o+1] += filter[j*2+1] * input[i-j];
         }
 
     // Sliding filter out
     for(; i < N+F/2; ++i, o += 2)
-        for(index_t j = i-(N-1); j < F/2; ++j){
+        for(size_t j = i-(N-1); j < F/2; ++j){
             output[o] += filter[j*2] * input[i-j];
             output[o+1] += filter[j*2+1] * input[i-j];
         }
@@ -319,9 +322,9 @@ int @type@_upsampling_convolution_full(const @type@ * const restrict input, cons
  * The input data has to be periodically extended for this mode.
  */
 
-int @type@_upsampling_convolution_valid_sf_periodization(const @type@ * const restrict input, const index_t N,
-                                                         const @type@ * const restrict filter, const index_t F,
-                                                         @type@ * const restrict output, const index_t O)
+int @type@_upsampling_convolution_valid_sf_periodization(const @type@ * const restrict input, const size_t N,
+                                                         const @type@ * const restrict filter, const size_t F,
+                                                         @type@ * const restrict output, const size_t O)
 {
     if(F%2) return -3; /* Filter must have even-length. */
 
@@ -330,18 +333,18 @@ int @type@_upsampling_convolution_valid_sf_periodization(const @type@ * const re
      * the filter's length. The coeff array has to be extended periodically.
      * This can be only valid for PERIODIZATION_MODE
      */
-    index_t const start = F/4;
-    index_t i = start;
-    index_t const end = N + start - (((F/2)%2) ? 0 : 1);
-    index_t o = 0;
+    size_t const start = F/4;
+    size_t i = start;
+    size_t const end = N + start - (((F/2)%2) ? 0 : 1);
+    size_t o = 0;
 
     if ((F/2)%2 == 0){
         // Shift everything one element right
 
         // i = N-1; even element goes to output[O-1], odd element goes to output[o]
-        index_t j = 0;
-        while(start-1-j >= 0){
-            for (index_t k = 0; k < N && start-1-j >= 0; ++k, ++j){
+        size_t j = 0;
+        while(j <= start-1){
+            for (size_t k = 0; k < N && j <= start-1; ++k, ++j){
                 output[2*N-1] += filter[2*(start-1-j)] * input[k];
                 output[0] += filter[2*(start-1-j)+1] * input[k];
             }
@@ -351,7 +354,7 @@ int @type@_upsampling_convolution_valid_sf_periodization(const @type@ * const re
             output[0] += filter[2*j+1] * input[N+start-1-j];
         }
         while (j < F / 2){
-            for (index_t k = 0; k < N && j < F/2; ++k, ++j){
+            for (size_t k = 0; k < N && j < F/2; ++k, ++j){
                 output[2*N-1] += filter[2*j] * input[N-1-k];
                 output[0] += filter[2*j+1] * input[N-1-k];
             }
@@ -361,13 +364,13 @@ int @type@_upsampling_convolution_valid_sf_periodization(const @type@ * const re
     }
 
     for (; i < F/2 && i < N; ++i, o += 2){
-        index_t j = 0;
+        size_t j = 0;
         for(; j <= i; ++j){
             output[o] += filter[2*j] * input[i-j];
             output[o+1] += filter[2*j+1] * input[i-j];
         }
         while (j < F/2){
-            for(index_t k = 0; k < N && j < F/2; ++k, ++j){
+            for(size_t k = 0; k < N && j < F/2; ++k, ++j){
                 output[o] += filter[2*j] * input[N-1-k];
                 output[o+1] += filter[2*j+1] * input[N-1-k];
             }
@@ -375,16 +378,16 @@ int @type@_upsampling_convolution_valid_sf_periodization(const @type@ * const re
     }
 
     for (; i < N; ++i, o += 2){
-        for(index_t j = 0; j < F/2; ++j){
+        for(size_t j = 0; j < F/2; ++j){
             output[o] += filter[2*j] * input[i-j];
             output[o+1] += filter[2*j+1] * input[i-j];
         }
     }
 
     for (; i < F/2 && i < end; ++i, o += 2){
-        index_t j = 0;
+        size_t j = 0;
         while(i-j >= N){
-            for (index_t k = 0; k < N && i-j >= N; ++k, ++j){
+            for (size_t k = 0; k < N && i-j >= N; ++k, ++j){
                 output[o] += filter[2*(i-N-j)] * input[k];
                 output[o+1] += filter[2*(i-N-j)+1] * input[k];
             }
@@ -394,7 +397,7 @@ int @type@_upsampling_convolution_valid_sf_periodization(const @type@ * const re
             output[o+1] += filter[2*j+1] * input[i-j];
         }
         while (j < F / 2){
-            for (index_t k = 0; k < N && j < F/2; ++k, ++j){
+            for (size_t k = 0; k < N && j < F/2; ++k, ++j){
                 output[o] += filter[2*j] * input[N-1-k];
                 output[o+1] += filter[2*j+1] * input[N-1-k];
             }
@@ -402,9 +405,9 @@ int @type@_upsampling_convolution_valid_sf_periodization(const @type@ * const re
     }
 
     for (; i < end; ++i, o += 2){
-        index_t j = 0;
+        size_t j = 0;
         while(i-j >= N){
-            for (index_t k = 0; k < N && i-j >= N; ++k, ++j){
+            for (size_t k = 0; k < N && i-j >= N; ++k, ++j){
                 output[o] += filter[2*(i-N-j)] * input[k];
                 output[o+1] += filter[2*(i-N-j)+1] * input[k];
             }
@@ -427,9 +430,9 @@ int @type@_upsampling_convolution_valid_sf_periodization(const @type@ * const re
  * case to separate function this looks much clearer now.
  */
 
-int @type@_upsampling_convolution_valid_sf(const @type@ * const restrict input, const index_t N,
-                                           const @type@ * const restrict filter, const index_t F,
-                                           @type@ * const restrict output, const index_t O,
+int @type@_upsampling_convolution_valid_sf(const @type@ * const restrict input, const size_t N,
+                                           const @type@ * const restrict filter, const size_t F,
+                                           @type@ * const restrict output, const size_t O,
                                            MODE mode)
 {
     if(mode == MODE_PERIODIZATION) /* Special case */
@@ -445,11 +448,11 @@ int @type@_upsampling_convolution_valid_sf(const @type@ * const restrict input, 
      *
      * This part is simple, no extra hacks, just two convolutions in one loop
      */
-    for(index_t o = 0, i = F/2 - 1; i < N; ++i, o += 2){
+    for(size_t o = 0, i = F/2 - 1; i < N; ++i, o += 2){
         @type@ sum_even = 0;
         @type@ sum_odd = 0;
 
-        for(index_t j = 0; j < F/2; ++j){
+        for(size_t j = 0; j < F/2; ++j){
             sum_even += filter[j*2] * input[i-j];
             sum_odd += filter[j*2+1] * input[i-j];
         }
@@ -460,10 +463,10 @@ int @type@_upsampling_convolution_valid_sf(const @type@ * const restrict input, 
 }
 
 /* -> swt - todo */
-int @type@_upsampled_filter_convolution(const @type@* input,
-                                        const index_t N, const @type@*
-                                        filter, const index_t F, @type@*
-                                        output, const index_t step, MODE mode)
+int @type@_upsampled_filter_convolution(const @type@* input, const size_t N,
+                                        const @type@* filter, const size_t F,
+                                        @type@* output,
+                                        const size_t step, MODE mode)
 {
     return -1;
 }

--- a/pywt/src/convolution.c.src
+++ b/pywt/src/convolution.c.src
@@ -568,43 +568,34 @@ int @type@_upsampling_convolution_valid_sf_periodization(const @type@* input,
  * case to separate function this looks much clearer now.
  */
 
-int @type@_upsampling_convolution_valid_sf(const @type@* input,
-                                           const index_t N, const @type@*
-                                           filter, const index_t F, @type@*
-                                           output, const index_t O, MODE
-                                           mode)
+int @type@_upsampling_convolution_valid_sf(const @type@* input, const index_t N,
+                                           const @type@* filter, const index_t F,
+                                           @type@* output, const index_t O,
+                                           MODE mode)
 {
-
-    @type@ *ptr_out = output;
-    @type@ *filter_even, *filter_odd;
-    @type@ *ptr_base;
-    @type@ sum_even, sum_odd;
-
-    index_t i, j;
-    index_t F_2 = F/2;
-
     if(mode == MODE_PERIODIZATION) /* Special case */
         return @type@_upsampling_convolution_valid_sf_periodization(input, N,
-                                                                     filter, F,
-                                                                     output, O);
+                                                                    filter, F,
+                                                                    output, O);
 
-    if((F%2) || (N < F_2)) /* Filter must have even length. */
+    if((F%2) || (N < F/2)) /* Filter must have even length. */
         return -1;
 
     /* Allocate memory for even and odd elements of the filter */
-    filter_even = wtmalloc(F_2 * sizeof(@type@));
-    filter_odd = wtmalloc(F_2 * sizeof(@type@));
+    @type@ * filter_even = wtmalloc(F/2 * sizeof(@type@));
+    @type@ * filter_odd = wtmalloc(F/2 * sizeof(@type@));
 
     if(filter_odd == NULL || filter_odd == NULL){
-        if(filter_odd == NULL) wtfree(filter_odd);
-        if(filter_even == NULL) wtfree(filter_even);
+        // NULL pointers may be safely free'd (no-op)
+        wtfree(filter_odd);
+        wtfree(filter_even);
         return -1;
     }
 
     /* split filter to even and odd values */
-    for(i = 0; i < F_2; ++i){
-        filter_even[i] = filter[i << 1];
-        filter_odd[i] = filter[(i << 1) + 1];
+    for(index_t i = 0; i < F/2; ++i){
+        filter_even[i] = filter[i * 2];
+        filter_odd[i] = filter[i * 2 + 1];
     }
 
     /*
@@ -614,20 +605,17 @@ int @type@_upsampling_convolution_valid_sf(const @type@* input,
      * This part is simple, no extra hacks, just two convolutions in one loop
      */
 
-    ptr_base = (@type@*)input + F_2 - 1;
-    i = 0;
+    for(index_t o = 0, i = F/2 - 1; i < N; ++i, o += 2){
+        @type@ sum_even = filter_even[0] * input[i];
+        @type@ sum_odd  = filter_odd[0] * input[i];
 
-    for(; i < N-(F_2-1); ++i){    /* sliding over signal from left to right */
-        sum_even = filter_even[0] * ptr_base[i];
-        sum_odd  = filter_odd[0] * ptr_base[i];
-
-        for(j = 1; j < F_2; ++j){
-            sum_even += filter_even[j] * ptr_base[i-j];
-            sum_odd += filter_odd[j] * ptr_base[i-j];
+        for(index_t j = 1; j < F/2; ++j){
+            sum_even += filter_even[j] * input[i-j];
+            sum_odd += filter_odd[j] * input[i-j];
         }
 
-        *(ptr_out++) += sum_even;
-        *(ptr_out++) += sum_odd;
+        output[o] += sum_even;
+        output[o+1] += sum_odd;
     }
 
     wtfree(filter_even);

--- a/pywt/src/convolution.c.src
+++ b/pywt/src/convolution.c.src
@@ -27,15 +27,14 @@ int @type@_downsampling_convolution_periodization(const @type@* input, const ind
 
     index_t i;
     @type@* ptr_w = output;
+    const index_t padding = N % 2; // Should be N%step for larger steps?
 
     for (i=F/2; i < F; i += step) {
         @type@ sum = 0;
         index_t j;
         for (j = 0; j <= i; ++j)
             sum += filter[j] * input[i-j];
-        // Pad out signals with non-divisible length using last element
-        // FIXME: Should N%2 be N%step for larger steps?
-        for (index_t k = 0; k < (N % 2) && j < F; ++k, ++j)
+        for (index_t k = 0; k < padding && j < F; ++k, ++j)
             sum += filter[j] * input[N-1];
         for (index_t k = N-1; j < F; --k, ++j)
             sum += filter[j] * input[k];
@@ -53,11 +52,9 @@ int @type@_downsampling_convolution_periodization(const @type@* input, const ind
     for(i = i - N; i < F/2; i += step){   /* input elements */
         @type@ sum = 0;
         index_t j;
-        for (j = 0; j <= i - (N % 2); ++j)
-          sum += filter[j] * input[i - j - (N % 2)];
-        // Pad out with last element
-        // FIXME: N%2 or N%step
-        for(index_t k = 0; k < (N % 2) && j < F; ++k, ++j)
+        for (j = 0; j <= i - padding; ++j)
+            sum += filter[j] * input[i - j - padding];
+        for(index_t k = 0; k < padding && j < F; ++k, ++j)
             sum += filter[j] * input[N-1];
         for(index_t k = N-1; j < F; --k, ++j)   /* overlapped elements */
             sum += filter[j]*input[k];

--- a/pywt/src/convolution.c.src
+++ b/pywt/src/convolution.c.src
@@ -7,6 +7,12 @@
  * #type = double, float#
  */
 
+#if defined _MSC_VER
+#define restrict __restrict
+#elif defined __GNUC__
+#define restrict __restrict__
+#endif
+
 /* This file contains several functions for computing the convolution of a
  * signal with a filter. The general scheme is:
  *   output[o] = sum(filter[j] * input[i-j] for j = [0..F) and i = [0..N))
@@ -491,3 +497,5 @@ int @type@_upsampled_filter_convolution(const @type@* input, const size_t N,
 }
 
 /**end repeat**/
+
+#undef restrict

--- a/pywt/src/convolution.c.src
+++ b/pywt/src/convolution.c.src
@@ -114,9 +114,11 @@ int @type@_downsampling_convolution(const @type@ * const restrict input, const i
 
     index_t i = step - 1, o = 0;
 
-    if(mode == MODE_PERIODIZATION){
+    if(mode == MODE_PERIODIZATION)
         return @type@_downsampling_convolution_periodization(input, N, filter, F, output, step);
-    }
+
+    if (mode == MODE_SMOOTH && N < 2)
+        mode = MODE_CONSTANT_EDGE;
 
     /* Other signal extension modes */
     /* 0 - F-1 : sliding in filter */

--- a/pywt/src/convolution.c.src
+++ b/pywt/src/convolution.c.src
@@ -12,57 +12,55 @@ int @type@_downsampling_convolution_periodization(const @type@* input, const_ind
                              @type@* output, const_index_t step)
 
 {
+    /*
+    * Should it be an error to call this mode with signal lengths
+    * not divisible by the step? Not really periodic if padded.
+    *
+    * If it is exactly divisible, can it be replaced by one loop?
+    *   for (i=0; i < N; i += step){
+    *     @type@ sum = 0;
+    *     for (j=0; j < F; j++){
+    *       sum += filter[j] * input[(i-j+N) % N];
+    *     *(ptr_w++) = sum;
+    *   }
+    */
 
-    index_t i, j, k;
-    index_t start;
-    @type@ sum;
+    index_t i;
     @type@* ptr_w = output;
 
-    start = F/2;  /* extending by (F-2)/2 elements */
-
-    for(i=start; i < F; i+=step){
-        sum = 0;
-        for(j = 0; j < i+1; ++j)    /* overlapping */
-            sum += filter[j]*input[i-j];
-
-        if(N%2){
-            if(F-j){ /* if something to extend */
-                sum += filter[j] * input[N-1];
-                if(F-j){
-                    for(k = 2; k <= F-j; ++k)
-                        sum += filter[j-1+k] * input[N-k+1];
-                }
-            }
-        } else { /* extra element from input   -> i0 i1 i2 [i2] */
-            for(k = 1; k <= F-j; ++k)
-                sum += filter[j-1+k] * input[N-k];
-        }
+    for (i=F/2; i < F; i += step) {
+        @type@ sum = 0;
+        index_t j;
+        for (j = 0; j <= i; ++j)
+            sum += filter[j] * input[i-j];
+        // Pad out signals with non-divisible length using last element
+        // FIXME: Should N%2 be N%step for larger steps?
+        for (index_t k = 0; k < (N % 2) && j < F; ++k, ++j)
+            sum += filter[j] * input[N-1];
+        for (index_t k = N-1; j < F; --k, ++j)
+            sum += filter[j] * input[k];
         *(ptr_w++) = sum;
     }
 
     /* F - N-1 : filter in input range.  Most time is spent in this loop */
     for(; i < N; i+=step){    /* input elements, */
-        sum = 0;
-        for(j = 0; j < F; ++j)
+        @type@ sum = 0;
+        for(index_t j = 0; j < F; ++j)
             sum += input[i-j]*filter[j];
         *(ptr_w++) = sum;
     }
 
-    for(; i < N-step + (F/2)+1 + N%2; i += step){   /* input elements */
-        sum = 0;
-        k = i-N+1;
-        for(j = k; j < F; ++j)   /* overlapped elements */
-            sum += filter[j]*input[i-j];
-
-        if(N%2 == 0){
-            for(j = 0; j < k; ++j){  /* out of boundary (filter elements [0, k-1]) */
-                sum += filter[j]*input[k-1-j];
-            }
-        } else {  /* repeating extra element -> i0 i1 i2 [i2] */
-            for(j = 0; j < k-1; ++j)  /* out of boundary (filter elements [0, k-1]) */
-                sum += filter[j]*input[k-2-j];
-            sum += filter[k-1] * input[N-1];
-        }
+    for(i = i - N; i < F/2; i += step){   /* input elements */
+        @type@ sum = 0;
+        index_t j;
+        for (j = 0; j <= i - (N % 2); ++j)
+          sum += filter[j] * input[i - j - (N % 2)];
+        // Pad out with last element
+        // FIXME: N%2 or N%step
+        for(index_t k = 0; k < (N % 2) && j < F; ++k, ++j)
+            sum += filter[j] * input[N-1];
+        for(index_t k = N-1; j < F; --k, ++j)   /* overlapped elements */
+            sum += filter[j]*input[k];
         *(ptr_w++) = sum;
     }
     return 0;

--- a/pywt/src/convolution.c.src
+++ b/pywt/src/convolution.c.src
@@ -107,19 +107,16 @@ int @type@_downsampling_convolution(const @type@* input, const index_t N,
 
     /* Other signal extension modes */
     /* 0 - F-1 : sliding in filter */
-    switch(mode)
-    {
-        case MODE_SYMMETRIC:
-            for(i=start; i < F; i+=step){
-                @type@ sum = 0;
-                index_t j;
+    for(i=start; i < F; i+=step){
+        @type@ sum = 0;
+        index_t j;
+        for(j = 0; j <= i; ++j)
+            sum += filter[j]*input[i-j];
 
-                for(j = 0; j <= i; ++j)
-                    sum += filter[j]*input[i-j];
-                for(index_t k = 0; j < F; ++j, ++k)
-                    sum += filter[j]*input[k];
-                *(ptr_w++) = sum;
-            }
+        switch(mode) {
+        case MODE_SYMMETRIC:
+            for(index_t k = 0; j < F; ++j, ++k)
+                sum += filter[j]*input[k];
             break;
 
         case MODE_ASYMMETRIC:
@@ -130,70 +127,30 @@ int @type@_downsampling_convolution(const @type@* input, const index_t N,
              *
              * ... (0 - 2) (0 - 1) (0 - 0) | 0 1 2 ...
              */
-            for(i=start; i < F; i+=step){
-                @type@ sum = 0;
-                index_t j;
-
-                for(j = 0; j <= i; ++j)
-                    sum += filter[j]*input[i-j];
-                for(index_t k = 0; j < F; ++j, ++k)
-                    sum += filter[j]*(input[0] - input[k]);
-                *(ptr_w++) = sum;
-            }
+            for(index_t k = 0; j < F; ++j, ++k)
+                sum += filter[j]*(input[0] - input[k]);
             break;
 
         case MODE_CONSTANT_EDGE:
-            for(i=start; i < F; i+=step){
-                @type@ sum = 0;
-                index_t j;
-
-                for(j = 0; j <= i; ++j)
-                    sum += filter[j]*input[i-j];
-                for(; j < F; ++j)
-                    sum += filter[j]*input[0];
-                *(ptr_w++) = sum;
-            }
+            for(; j < F; ++j)
+                sum += filter[j]*input[0];
             break;
 
-        case MODE_SMOOTH:{
-            @type@ gradient = input[0]-input[1];
-            for(i=start; i < F; i+=step){
-                @type@ sum = 0;
-                index_t j;
-
-                for(j = 0; j <= i; ++j)
-                    sum += filter[j]*input[i-j];
-                for(index_t k = 1; j < F; ++j, ++k)
-                    sum += filter[j]*(input[0] + gradient * k);
-                *(ptr_w++) = sum;
-            }
+        case MODE_SMOOTH:
+            for(index_t k = 1; j < F; ++j, ++k)
+                sum += filter[j]*(input[0] + k * (input[0] - input[1]));
             break;
-        }
 
         case MODE_PERIODIC:
-            for(i=start; i < F; i+=step){
-                @type@ sum = 0;
-                index_t j;
-
-                for(j = 0; j <= i; ++j)
-                    sum += filter[j]*input[i-j];
-                for(index_t k = N-1; j < F; ++j, --k)
-                    sum += filter[j]*input[k];
-                *(ptr_w++) = sum;
-            }
+            for(index_t k = N-1; j < F; ++j, --k)
+                sum += filter[j]*input[k];
             break;
 
         case MODE_ZEROPAD:
         default:
-            for(i=start; i < F; i+=step){
-                @type@ sum = 0;
-                index_t j;
-
-                for(j = 0; j <= i; ++j)
-                    sum += filter[j]*input[i-j];
-                *(ptr_w++) = sum;
-            }
             break;
+        }
+        *(ptr_w++) = sum;
     }
 
     /*
@@ -209,86 +166,38 @@ int @type@_downsampling_convolution(const @type@* input, const index_t N,
     }
 
     /* N - N+F-1 : sliding out filter */
-    switch(mode)
-    {
+    for(; i < N+F-1; i += step){  /* input elements */
+        @type@ sum = 0;
+        index_t j;
+        for(j = F - 1; i-j < N; --j)
+            sum += filter[j]*input[i-j];
+        switch(mode) {
         case MODE_SYMMETRIC:
-            for(; i < N+F-1; i += step){  /* input elements */
-                @type@ sum = 0;
-                index_t j;
-
-                /* TODO: add offset to j? Inherited, not sure what this means */
-                for(j = F - 1; i-j < N; --j)
-                    sum += filter[j]*input[i-j];
-                for(index_t k = N-1; j >= 0; --j, --k)
-                    sum += filter[j]*input[k];
-                *(ptr_w++) = sum;
-            }
+            /* TODO: add offset to j? Inherited, not sure what this means */
+            for(index_t k = N-1; j >= 0; --j, --k)
+                sum += filter[j]*input[k];
             break;
-
         case MODE_ASYMMETRIC:
-            for(; i < N+F-1; i += step){  /* input elements */
-                @type@ sum = 0;
-                index_t j;
-
-                for(j = F - 1; i-j < N; --j)
-                    sum += filter[j]*input[i-j];
-                for(index_t k = N-1; j >= 0; --j, --k)
-                    sum += filter[j]*(input[N-1] - input[k]);
-                *(ptr_w++) = sum;
-            }
+            for(index_t k = N-1; j >= 0; --j, --k)
+                sum += filter[j]*(input[N-1] - input[k]);
             break;
-
         case MODE_CONSTANT_EDGE:
-            for(; i < N+F-1; i += step){  /* input elements */
-                @type@ sum = 0;
-                index_t j;
-
-                for(j = F - 1; i-j < N; --j)  /* out of boundary (filter elements [0, k-1]) */
-                    sum += filter[j]*input[i-j];
-                for(; j >= 0; --j)   /* overlapped elements */
-                    sum += filter[j]*input[N-1]; /* input[N-1] = const */
-                *(ptr_w++) = sum;
-            }
+            for(; j >= 0; --j)   /* overlapped elements */
+                sum += filter[j]*input[N-1]; /* input[N-1] = const */
             break;
-
-        case MODE_SMOOTH:{
-            @type@ gradient = input[N-1]-input[N-2];
-            for(; i < N+F-1; i += step){  /* input elements */
-                @type@ sum = 0;
-                index_t j;
-
-                for(j = F - 1; i - j < N; --j)  /* overlapped elements */
-                    sum += filter[j]*input[i-j];
-                for(index_t k = 1; j >= 0; --j, ++k)  /* out of boundary (filter elements [0, k-1]) */
-                    sum += filter[j]*(input[N-1] + gradient * k);
-                *(ptr_w++) = sum;
-            }
+        case MODE_SMOOTH:
+            for(index_t k = 1; j >= 0; --j, ++k)  /* out of boundary (filter elements [0, k-1]) */
+                sum += filter[j]*(input[N-1] + k * (input[N-1] - input[N-2]));
             break;
-        }
-
         case MODE_PERIODIC:
-            for(; i < N+F-1; i += step){  /* input elements */
-                @type@ sum = 0;
-                index_t j;
-
-                for (j = F - 1; i - j < N; --j)
-                    sum += filter[j]*input[i-j];
-                for (index_t k = 0; j >= 0; --j, ++k)
-                    sum += filter[j]*input[k];
-                *(ptr_w++) = sum;
-            }
+            for (index_t k = 0; j >= 0; --j, ++k)
+                sum += filter[j]*input[k];
             break;
-
         case MODE_ZEROPAD:
         default:
-            for(; i < N+F-1; i += step){
-                @type@ sum = 0;
-
-                for(index_t j = F - 1; i - j < N; --j)
-                    sum += filter[j]*input[i-j];
-                *(ptr_w++) = sum;
-            }
             break;
+        }
+        *(ptr_w++) = sum;
     }
     return 0;
 }

--- a/pywt/src/convolution.c.src
+++ b/pywt/src/convolution.c.src
@@ -13,25 +13,23 @@ int @type@_downsampling_convolution_periodization(const @type@* input, const_ind
 
 {
 
-    index_t i, j, k, F_2, corr;
+    index_t i, j, k;
     index_t start;
     @type@ sum;
     @type@* ptr_w = output;
 
-    i = step-1;  /* first element taken from input is input[step-1] */
-    start = F_2 = F/2;  /* extending by (F-2)/2 elements */
-    corr = 0;
+    start = F/2;  /* extending by (F-2)/2 elements */
 
     for(i=start; i < F; i+=step){
         sum = 0;
-        for(j = 0; j < i+1-corr; ++j)    /* overlapping */
-            sum += filter[j]*input[i-j-corr];
+        for(j = 0; j < i+1; ++j)    /* overlapping */
+            sum += filter[j]*input[i-j];
 
         if(N%2){
             if(F-j){ /* if something to extend */
                 sum += filter[j] * input[N-1];
                 if(F-j){
-                    for(k = 2-corr; k <= F-j; ++k)
+                    for(k = 2; k <= F-j; ++k)
                         sum += filter[j-1+k] * input[N-k+1];
                 }
             }
@@ -197,7 +195,7 @@ int @type@_downsampling_convolution(const @type@* input, const_index_t N,
             }
 
             /*
-             * F - N-1 : filter in input range - simple convolution 
+             * F - N-1 : filter in input range - simple convolution
              * Most time is spent in this loop.
              */
             #ifdef OPT_UNROLL4
@@ -485,7 +483,8 @@ int @type@_allocating_downsampling_convolution(const @type@* input, const_index_
 
 int @type@_upsampling_convolution_full(const @type@* input, const_index_t N,
                                 const @type@* filter, const_index_t F,
-                                @type@* output, const_index_t O){
+                                @type@* output, const_index_t O)
+{
     register index_t i;
     register index_t j;
     @type@ *ptr_out;
@@ -644,9 +643,9 @@ int @type@_upsampling_convolution_valid_sf_periodization(const @type@* input,
 
         /* Check if extending is really needed */
         /* split filter len correct + extra samples*/
-        N_p = F_2-1 + (index_t) ceil(k/2.); 
+        N_p = F_2-1 + (index_t) ceil(k/2.);
 
-        /* 
+        /*
          * ok, if is then do:
          * 1. Allocate buffers for front and rear parts of extended input
          * 2. Copy periodically appropriate elements from input to the buffers
@@ -656,7 +655,7 @@ int @type@_upsampling_convolution_valid_sf_periodization(const @type@* input,
          */
 
         if(N_p > 0){
-            /* 
+            /*
              * Allocate memory only for the front and rear extension parts, not
              * the whole input
              */
@@ -680,7 +679,7 @@ int @type@_upsampling_convolution_valid_sf_periodization(const @type@* input,
                 periodization_buf[(N_p - k) - i] = input[N - (i%N)];
 
             /* copy from end of input to beginning of buffer */
-            memcpy(periodization_buf_rear, input + N - k, k * sizeof(@type@));  
+            memcpy(periodization_buf_rear, input + N - k, k * sizeof(@type@));
             for(i = 0; i < (N_p - k); ++i)
                 periodization_buf_rear[k + i] = input[i%N];
 
@@ -785,7 +784,8 @@ int @type@_upsampling_convolution_valid_sf(const @type@* input,
                                            const_index_t N, const @type@*
                                            filter, const_index_t F, @type@*
                                            output, const_index_t O, MODE
-                                           mode){
+                                           mode)
+{
 
     @type@ *ptr_out = output;
     @type@ *filter_even, *filter_odd;

--- a/pywt/src/convolution.c.src
+++ b/pywt/src/convolution.c.src
@@ -284,25 +284,28 @@ int @type@_upsampling_convolution_full(const @type@ * const restrict input, cons
     if(F<2)
         return -1;
 
-    for(index_t i = 0, o = 0; i < N + F/2; ++i, o += 2){
-        @type@ sum_even = 0;
-        @type@ sum_odd = 0;
+    index_t i = 0, o = 0;
 
-        /*
-         * sliding in filter from the right (end of input)
-         * i0 0  i1 0  i2 0
-         *                f1 -> o1
-         *             f1 f2 -> o2
-         *          f1 f2 f3 -> o3
-         */
-        for(index_t j = (i >= N) ? i-(N-1) : 0; j < F/2 && j <= i; ++j){
-            sum_even += filter[j*2] * input[i-j];
-            sum_odd += filter[j*2+1] * input[i-j];
+    // Sliding filter in
+    for(; i < N && i < F/2; ++i, o += 2)
+        for(index_t j = 0; j <= i; ++j){
+            output[o] += filter[j*2] * input[i-j];
+            output[o+1] += filter[j*2+1] * input[i-j];
         }
 
-        output[o] += sum_even;
-        output[o+1] += sum_odd;
-    }
+    // Equivalent to upsampling_convolution_valid_sf
+    for(; i < N; ++i, o += 2)
+        for(index_t j = 0; j < F/2; ++j){
+            output[o] += filter[j*2] * input[i-j];
+            output[o+1] += filter[j*2+1] * input[i-j];
+        }
+
+    // Sliding filter out
+    for(; i < N+F/2; ++i, o += 2)
+        for(index_t j = i-(N-1); j < F/2; ++j){
+            output[o] += filter[j*2] * input[i-j];
+            output[o+1] += filter[j*2+1] * input[i-j];
+        }
     return 0;
 }
 

--- a/pywt/src/convolution.c.src
+++ b/pywt/src/convolution.c.src
@@ -581,45 +581,23 @@ int @type@_upsampling_convolution_valid_sf(const @type@ * const restrict input, 
     if((F%2) || (N < F/2)) /* Filter must have even length. */
         return -1;
 
-    /* Allocate memory for even and odd elements of the filter */
-    @type@ * filter_even = wtmalloc(F/2 * sizeof(@type@));
-    @type@ * filter_odd = wtmalloc(F/2 * sizeof(@type@));
-
-    if(filter_odd == NULL || filter_odd == NULL){
-        // NULL pointers may be safely free'd (no-op)
-        wtfree(filter_odd);
-        wtfree(filter_even);
-        return -1;
-    }
-
-    /* split filter to even and odd values */
-    for(index_t i = 0; i < F/2; ++i){
-        filter_even[i] = filter[i * 2];
-        filter_odd[i] = filter[i * 2 + 1];
-    }
-
-    /*
-     * Perform _valid_ convolution (only when all filter_even and filter_odd elements
+    /* Perform _valid_ convolution (only when all filter_even and filter_odd elements
      * are in range of input data).
      *
      * This part is simple, no extra hacks, just two convolutions in one loop
      */
 
     for(index_t o = 0, i = F/2 - 1; i < N; ++i, o += 2){
-        @type@ sum_even = filter_even[0] * input[i];
-        @type@ sum_odd  = filter_odd[0] * input[i];
+        @type@ sum_even = 0;
+        @type@ sum_odd = 0;
 
-        for(index_t j = 1; j < F/2; ++j){
-            sum_even += filter_even[j] * input[i-j];
-            sum_odd += filter_odd[j] * input[i-j];
+        for(index_t j = 0; j < F/2; ++j){
+            sum_even += filter[j*2] * input[i-j];
+            sum_odd += filter[j*2+1] * input[i-j];
         }
-
         output[o] += sum_even;
         output[o+1] += sum_odd;
     }
-
-    wtfree(filter_even);
-    wtfree(filter_odd);
     return 0;
 }
 

--- a/pywt/src/convolution.c.src
+++ b/pywt/src/convolution.c.src
@@ -108,7 +108,9 @@ int @type@_downsampling_convolution(const @type@* input, const index_t N,
      * 1. Handle extended on the left, convolve filter with samples computed for
      *    time < 0
      * 2. Do the normal decimated convolution of filter with signal samples
-     * 3. Handle extended on the right, convolve filter with samples computed
+     * 3. Handle case where filter extends beyond signal to both the left and
+     *    right (only applies if F > N)
+     * 4. Handle extended on the right, convolve filter with samples computed
      *    for time > n-1
      */
 

--- a/pywt/src/convolution.c.src
+++ b/pywt/src/convolution.c.src
@@ -332,7 +332,7 @@ int @type@_upsampling_convolution_valid_sf_periodization(const @type@* input, co
      */
     index_t const start = F/4;
     index_t i = start;
-    index_t const end = ((F/2)%2) ? N + F/4 : N + F/4 - 1;
+    index_t const end = N + start - (((F/2)%2) ? 0 : 1);
     index_t o = 0;
 
     if ((F/2)%2 == 0){
@@ -340,10 +340,10 @@ int @type@_upsampling_convolution_valid_sf_periodization(const @type@* input, co
 
         // i = N-1; even element goes to output[O-1], odd element goes to output[o]
         index_t j = 0;
-        while(N+start-1-j >= N){
-            for (index_t k = 0; k < N && N+start-1-j >= N; ++k, ++j){
-                output[2*N-1] += filter[2*(N+start-1-N-j)] * input[k];
-                output[0] += filter[2*(N+start-1-N-j)+1] * input[k];
+        while(start-1-j >= 0){
+            for (index_t k = 0; k < N && start-1-j >= 0; ++k, ++j){
+                output[2*N-1] += filter[2*(start-1-j)] * input[k];
+                output[0] += filter[2*(start-1-j)+1] * input[k];
             }
         }
         for (; j <= N+start-1 && j < F/2; ++j){

--- a/pywt/src/convolution.c.src
+++ b/pywt/src/convolution.c.src
@@ -303,6 +303,13 @@ int @type@_upsampling_convolution_full(const @type@ * const restrict input, cons
             output[o+1] += filter[j*2+1] * input[i-j];
         }
 
+    // Overlap at both ends, if N < F/2
+    for(; i < F/2; ++i, o += 2)
+        for(size_t j = i-(N-1); j <= i; ++j){
+            output[o] += filter[j*2] * input[i-j];
+            output[o+1] += filter[j*2+1] * input[i-j];
+        }
+
     // Sliding filter out
     for(; i < N+F/2; ++i, o += 2)
         for(size_t j = i-(N-1); j < F/2; ++j){

--- a/pywt/src/convolution.c.src
+++ b/pywt/src/convolution.c.src
@@ -90,13 +90,10 @@ int @type@_downsampling_convolution(const @type@* input, const_index_t N,
      *    for time > n-1
      */
 
-    index_t i, j, k;
-    index_t start;
-    @type@ sum, tmp;
+    index_t i;
+    index_t start = step-1; /* first element taken from input is input[step-1] */
 
     @type@* ptr_w = output;
-
-    i = start = step-1; /* first element taken from input is input[step-1] */
 
     if (F > N) {
         /* reallocating memory for short signals (shorter than filter) is cheap */
@@ -114,11 +111,13 @@ int @type@_downsampling_convolution(const @type@* input, const_index_t N,
     {
         case MODE_SYMMETRIC:
             for(i=start; i < F; i+=step){
-                sum = 0;
+                index_t k = i+1;
+                @type@ sum = 0;
+                index_t j;
+
                 for(j = 0; j <= i; ++j)
                     sum += filter[j]*input[i-j];
-                k = i+1;
-                for(j = i+1; j < F; ++j)
+                for(; j < F; ++j)
                     sum += filter[j] * input[j-k];
                 *(ptr_w++) = sum;
             }
@@ -126,11 +125,13 @@ int @type@_downsampling_convolution(const @type@* input, const_index_t N,
 
         case MODE_ASYMMETRIC:
             for(i=start; i < F; i+=step){
-                sum = 0;
+                index_t k = i+1;
+                @type@ sum = 0;
+                index_t j;
+
                 for(j = 0; j <= i; ++j)
                     sum += filter[j]*input[i-j];
-                k = i+1;
-                for(j = i+1; j < F; ++j)
+                for(; j < F; ++j)
                     sum += filter[j] * (input[0] - input[j-k]);
                 *(ptr_w++) = sum;
             }
@@ -138,41 +139,42 @@ int @type@_downsampling_convolution(const @type@* input, const_index_t N,
 
         case MODE_CONSTANT_EDGE:
             for(i=start; i < F; i+=step){
-                sum = 0;
+                @type@ sum = 0;
+                index_t k = i+1;
+                index_t j;
+
                 for(j = 0; j <= i; ++j)
                     sum += filter[j]*input[i-j];
-
-                k = i+1;
-                for(j = i+1; j < F; ++j)
+                for(; j < F; ++j)
                     sum += filter[j] * input[0];
-
                 *(ptr_w++) = sum;
             }
             break;
 
         case MODE_SMOOTH:
             for(i=start; i < F; i+=step){
-                sum = 0;
+                @type@ sum = 0;
+                @type@ tmp = input[0]-input[1];
+                index_t j;
+
                 for(j = 0; j <= i; ++j)
                     sum += filter[j]*input[i-j];
-                tmp = input[0]-input[1];
-                for(j = i+1; j < F; ++j){
+                for(; j < F; ++j)
                     sum += filter[j] * (input[0] + tmp * (j-i));
-                }
                 *(ptr_w++) = sum;
             }
             break;
 
         case MODE_PERIODIC:
             for(i=start; i < F; i+=step){
-                sum = 0;
+                @type@ sum = 0;
+                index_t k = N+i;
+                index_t j;
+
                 for(j = 0; j <= i; ++j)
                     sum += filter[j]*input[i-j];
-
-                k = N+i;
-                for(j = i+1; j < F; ++j)
+                for(; j < F; ++j)
                     sum += filter[j] * input[k-j];
-
                 *(ptr_w++) = sum;
             }
             break;
@@ -180,7 +182,9 @@ int @type@_downsampling_convolution(const @type@* input, const_index_t N,
         case MODE_ZEROPAD:
         default:
             for(i=start; i < F; i+=step){
-                sum = 0;
+                @type@ sum = 0;
+                index_t j;
+
                 for(j = 0; j <= i; ++j)
                     sum += filter[j]*input[i-j];
                 *(ptr_w++) = sum;
@@ -193,10 +197,10 @@ int @type@_downsampling_convolution(const @type@* input, const_index_t N,
      * Most time is spent in this loop.
      */
     for(; i < N; i+=step){  /* input elements, */
-        sum = input[i] * filter[0];
-        for(j = 1; j < F; ++j){
+        @type@ sum = 0;
+
+        for(index_t j = 0; j < F; ++j)
             sum += input[i-j]*filter[j];
-        }
         *(ptr_w++) = sum;
     }
 
@@ -205,68 +209,72 @@ int @type@_downsampling_convolution(const @type@* input, const_index_t N,
     {
         case MODE_SYMMETRIC:
             for(; i < N+F-1; i += step){  /* input elements */
-                sum = 0;
-                k = i-N+1;   /* 1, 2, 3 : overlapped elements */
-                for(j = k; j < F; ++j)   /*TODO: j < F-_offset */
-                    sum += filter[j]*input[i-j];
+                @type@ sum = 0;
+                index_t k = i-N+1;   /* 1, 2, 3 : overlapped elements */
+                index_t j;
 
                 for(j = 0; j < k; ++j)  /* out of boundary (TODO: j = _offset) */
                     /* j-i-1      0*(N-1), 0*(N-2) 1*(N-1) */
                     sum += filter[j]*input[N-k+j];
-
+                for(; j < F; ++j)   /*TODO: j < F-_offset */
+                    sum += filter[j]*input[i-j];
                 *(ptr_w++) = sum;
             }
             break;
 
         case MODE_ASYMMETRIC:
             for(; i < N+F-1; i += step){  /* input elements */
-                sum = 0;
-                k = i-N+1;
-                for(j = k; j < F; ++j)   /* overlapped elements */
-                    sum += filter[j]*input[i-j];
+                @type@ sum = 0;
+                index_t k = i-N+1;
+                index_t j;
 
                 for(j = 0; j < k; ++j)   /* out of boundary */
                     sum += filter[j]*(input[N-1]-input[N-k-1+j]); /* -= j-i-1 */
+                for(; j < F; ++j)   /* overlapped elements */
+                    sum += filter[j]*input[i-j];
                 *(ptr_w++) = sum;
             }
             break;
 
         case MODE_CONSTANT_EDGE:
             for(; i < N+F-1; i += step){  /* input elements */
-                sum = 0;
-                k = i-N+1;
-                for(j = k; j < F; ++j)   /* overlapped elements */
-                    sum += filter[j]*input[i-j];
+                @type@ sum = 0;
+                index_t k = i-N+1;
+                index_t j;
 
                 for(j = 0; j < k; ++j)  /* out of boundary (filter elements [0, k-1]) */
                     sum += filter[j]*input[N-1]; /* input[N-1] = const */
-
+                for(; j < F; ++j)   /* overlapped elements */
+                    sum += filter[j]*input[i-j];
                 *(ptr_w++) = sum;
             }
             break;
 
         case MODE_SMOOTH:
             for(; i < N+F-1; i += step){  /* input elements */
-                sum = 0;
-                k = i-N+1;
-                for(j = k; j < F; ++j)  /* overlapped elements */
-                    sum += filter[j]*input[i-j];
+                @type@ sum = 0;
+                @type@ tmp = input[N-1]-input[N-2];
+                index_t k = i-N+1;
+                index_t j;
 
-                tmp = input[N-1]-input[N-2];
                 for(j = 0; j < k; ++j)  /* out of boundary (filter elements [0, k-1]) */
                     sum += filter[j] * (input[N-1] + tmp * (k-j));
+                for(; j < F; ++j)  /* overlapped elements */
+                    sum += filter[j]*input[i-j];
                 *(ptr_w++) = sum;
             }
             break;
 
         case MODE_PERIODIC:
             for(; i < N+F-1; i += step){  /* input elements */
-                sum = 0;
-                k = i-N+1;
-                for(j = k; j < F; ++j)   /* overlapped elements */
-                    sum += filter[j]*input[i-j];
+                @type@ sum = 0;
+                index_t k = i-N+1;
+                index_t j;
+
                 for(j = 0; j < k; ++j)  /* out of boundary (filter elements [0, k-1]) */
                     sum += filter[j]*input[k-1-j];
+                for(; j < F; ++j)   /* overlapped elements */
+                    sum += filter[j]*input[i-j];
                 *(ptr_w++) = sum;
             }
             break;
@@ -274,7 +282,9 @@ int @type@_downsampling_convolution(const @type@* input, const_index_t N,
         case MODE_ZEROPAD:
         default:
             for(; i < N+F-1; i += step){
-                sum = 0;
+                @type@ sum = 0;
+                index_t j;
+
                 for(j = i-(N-1); j < F; ++j)
                     sum += input[i-j]*filter[j];
                 *(ptr_w++) = sum;

--- a/pywt/src/convolution.c.src
+++ b/pywt/src/convolution.c.src
@@ -278,19 +278,13 @@ int @type@_downsampling_convolution(const @type@ * const restrict input, const i
  */
 
 int @type@_upsampling_convolution_full(const @type@* input, const index_t N,
-                                const @type@* filter, const index_t F,
-                                @type@* output, const index_t O)
+                                       const @type@* filter, const index_t F,
+                                       @type@* output, const index_t O)
 {
-    register index_t i;
-    register index_t j;
-    @type@ *ptr_out;
-
     if(F<2)
         return -1;
 
-    ptr_out = output + ((N-1) << 1);
-
-    for(i = N-1; i >= 0; --i){
+    for(index_t i = N-1, o = (N-1) * 2; i >= 0; --i, o -= 2){
         /*
          * sliding in filter from the right (end of input)
          * i0 0  i1 0  i2 0
@@ -298,10 +292,8 @@ int @type@_upsampling_convolution_full(const @type@* input, const index_t N,
          *             f1 f2 -> o2
          *          f1 f2 f3 -> o3
          */
-
-        for(j = 0; j < F; ++j)
-            ptr_out[j] += input[i] * filter[j]; /* input[i] - const in loop */
-        ptr_out -= 2;
+        for(index_t j = 0; j < F; ++j)
+            output[o + j] += input[i] * filter[j];
     }
     return 0;
 }

--- a/pywt/src/convolution.c.src
+++ b/pywt/src/convolution.c.src
@@ -36,7 +36,7 @@ int @type@_downsampling_convolution_periodization(const @type@ * const restrict 
                                                   @type@ * const restrict output, const size_t step)
 {
     size_t i = F/2, o = 0;
-    const size_t padding = N % 2; // FIXME: Should be N%step for larger steps?
+    const size_t padding = (step - (N % step)) % step;
 
     for (; i < F && i < N; i += step, ++o) {
         @type@ sum = 0;
@@ -301,13 +301,13 @@ int @type@_upsampling_convolution_full(const @type@ * const restrict input, cons
      * for idwt.
      */
 
-    // FIXME? Return a valid result for i%2 != 0? Not for idwt, but could be useful.
-
     // If check omitted, this function would be a no-op for F<2
     size_t i = 0, o = 0;
 
     if(F<2)
         return -1;
+    if(F%2)
+        return -3;
 
     for(; i < N && i < F/2; ++i, o += 2){
         size_t j;

--- a/pywt/src/convolution.c.src
+++ b/pywt/src/convolution.c.src
@@ -29,15 +29,17 @@ int @type@_downsampling_convolution_periodization(const @type@* input, const ind
     @type@* ptr_w = output;
     const index_t padding = N % 2; // Should be N%step for larger steps?
 
-    for (i=F/2; i < F; i += step) {
+    for (i=F/2; i < F && i < N; i += step) {
         @type@ sum = 0;
         index_t j;
         for (j = 0; j <= i; ++j)
             sum += filter[j] * input[i-j];
-        for (index_t k = 0; k < padding && j < F; ++k, ++j)
-            sum += filter[j] * input[N-1];
-        for (index_t k = N-1; j < F; --k, ++j)
-            sum += filter[j] * input[k];
+        while (j < F){
+            for (index_t k = 0; k < padding && j < F; ++k, ++j)
+                sum += filter[j] * input[N-1];
+            for (index_t k = 0; k < N && j < F; ++k, ++j)
+                sum += filter[j] * input[N-1-k];
+        }
         *(ptr_w++) = sum;
     }
 
@@ -49,15 +51,38 @@ int @type@_downsampling_convolution_periodization(const @type@* input, const ind
         *(ptr_w++) = sum;
     }
 
-    for(i = i - N; i < F/2; i += step){   /* input elements */
+    for (; i < F && i < N + F/2; i += step) {
         @type@ sum = 0;
-        index_t j;
-        for (j = 0; j <= i - padding; ++j)
-            sum += filter[j] * input[i - j - padding];
-        for(index_t k = 0; k < padding && j < F; ++k, ++j)
-            sum += filter[j] * input[N-1];
-        for(index_t k = N-1; j < F; --k, ++j)   /* overlapped elements */
-            sum += filter[j]*input[k];
+        index_t j = 0;
+
+        while (i-j >= N){
+            for (index_t k = 0; k < padding && i-j >= N; ++k, ++j)
+                sum += filter[i-N-j] * input[N-1];
+            for (index_t k = 0; k < N && i-j >= N; ++k, ++j)
+                sum += filter[i-N-j] * input[k];
+        }
+        for (; j <= i; ++j)
+            sum += filter[j] * input[i-j];
+        while (j < F){
+            for (index_t k = 0; k < padding && j < F; ++k, ++j)
+                sum += filter[j] * input[N-1];
+            for (index_t k = 0; k < N && j < F; ++k, ++j)
+                sum += filter[j] * input[N-1-k];
+        }
+        *(ptr_w++) = sum;
+    }
+
+    for(; i < N + F/2; i += step){   /* input elements */
+        @type@ sum = 0;
+        index_t j = 0;
+        while (i-j >= N){
+            for (index_t k = 0; k < padding && i-j >= N; ++k, ++j)
+                sum += filter[i-N-j] * input[N-1];
+            for (index_t k = 0; k < N && i-j >= N; ++k, ++j)
+                sum += filter[i-N-j] * input[k];
+        }
+        for (; j < F; ++j)
+            sum += filter[j] * input[i-j];
         *(ptr_w++) = sum;
     }
     return 0;
@@ -93,8 +118,6 @@ int @type@_downsampling_convolution(const @type@* input, const index_t N,
     @type@* ptr_w = output;
 
     if(mode == MODE_PERIODIZATION){
-        if (F > N)
-            return @type@_allocating_downsampling_convolution_periodization(input, N, filter, F, output, step);
         return @type@_downsampling_convolution_periodization(input, N, filter, F, output, step);
     }
 
@@ -247,61 +270,6 @@ int @type@_downsampling_convolution(const @type@* input, const index_t N,
             sum += filter[j]*input[i-j];
         *(ptr_w++) = sum;
     }
-    return 0;
-}
-
-/*
- * ### like downsampling_convolution, but with memory allocation ###
- */
-
-int @type@_allocating_downsampling_convolution_periodization(const @type@* input, const index_t N,
-                                                             const @type@* filter, const index_t F,
-                                                             @type@* output, const index_t step)
-{
-    index_t N_extended_right_start, start, stop;
-    @type@ *buffer;
-
-    index_t N_extended_len = N + F-1;
-    N_extended_right_start = N-1 + F/2;
-
-    buffer = wtcalloc(N_extended_len, sizeof(@type@));
-    if(buffer == NULL)
-        return -1;
-
-    memcpy(buffer+F/2-1, input, sizeof(@type@) * N);
-
-    start = (F-1) + step - 2;
-    if(step == 1)
-        stop = N_extended_len-1;
-    else /* step == 2 */
-        stop = N_extended_len;
-
-    if(N%2){ /* odd - repeat last element */
-        buffer[N_extended_right_start] = input[N-1];
-        for(index_t j = 1; j < F/2; ++j)
-            buffer[N_extended_right_start+j] = buffer[F/2-2 + j]; /* copy from beginning of `input` to right */
-        for(index_t j = 0; j < F/2-1; ++j)   /* copy from 'buffer' to left */
-            buffer[F/2-2-j] =  buffer[N_extended_right_start-j];
-    } else {
-        for(index_t j = 0; j < F/2; ++j)
-            buffer[N_extended_right_start+j] = input[j%N]; /* copy from beginning of `input` to right */
-        for(index_t j = 0; j < F/2-1; ++j)   /* copy from 'buffer' to left */
-            buffer[F/2-2-j] =  buffer[N_extended_right_start-1-j];
-    }
-    /*
-     * F - N-1 : filter in input range, perform convolution with decimation
-     */
-    for(index_t i=start, o=0; i < stop; i+=step, ++o){  /* input elements */
-        @type@ sum = 0;
-
-        for(index_t j = 0; j < F; ++j){
-            sum += buffer[i-j]*filter[j];
-        }
-        output[o] = sum;
-    }
-
-    /* free memory */
-    wtfree(buffer);
     return 0;
 }
 

--- a/pywt/src/convolution.c.src
+++ b/pywt/src/convolution.c.src
@@ -331,55 +331,68 @@ int @type@_upsampling_convolution_valid_sf_periodization(const @type@* input, co
      * This can be only valid for PERIODIZATION_MODE
      */
     if(N < F/2) {
-        @type@ * const restrict ptr_out = wtcalloc(idwt_buffer_length(N, F, MODE_PERIODIZATION),
-                                                   sizeof(@type@));
-        const index_t start = F/4;
-        index_t i = start, o = 0;
+        index_t const start = F/4;
+        index_t i = start;
+        index_t const end = ((F/2)%2) ? N + F/4 : N + F/4 - 1;
+        index_t o = ((F/2)%2) ? 0 : 1;
+
+        if ((F/2)%2 == 0){
+            // Shift everything one element right
+
+            // i = N-1; even element goes to output[O-1], odd element goes to output[o]
+            index_t j = 0;
+            while(N+start-1-j >= N){
+                for (index_t k = 0; k < N && N+start-1-j >= N; ++k, ++j){
+                    output[2*N-1] += filter[2*(N+start-1-N-j)] * input[k];
+                    output[0] += filter[2*(N+start-1-N-j)+1] * input[k];
+                }
+            }
+            for (; j <= N+start-1 && j < F/2; ++j){
+                output[2*N-1] += filter[2*j] * input[N+start-1-j];
+                output[0] += filter[2*j+1] * input[N+start-1-j];
+            }
+            while (j < F / 2){
+                for (index_t k = 0; k < N && j < F/2; ++k, ++j){
+                    output[2*N-1] += filter[2*j] * input[N-1-k];
+                    output[0] += filter[2*j+1] * input[N-1-k];
+                }
+            }
+        }
 
         for (; i < N; ++i, o += 2){
             index_t j = 0;
             for(; j <= i; ++j){
-                ptr_out[o] += filter[2*j] * input[i-j];
-                ptr_out[o+1] += filter[2*j+1] * input[i-j];
+                output[o] += filter[2*j] * input[i-j];
+                output[o+1] += filter[2*j+1] * input[i-j];
             }
             while (j < F/2){
                 for(index_t k = 0; k < N && j < F/2; ++k, ++j){
-                    ptr_out[o] += filter[2*j] * input[N-1-k];
-                    ptr_out[o+1] += filter[2*j+1] * input[N-1-k];
+                    output[o] += filter[2*j] * input[N-1-k];
+                    output[o+1] += filter[2*j+1] * input[N-1-k];
                 }
             }
         }
 
-        for (; i < N + start; ++i, o += 2){
+        for (; i < end; ++i, o += 2){
             index_t j = 0;
             while(i-j >= N){
                 for (index_t k = 0; k < N && i-j >= N; ++k, ++j){
-                    ptr_out[o] += filter[2*(i-N-j)] * input[k];
-                    ptr_out[o+1] += filter[2*(i-N-j)+1] * input[k];
+                    output[o] += filter[2*(i-N-j)] * input[k];
+                    output[o+1] += filter[2*(i-N-j)+1] * input[k];
                 }
             }
             for (; j <= i && j < F/2; ++j){
-                ptr_out[o] += filter[2*j] * input[i-j];
-                ptr_out[o+1] += filter[2*j+1] * input[i-j];
+                output[o] += filter[2*j] * input[i-j];
+                output[o+1] += filter[2*j+1] * input[i-j];
             }
             while (j < F / 2){
                 for (index_t k = 0; k < N && j < F/2; ++k, ++j){
-                    ptr_out[o] += filter[2*j] * input[N-1-k];
-                    ptr_out[o+1] += filter[2*j+1] * input[N-1-k];
+                    output[o] += filter[2*j] * input[N-1-k];
+                    output[o+1] += filter[2*j+1] * input[N-1-k];
                 }
             }
         }
 
-        if ((F/2)%2 == 0){
-            // Shift everything one element right
-            for(index_t i = 1; i < 2*N; ++i)
-                output[i] += ptr_out[i-1];
-            output[0] += ptr_out[2*N-1];
-        } else {
-            for (index_t i = 0; i < 2*N; ++i)
-                output[i] += ptr_out[i];
-        }
-        wtfree(ptr_out);
     } else {
         /* Otherwise (N >= F_2) */
         @type@ * ptr_out = output;

--- a/pywt/src/convolution.c.src
+++ b/pywt/src/convolution.c.src
@@ -284,7 +284,10 @@ int @type@_upsampling_convolution_full(const @type@ * const restrict input, cons
     if(F<2)
         return -1;
 
-    for(index_t i = N-1, o = (N-1) * 2; i >= 0; --i, o -= 2){
+    for(index_t i = 0, o = 0; i < N + F/2; ++i, o += 2){
+        @type@ sum_even = 0;
+        @type@ sum_odd = 0;
+
         /*
          * sliding in filter from the right (end of input)
          * i0 0  i1 0  i2 0
@@ -292,8 +295,13 @@ int @type@_upsampling_convolution_full(const @type@ * const restrict input, cons
          *             f1 f2 -> o2
          *          f1 f2 f3 -> o3
          */
-        for(index_t j = 0; j < F; ++j)
-            output[o + j] += input[i] * filter[j];
+        for(index_t j = (i >= N) ? i-(N-1) : 0; j < F/2 && j <= i; ++j){
+            sum_even += filter[j*2] * input[i-j];
+            sum_odd += filter[j*2+1] * input[i-j];
+        }
+
+        output[o] += sum_even;
+        output[o+1] += sum_odd;
     }
     return 0;
 }
@@ -530,7 +538,6 @@ int @type@_upsampling_convolution_valid_sf(const @type@ * const restrict input, 
      *
      * This part is simple, no extra hacks, just two convolutions in one loop
      */
-
     for(index_t o = 0, i = F/2 - 1; i < N; ++i, o += 2){
         @type@ sum_even = 0;
         @type@ sum_odd = 0;

--- a/pywt/src/convolution.c.src
+++ b/pywt/src/convolution.c.src
@@ -152,31 +152,33 @@ int @type@_downsampling_convolution(const @type@* input, const index_t N,
     /* N - N+F-1 : sliding out filter */
     for(; i < N+F-1; i += step){  /* input elements */
         @type@ sum = 0;
-        index_t j;
-        for(j = F - 1; i-j < N; --j)
-            sum += filter[j]*input[i-j];
+        index_t j = 0;
         switch(mode) {
         case MODE_SYMMETRIC:
             /* TODO: add offset to j? Inherited, not sure what this means */
-            for(index_t k = N-1; j >= 0; --j, --k)
-                sum += filter[j]*input[k];
+            // Process elements beyond end in reverse (i.e. away from data)
+            for(index_t k = N-1; i-j >= N; ++j, --k)
+                sum += filter[i-N-j]*input[k];
             break;
         case MODE_CONSTANT_EDGE:
-            for(; j >= 0; --j)   /* overlapped elements */
-                sum += filter[j]*input[N-1]; /* input[N-1] = const */
+            for(; i-j >= N; ++j)
+                sum += filter[j]*input[N-1];
             break;
         case MODE_SMOOTH:
-            for(index_t k = 1; j >= 0; --j, ++k)  /* out of boundary (filter elements [0, k-1]) */
+            for(index_t k = i - N + 1; i-j >= N; ++j, --k)
                 sum += filter[j]*(input[N-1] + k * (input[N-1] - input[N-2]));
             break;
         case MODE_PERIODIC:
-            for (index_t k = 0; j >= 0; --j, ++k)
-                sum += filter[j]*input[k];
+            for (index_t k = 0; i-j >= N; ++j, ++k)
+                sum += filter[i-N-j]*input[k];
             break;
         case MODE_ZEROPAD:
         default:
+            j = i - N + 1;
             break;
         }
+        for(; j < F; ++j)
+            sum += filter[j]*input[i-j];
         *(ptr_w++) = sum;
     }
     return 0;

--- a/pywt/src/convolution.h.src
+++ b/pywt/src/convolution.h.src
@@ -34,12 +34,10 @@ int @type@_downsampling_convolution(const @type@* input, const index_t N,
  * signals (shorter than filter).  This is called from downsampling_convolution
  */
 
-int @type@_allocating_downsampling_convolution(const @type@* input,
-                                               const index_t N, const @type@*
-                                               filter, const index_t F,
-                                               @type@* output, const index_t
-                                               step, MODE mode);
-
+int @type@_allocating_downsampling_convolution_periodization(const @type@* input,
+                                                             const index_t N, const @type@*
+                                                             filter, const index_t F,
+                                                             @type@* output, const index_t step);
 
 /*
  * Performs normal (full) convolution of "upsampled" input coeffs array with

--- a/pywt/src/convolution.h.src
+++ b/pywt/src/convolution.h.src
@@ -1,8 +1,7 @@
 /* Copyright (c) 2006-2012 Filip Wasilewski <http://en.ig.ma/> */
 /* See COPYING for license details. */
 
-#ifndef _CONVOLUTION_H_
-#define _CONVOLUTION_H_
+#pragma once
 
 #include "common.h"
 
@@ -64,5 +63,3 @@ int @type@_upsampling_convolution_valid_sf(const @type@ * const restrict input, 
  */
 
 /**end repeat**/
-
-#endif

--- a/pywt/src/convolution.h.src
+++ b/pywt/src/convolution.h.src
@@ -4,7 +4,6 @@
 #ifndef _CONVOLUTION_H_
 #define _CONVOLUTION_H_
 
-#include <math.h>
 #include "common.h"
 
 /**begin repeat

--- a/pywt/src/convolution.h.src
+++ b/pywt/src/convolution.h.src
@@ -25,9 +25,9 @@
 
 /* memory efficient version */
 
-int @type@_downsampling_convolution(const @type@* input, const index_t N,
-                                    const @type@* filter, const index_t F,
-                                    @type@* output, const index_t step,
+int @type@_downsampling_convolution(const @type@ * const restrict input, const index_t N,
+                                    const @type@ * const restrict filter, const index_t F,
+                                    @type@ * const restrict output, const index_t step,
                                     MODE mode);
 
 /*

--- a/pywt/src/convolution.h.src
+++ b/pywt/src/convolution.h.src
@@ -25,9 +25,9 @@
 
 /* memory efficient version */
 
-int @type@_downsampling_convolution(const @type@* input, const_index_t N,
-                                    const @type@* filter, const_index_t F,
-                                    @type@* output, const_index_t step,
+int @type@_downsampling_convolution(const @type@* input, const index_t N,
+                                    const @type@* filter, const index_t F,
+                                    @type@* output, const index_t step,
                                     MODE mode);
 
 /* Straightforward implementation with memory reallocation - for very short
@@ -35,9 +35,9 @@ int @type@_downsampling_convolution(const @type@* input, const_index_t N,
  */
 
 int @type@_allocating_downsampling_convolution(const @type@* input,
-                                               const_index_t N, const @type@*
-                                               filter, const_index_t F,
-                                               @type@* output, const_index_t
+                                               const index_t N, const @type@*
+                                               filter, const index_t F,
+                                               @type@* output, const index_t
                                                step, MODE mode);
 
 
@@ -55,18 +55,18 @@ int @type@_allocating_downsampling_convolution(const @type@* input,
  * mode     - signal extension mode
  */
 
-int @type@_upsampling_convolution_full(const @type@* input, const_index_t N,
-                                       const @type@* filter, const_index_t F,
-                                       @type@* output, const_index_t O);
+int @type@_upsampling_convolution_full(const @type@* input, const index_t N,
+                                       const @type@* filter, const index_t F,
+                                       @type@* output, const index_t O);
 
 /* Performs valid convolution (signals must overlap)
  * Extends (virtually) input for MODE_PERIODIZATION.
  */
 
-int @type@_upsampling_convolution_valid_sf(const @type@* input, const_index_t N,
+int @type@_upsampling_convolution_valid_sf(const @type@* input, const index_t N,
                                            const @type@* filter,
-                                           const_index_t F, @type@* output,
-                                           const_index_t O, MODE mode);
+                                           const index_t F, @type@* output,
+                                           const index_t O, MODE mode);
 
 /* TODO
  * for SWT

--- a/pywt/src/convolution.h.src
+++ b/pywt/src/convolution.h.src
@@ -30,15 +30,6 @@ int @type@_downsampling_convolution(const @type@* input, const index_t N,
                                     @type@* output, const index_t step,
                                     MODE mode);
 
-/* Straightforward implementation with memory reallocation - for very short
- * signals (shorter than filter).  This is called from downsampling_convolution
- */
-
-int @type@_allocating_downsampling_convolution_periodization(const @type@* input,
-                                                             const index_t N, const @type@*
-                                                             filter, const index_t F,
-                                                             @type@* output, const index_t step);
-
 /*
  * Performs normal (full) convolution of "upsampled" input coeffs array with
  * filter Requires zero-filled output buffer (adds values instead of

--- a/pywt/src/convolution.h.src
+++ b/pywt/src/convolution.h.src
@@ -52,10 +52,10 @@ int @type@_upsampling_convolution_full(const @type@ * const restrict input, cons
  * Extends (virtually) input for MODE_PERIODIZATION.
  */
 
-int @type@_upsampling_convolution_valid_sf(const @type@* input, const index_t N,
-                                           const @type@* filter,
-                                           const index_t F, @type@* output,
-                                           const index_t O, MODE mode);
+int @type@_upsampling_convolution_valid_sf(const @type@ * const restrict input, const index_t N,
+                                           const @type@ * const restrict filter, const index_t F,
+                                           @type@ * const restrict output, const index_t O,
+                                           MODE mode);
 
 /* TODO
  * for SWT

--- a/pywt/src/convolution.h.src
+++ b/pywt/src/convolution.h.src
@@ -44,9 +44,9 @@ int @type@_downsampling_convolution(const @type@ * const restrict input, const i
  * mode     - signal extension mode
  */
 
-int @type@_upsampling_convolution_full(const @type@* input, const index_t N,
-                                       const @type@* filter, const index_t F,
-                                       @type@* output, const index_t O);
+int @type@_upsampling_convolution_full(const @type@ * const restrict input, const index_t N,
+                                       const @type@ * const restrict filter, const index_t F,
+                                       @type@ * const restrict output, const index_t O);
 
 /* Performs valid convolution (signals must overlap)
  * Extends (virtually) input for MODE_PERIODIZATION.

--- a/pywt/src/convolution.h.src
+++ b/pywt/src/convolution.h.src
@@ -5,6 +5,12 @@
 
 #include "common.h"
 
+#if defined _MSC_VER
+#define restrict __restrict
+#elif defined __GNUC__
+#define restrict __restrict__
+#endif
+
 /**begin repeat
  * #type = double, float#
  */

--- a/pywt/src/convolution.h.src
+++ b/pywt/src/convolution.h.src
@@ -69,3 +69,5 @@ int @type@_upsampling_convolution_valid_sf(const @type@ * const restrict input, 
  */
 
 /**end repeat**/
+
+#undef restrict

--- a/pywt/src/convolution.h.src
+++ b/pywt/src/convolution.h.src
@@ -24,9 +24,9 @@
 
 /* memory efficient version */
 
-int @type@_downsampling_convolution(const @type@ * const restrict input, const index_t N,
-                                    const @type@ * const restrict filter, const index_t F,
-                                    @type@ * const restrict output, const index_t step,
+int @type@_downsampling_convolution(const @type@ * const restrict input, const size_t N,
+                                    const @type@ * const restrict filter, const size_t F,
+                                    @type@ * const restrict output, const size_t step,
                                     MODE mode);
 
 /*
@@ -43,17 +43,17 @@ int @type@_downsampling_convolution(const @type@ * const restrict input, const i
  * mode     - signal extension mode
  */
 
-int @type@_upsampling_convolution_full(const @type@ * const restrict input, const index_t N,
-                                       const @type@ * const restrict filter, const index_t F,
-                                       @type@ * const restrict output, const index_t O);
+int @type@_upsampling_convolution_full(const @type@ * const restrict input, const size_t N,
+                                       const @type@ * const restrict filter, const size_t F,
+                                       @type@ * const restrict output, const size_t O);
 
 /* Performs valid convolution (signals must overlap)
  * Extends (virtually) input for MODE_PERIODIZATION.
  */
 
-int @type@_upsampling_convolution_valid_sf(const @type@ * const restrict input, const index_t N,
-                                           const @type@ * const restrict filter, const index_t F,
-                                           @type@ * const restrict output, const index_t O,
+int @type@_upsampling_convolution_valid_sf(const @type@ * const restrict input, const size_t N,
+                                           const @type@ * const restrict filter, const size_t F,
+                                           @type@ * const restrict output, const size_t O,
                                            MODE mode);
 
 /* TODO

--- a/pywt/src/convolution.h.src
+++ b/pywt/src/convolution.h.src
@@ -11,8 +11,7 @@
  * #type = double, float#
  */
 
-/* 
- * Performs convolution of input with filter and downsamples by taking every
+/* Performs convolution of input with filter and downsamples by taking every
  * step-th element from the result.
  *
  * input    - input data
@@ -31,10 +30,9 @@ int @type@_downsampling_convolution(const @type@* input, const_index_t N,
                                     @type@* output, const_index_t step,
                                     MODE mode);
 
-/* 
- * Straightforward implementation with memory reallocation - for very short
- * signals (shorter than filter).  This id called from downsampling_convolution
- */ 
+/* Straightforward implementation with memory reallocation - for very short
+ * signals (shorter than filter).  This is called from downsampling_convolution
+ */
 
 int @type@_allocating_downsampling_convolution(const @type@* input,
                                                const_index_t N, const @type@*
@@ -61,8 +59,7 @@ int @type@_upsampling_convolution_full(const @type@* input, const_index_t N,
                                        const @type@* filter, const_index_t F,
                                        @type@* output, const_index_t O);
 
-/* 
- * Performs valid convolution (signals must overlap)
+/* Performs valid convolution (signals must overlap)
  * Extends (virtually) input for MODE_PERIODIZATION.
  */
 
@@ -71,8 +68,7 @@ int @type@_upsampling_convolution_valid_sf(const @type@* input, const_index_t N,
                                            const_index_t F, @type@* output,
                                            const_index_t O, MODE mode);
 
-/* 
- * TODO
+/* TODO
  * for SWT
  * int upsampled_filter_convolution(const @type@* input, const int N,
  *                                  const @type@* filter, const int F,

--- a/pywt/src/wavelets.c.src
+++ b/pywt/src/wavelets.c.src
@@ -20,15 +20,15 @@ Wavelet* wavelet(char name, int order)
         return w;
 
     /* Reverse biorthogonal wavelets family */
-    } else if (name == 'r' || name == 'R') { 
+    } else if (name == 'r' || name == 'R') {
 
         /* rbio is like bior, only with switched filters */
         wtmp = wavelet('b', order);
         w = copy_wavelet(wtmp);
-        
+
         if(w == NULL)
             return NULL;
-        
+
         w->dec_len = wtmp->rec_len;
         w->rec_len = wtmp->dec_len;
 
@@ -57,7 +57,7 @@ Wavelet* wavelet(char name, int order)
         w->short_name = "rbio";
 
         free_wavelet(wtmp);
-        
+
         return w;
     }
 
@@ -98,7 +98,7 @@ Wavelet* wavelet(char name, int order)
                     w->rec_hi_@type@ = db@order@_@type@[3];
                     /**end repeat1**/
                     break;
-                /**end repeat**/ 
+                /**end repeat**/
                 default:
                     wtfree(w);
                     return NULL;
@@ -135,7 +135,7 @@ Wavelet* wavelet(char name, int order)
                     /**end repeat1**/
                     break;
                 /**end repeat**/
-            
+
                 default:
                     wtfree(w);
                     return NULL;
@@ -172,7 +172,7 @@ Wavelet* wavelet(char name, int order)
                     /**end repeat1**/
                     break;
                 /**end repeat**/
-            
+
                 default:
                     wtfree(w);
                     return NULL;
@@ -344,7 +344,7 @@ Wavelet* blank_wavelet(index_t filters_length)
     w = wtmalloc(sizeof(Wavelet));
     if(w == NULL) return NULL;
 
-    /* 
+    /*
      * Important!
      * Otherwise filters arrays allocated here won't be deallocated by free_wavelet
      */

--- a/pywt/src/wavelets.c.src
+++ b/pywt/src/wavelets.c.src
@@ -31,22 +31,28 @@ Wavelet* wavelet(char name, unsigned int order)
         w->dec_len = wtmp->rec_len;
         w->rec_len = wtmp->dec_len;
 
-        for(size_t i = 0; i < w->rec_len; ++i){
-            /**begin repeat
-             * #type = double, float#
-             */
+        {
+            size_t i;
+            for(i = 0; i < w->rec_len; ++i){
+                /**begin repeat
+                 * #type = double, float#
+                 */
                 w->rec_lo_@type@[i] = wtmp->dec_lo_@type@[wtmp->dec_len-1-i];
                 w->rec_hi_@type@[i] = wtmp->dec_hi_@type@[wtmp->dec_len-1-i];
-            /**end repeat**/
+                /**end repeat**/
+            }
         }
 
-        for(size_t i = 0; i < w->dec_len; ++i){
-            /**begin repeat
-             * #type = double, float#
-             */
+        {
+            size_t i;
+            for(i = 0; i < w->dec_len; ++i){
+                /**begin repeat
+                 * #type = double, float#
+                 */
                 w->dec_hi_@type@[i] = wtmp->rec_hi_@type@[wtmp->rec_len-1-i];
                 w->dec_lo_@type@[i] = wtmp->rec_lo_@type@[wtmp->rec_len-1-i];
-            /**end repeat**/
+                /**end repeat**/
+            }
         }
 
         w->vanishing_moments_psi = order / 10; /* 1st digit */
@@ -410,16 +416,11 @@ Wavelet* copy_wavelet(Wavelet* base)
             return NULL;
         }
 
-        // FIXME: memcpy
-        for(size_t i=0; i< w->dec_len; ++i){
-            w->dec_lo_@type@[i] = base->dec_lo_@type@[i];
-            w->dec_hi_@type@[i] = base->dec_hi_@type@[i];
-        }
-
-        for(size_t i=0; i< w->rec_len; ++i){
-            w->rec_lo_@type@[i] = base->rec_lo_@type@[i];
-            w->rec_hi_@type@[i] = base->rec_hi_@type@[i];
-        }
+        // FIXME: Test coverage, the only use in `wavelet` overwrites the filter
+        memcpy(w->dec_lo_@type@, base->dec_lo_@type@, w->dec_len * sizeof(@type@));
+        memcpy(w->dec_hi_@type@, base->dec_hi_@type@, w->dec_len * sizeof(@type@));
+        memcpy(w->rec_lo_@type@, base->rec_lo_@type@, w->rec_len * sizeof(@type@));
+        memcpy(w->rec_hi_@type@, base->rec_hi_@type@, w->rec_len * sizeof(@type@));
 
     /**end repeat**/
 

--- a/pywt/src/wavelets.c.src
+++ b/pywt/src/wavelets.c.src
@@ -5,10 +5,9 @@
 #include "wavelets.h"
 #include "wavelets_coeffs.h"
 
-Wavelet* wavelet(char name, int order)
+Wavelet* wavelet(char name, unsigned int order)
 {
     Wavelet *w, *wtmp;
-    index_t i;
 
     /* Haar wavelet */
     if(name == 'h' || name == 'H'){
@@ -32,7 +31,7 @@ Wavelet* wavelet(char name, int order)
         w->dec_len = wtmp->rec_len;
         w->rec_len = wtmp->dec_len;
 
-        for(i = 0; i < w->rec_len; ++i){
+        for(size_t i = 0; i < w->rec_len; ++i){
             /**begin repeat
              * #type = double, float#
              */
@@ -41,7 +40,7 @@ Wavelet* wavelet(char name, int order)
             /**end repeat**/
         }
 
-        for(i = 0; i < w->dec_len; ++i){
+        for(size_t i = 0; i < w->dec_len; ++i){
             /**begin repeat
              * #type = double, float#
              */
@@ -330,7 +329,7 @@ Wavelet* wavelet(char name, int order)
 }
 
 
-Wavelet* blank_wavelet(index_t filters_length)
+Wavelet* blank_wavelet(size_t filters_length)
 {
     Wavelet* w;
 
@@ -384,7 +383,6 @@ Wavelet* blank_wavelet(index_t filters_length)
 Wavelet* copy_wavelet(Wavelet* base)
 {
     Wavelet* w;
-    index_t i;
 
     if(base == NULL) return NULL;
 
@@ -412,12 +410,13 @@ Wavelet* copy_wavelet(Wavelet* base)
             return NULL;
         }
 
-        for(i=0; i< w->dec_len; ++i){
+        // FIXME: memcpy
+        for(size_t i=0; i< w->dec_len; ++i){
             w->dec_lo_@type@[i] = base->dec_lo_@type@[i];
             w->dec_hi_@type@[i] = base->dec_hi_@type@[i];
         }
 
-        for(i=0; i< w->rec_len; ++i){
+        for(size_t i=0; i< w->rec_len; ++i){
             w->rec_lo_@type@[i] = base->rec_lo_@type@[i];
             w->rec_hi_@type@[i] = base->rec_hi_@type@[i];
         }

--- a/pywt/src/wavelets.h
+++ b/pywt/src/wavelets.h
@@ -19,14 +19,14 @@ typedef enum {
 
 /* Wavelet structure holding pointers to filter arrays and property attributes */
 typedef struct {
-        double* dec_hi_double;  /* highpass decomposition */
-        double* dec_lo_double;  /* lowpass decomposition */
-        double* rec_hi_double;  /* highpass reconstruction */
-        double* rec_lo_double;  /* lowpass reconstruction */
-        float* dec_hi_float;
-        float* dec_lo_float;
-        float* rec_hi_float;
-        float* rec_lo_float;
+    double* dec_hi_double;  /* highpass decomposition */
+    double* dec_lo_double;  /* lowpass decomposition */
+    double* rec_hi_double;  /* highpass reconstruction */
+    double* rec_lo_double;  /* lowpass reconstruction */
+    float* dec_hi_float;
+    float* dec_lo_float;
+    float* rec_hi_float;
+    float* rec_lo_float;
 
     size_t dec_len;   /* length of decomposition filter */
     size_t rec_len;   /* length of reconstruction filter */

--- a/pywt/src/wavelets.h
+++ b/pywt/src/wavelets.h
@@ -38,9 +38,9 @@ typedef struct {
 
     SYMMETRY symmetry;
 
-    int orthogonal:1;
-    int biorthogonal:1;
-    int compact_support:1;
+    unsigned int orthogonal:1;
+    unsigned int biorthogonal:1;
+    unsigned int compact_support:1;
 
     /*
      * Set if filters arrays shouldn't be deallocated by

--- a/pywt/src/wavelets.h
+++ b/pywt/src/wavelets.h
@@ -1,10 +1,7 @@
 /* Copyright (c) 2006-2012 Filip Wasilewski <http://en.ig.ma/> */
 /* See COPYING for license details. */
 
-/* Wavelet struct */
-
-#ifndef _WAVELETS_H_
-#define _WAVELETS_H_
+#pragma once
 
 #include "common.h"
 
@@ -77,5 +74,3 @@ Wavelet* copy_wavelet(Wavelet* base);
  * wavelet(...) or blank_wavelet(...) functions.
  */
 void free_wavelet(Wavelet *wavelet);
-
-#endif

--- a/pywt/src/wavelets.h
+++ b/pywt/src/wavelets.h
@@ -27,10 +27,10 @@ typedef struct {
         float* dec_lo_float;
         float* rec_hi_float;
         float* rec_lo_float;
-    
-    index_t dec_len;   /* length of decomposition filter */
-    index_t rec_len;   /* length of reconstruction filter */
-    
+
+    size_t dec_len;   /* length of decomposition filter */
+    size_t rec_len;   /* length of reconstruction filter */
+
     /* Wavelet properties */
     int vanishing_moments_psi;
     int vanishing_moments_phi;
@@ -61,13 +61,13 @@ typedef struct {
  *
  * _builtin field is set to 1
  */
-Wavelet* wavelet(char name, int order);
+Wavelet* wavelet(char name, unsigned int order);
 
 /* 
  * Allocate blank Wavelet with zero-filled filters of given length
  * _builtin field is set to 0
  */
-Wavelet* blank_wavelet(index_t filters_length);
+Wavelet* blank_wavelet(size_t filters_length);
 
 /* Deep copy Wavelet */
 Wavelet* copy_wavelet(Wavelet* base);

--- a/pywt/src/wavelets_coeffs.h.src
+++ b/pywt/src/wavelets_coeffs.h.src
@@ -1,5 +1,4 @@
-#ifndef _WAVELETS_COEFFS_H_
-#define _WAVELETS_COEFFS_H_
+#pragma once
 
 /*
  * Filters coefficients for selected wavelets
@@ -445,5 +444,3 @@ static @type@ dmey_@type@[][62] = {
 };
 
 /**end repeat**/
-
-#endif

--- a/pywt/src/wt.c.src
+++ b/pywt/src/wt.c.src
@@ -9,10 +9,10 @@
  * #type = double, float#
  */
 
-int @type@_dec_a(@type@ input[], size_t input_len,
-                 Wavelet* wavelet,
-                 @type@ output[], size_t output_len,
-                 MODE mode){
+int @type@_dec_a(const @type@ * const restrict input, const size_t input_len,
+                 const Wavelet * const restrict wavelet,
+                 @type@ * const restrict output, const size_t output_len,
+                 const MODE mode){
 
     /* check output length */
     if(output_len != dwt_buffer_length(input_len, wavelet->dec_len, mode)){
@@ -28,10 +28,10 @@ int @type@_dec_a(@type@ input[], size_t input_len,
 
 /* Decomposition of input with highpass filter */
 
-int @type@_dec_d(@type@ input[], size_t input_len,
-                 Wavelet* wavelet,
-                 @type@ output[], size_t output_len,
-                 MODE mode){
+int @type@_dec_d(const @type@ * const restrict input, const size_t input_len,
+                 const Wavelet * const restrict wavelet,
+                 @type@ * const restrict output, const size_t output_len,
+                 const MODE mode){
 
     /* check output length */
     if(output_len != dwt_buffer_length(input_len, wavelet->dec_len, mode))
@@ -46,9 +46,9 @@ int @type@_dec_d(@type@ input[], size_t input_len,
 
 /* Direct reconstruction with lowpass reconstruction filter */
 
-int @type@_rec_a(@type@ coeffs_a[], size_t coeffs_len,
-                 Wavelet* wavelet,
-                 @type@ output[], size_t output_len){
+int @type@_rec_a(const @type@ * const restrict coeffs_a, const size_t coeffs_len,
+                 const Wavelet * const restrict wavelet,
+                 @type@ * const restrict output, const size_t output_len){
 
     /* check output length */
     if(output_len != reconstruction_buffer_length(coeffs_len, wavelet->rec_len))
@@ -63,9 +63,9 @@ int @type@_rec_a(@type@ coeffs_a[], size_t coeffs_len,
 
 /* Direct reconstruction with highpass reconstruction filter */
 
-int @type@_rec_d(@type@ coeffs_d[], size_t coeffs_len,
-                 Wavelet* wavelet,
-                 @type@ output[], size_t output_len){
+int @type@_rec_d(const @type@ * const restrict coeffs_d, const size_t coeffs_len,
+                 const Wavelet * const restrict wavelet,
+                 @type@ * const restrict output, const size_t output_len){
 
     /* check for output length */
     if(output_len != reconstruction_buffer_length(coeffs_len, wavelet->rec_len))
@@ -84,11 +84,11 @@ int @type@_rec_d(@type@ coeffs_d[], size_t coeffs_len,
  * is useful in multilevel decompositions and reconstructions of odd-length
  * signals).  Requires zero-filled output buffer.
  */
-int @type@_idwt(@type@ coeffs_a[], size_t coeffs_a_len,
-                @type@ coeffs_d[], size_t coeffs_d_len,
-                Wavelet* wavelet,
-                @type@ output[], size_t output_len,
-                MODE mode, int fix_size_diff){
+int @type@_idwt(const @type@ * const restrict coeffs_a, const size_t coeffs_a_len,
+                const @type@ * const restrict coeffs_d, const size_t coeffs_d_len,
+                const Wavelet * const restrict wavelet,
+                @type@ * const restrict output, const size_t output_len,
+                const MODE mode, const int fix_size_diff){
 
     size_t input_len;
 

--- a/pywt/src/wt.c.src
+++ b/pywt/src/wt.c.src
@@ -3,6 +3,12 @@
 
 #include "wt.h"
 
+#if defined _MSC_VER
+#define restrict __restrict
+#elif defined __GNUC__
+#define restrict __restrict__
+#endif
+
 /* Decomposition of input with lowpass filter */
 
 /**begin repeat
@@ -223,3 +229,5 @@ int @type@_swt_d(@type@ input[], index_t input_len, Wavelet* wavelet,
                        wavelet->dec_len, output, output_len, level);
 }
 /**end repeat**/
+
+#undef restrict

--- a/pywt/src/wt.c.src
+++ b/pywt/src/wt.c.src
@@ -39,7 +39,7 @@ int @type@_dec_d(@type@ input[], index_t input_len,
 
     return @type@_downsampling_convolution(input, input_len,
                                            wavelet->dec_hi_@type@,
-                                           wavelet->dec_len, output, 
+                                           wavelet->dec_len, output,
                                            2, mode);
 }
 
@@ -53,7 +53,7 @@ int @type@_rec_a(@type@ coeffs_a[], index_t coeffs_len,
     /* check output length */
     if(output_len != reconstruction_buffer_length(coeffs_len, wavelet->rec_len))
         return -1;
-    
+
     return @type@_upsampling_convolution_full(coeffs_a, coeffs_len,
                                               wavelet->rec_lo_@type@,
                                               wavelet->rec_len, output,
@@ -70,7 +70,7 @@ int @type@_rec_d(@type@ coeffs_d[], index_t coeffs_len,
     /* check for output length */
     if(output_len != reconstruction_buffer_length(coeffs_len, wavelet->rec_len))
         return -1;
-    
+
     return @type@_upsampling_convolution_full(coeffs_d, coeffs_len,
                                               wavelet->rec_hi_@type@,
                                               wavelet->rec_len, output,
@@ -91,7 +91,7 @@ int @type@_idwt(@type@ coeffs_a[], index_t coeffs_a_len,
                 MODE mode, int fix_size_diff){
 
     index_t input_len;
-    
+
     /*
      * If one of coeffs array is NULL then the reconstruction will be performed
      * using the other one
@@ -123,12 +123,12 @@ int @type@_idwt(@type@ coeffs_a[], index_t coeffs_a_len,
     } else {
         goto error;
     }
-    
+
     /* check output size */
     if(output_len != idwt_buffer_length(input_len, wavelet->rec_len, mode))
         goto error;
 
-    /* 
+    /*
      * Set output to zero (this can be omitted if output array is already
      * cleared) memset(output, 0, output_len * sizeof(@type@));
      */
@@ -142,7 +142,7 @@ int @type@_idwt(@type@ coeffs_a[], index_t coeffs_a_len,
             goto error;
         }
     }
-    /* 
+    /*
      * Add reconstruction of details coeffs performed with highpass
      * reconstruction filter.
      */
@@ -172,7 +172,7 @@ int @type@_swt_(@type@ input[], index_t input_len,
 
     if(level < 1)
         return -1;
-    
+
     if(level > swt_max_level(input_len))
         return -2;
 

--- a/pywt/src/wt.c.src
+++ b/pywt/src/wt.c.src
@@ -9,9 +9,9 @@
  * #type = double, float#
  */
 
-int @type@_dec_a(@type@ input[], index_t input_len,
+int @type@_dec_a(@type@ input[], size_t input_len,
                  Wavelet* wavelet,
-                 @type@ output[], index_t output_len,
+                 @type@ output[], size_t output_len,
                  MODE mode){
 
     /* check output length */
@@ -28,9 +28,9 @@ int @type@_dec_a(@type@ input[], index_t input_len,
 
 /* Decomposition of input with highpass filter */
 
-int @type@_dec_d(@type@ input[], index_t input_len,
+int @type@_dec_d(@type@ input[], size_t input_len,
                  Wavelet* wavelet,
-                 @type@ output[], index_t output_len,
+                 @type@ output[], size_t output_len,
                  MODE mode){
 
     /* check output length */
@@ -46,9 +46,9 @@ int @type@_dec_d(@type@ input[], index_t input_len,
 
 /* Direct reconstruction with lowpass reconstruction filter */
 
-int @type@_rec_a(@type@ coeffs_a[], index_t coeffs_len,
+int @type@_rec_a(@type@ coeffs_a[], size_t coeffs_len,
                  Wavelet* wavelet,
-                 @type@ output[], index_t output_len){
+                 @type@ output[], size_t output_len){
 
     /* check output length */
     if(output_len != reconstruction_buffer_length(coeffs_len, wavelet->rec_len))
@@ -63,9 +63,9 @@ int @type@_rec_a(@type@ coeffs_a[], index_t coeffs_len,
 
 /* Direct reconstruction with highpass reconstruction filter */
 
-int @type@_rec_d(@type@ coeffs_d[], index_t coeffs_len,
+int @type@_rec_d(@type@ coeffs_d[], size_t coeffs_len,
                  Wavelet* wavelet,
-                 @type@ output[], index_t output_len){
+                 @type@ output[], size_t output_len){
 
     /* check for output length */
     if(output_len != reconstruction_buffer_length(coeffs_len, wavelet->rec_len))
@@ -84,13 +84,13 @@ int @type@_rec_d(@type@ coeffs_d[], index_t coeffs_len,
  * is useful in multilevel decompositions and reconstructions of odd-length
  * signals).  Requires zero-filled output buffer.
  */
-int @type@_idwt(@type@ coeffs_a[], index_t coeffs_a_len,
-                @type@ coeffs_d[], index_t coeffs_d_len,
+int @type@_idwt(@type@ coeffs_a[], size_t coeffs_a_len,
+                @type@ coeffs_d[], size_t coeffs_d_len,
                 Wavelet* wavelet,
-                @type@ output[], index_t output_len,
+                @type@ output[], size_t output_len,
                 MODE mode, int fix_size_diff){
 
-    index_t input_len;
+    size_t input_len;
 
     /*
      * If one of coeffs array is NULL then the reconstruction will be performed

--- a/pywt/src/wt.h.src
+++ b/pywt/src/wt.h.src
@@ -19,31 +19,31 @@
  */
 
 /* Single level decomposition */
-int @type@_dec_a(@type@ input[], size_t input_len,
-                 Wavelet* wavelet,
-                 @type@ output[], size_t output_len,
-                 MODE mode);
+int @type@_dec_a(const @type@ * const restrict input, const size_t input_len,
+                 const Wavelet * const restrict wavelet,
+                 @type@ * const restrict output, const size_t output_len,
+                 const MODE mode);
 
-int @type@_dec_d(@type@ input[], size_t input_len,
-                 Wavelet* wavelet,
-                 @type@ output[], size_t output_len,
-                 MODE mode);
+int @type@_dec_d(const @type@ * const restrict input, const size_t input_len,
+                 const Wavelet * const restrict wavelet,
+                 @type@ * const restrict output, const size_t output_len,
+                 const MODE mode);
 
 /* Single level reconstruction */
-int @type@_rec_a(@type@ coeffs_a[], size_t coeffs_len,
-                 Wavelet* wavelet,
-                 @type@ output[], size_t output_len);
+int @type@_rec_a(const @type@ * const restrict coeffs_a, const size_t coeffs_len,
+                 const Wavelet * const restrict wavelet,
+                 @type@ * const restrict output, const size_t output_len);
 
-int @type@_rec_d(@type@ coeffs_d[], size_t coeffs_len,
-                 Wavelet* wavelet,
-                 @type@ output[], size_t output_len);
+int @type@_rec_d(const @type@ * const restrict coeffs_d, const size_t coeffs_len,
+                 const Wavelet * const restrict wavelet,
+                 @type@ * const restrict output, const size_t output_len);
 
 /* Single level IDWT reconstruction */
-int @type@_idwt(@type@ coeffs_a[], size_t coeffs_a_len,
-                @type@ coeffs_d[], size_t coeffs_d_len,
-                Wavelet* wavelet,
-                @type@ output[], size_t output_len,
-                MODE mode, int fix_size_diff);
+int @type@_idwt(const @type@ * const restrict coeffs_a, const size_t coeffs_a_len,
+                const @type@ * const restrict coeffs_d, const size_t coeffs_d_len,
+                const Wavelet * const wavelet,
+                @type@ * const restrict output, const size_t output_len,
+                const MODE mode, const int fix_size_diff);
 
 /* SWT decomposition at given level */
 int @type@_swt_a(@type@ input[], index_t input_len,

--- a/pywt/src/wt.h.src
+++ b/pywt/src/wt.h.src
@@ -9,6 +9,11 @@
 #include "convolution.h"
 #include "wavelets.h"
 
+#if defined _MSC_VER
+#define restrict __restrict
+#elif defined __GNUC__
+#define restrict __restrict__
+#endif
 
 /* _a suffix - wavelet transform approximations */
 /* _d suffix - wavelet transform details */

--- a/pywt/src/wt.h.src
+++ b/pywt/src/wt.h.src
@@ -6,9 +6,6 @@
 #ifndef _WT_H_
 #define _WT_H_
 
-#include <memory.h>
-#include <math.h>
-
 #include "common.h"
 #include "convolution.h"
 #include "wavelets.h"

--- a/pywt/src/wt.h.src
+++ b/pywt/src/wt.h.src
@@ -61,3 +61,5 @@ int @type@_swt_d(@type@ input[], index_t input_len,
                  int level);
 
 /**end repeat**/
+
+#undef restrict

--- a/pywt/src/wt.h.src
+++ b/pywt/src/wt.h.src
@@ -19,30 +19,30 @@
  */
 
 /* Single level decomposition */
-int @type@_dec_a(@type@ input[], index_t input_len,
+int @type@_dec_a(@type@ input[], size_t input_len,
                  Wavelet* wavelet,
-                 @type@ output[], index_t output_len,
+                 @type@ output[], size_t output_len,
                  MODE mode);
 
-int @type@_dec_d(@type@ input[], index_t input_len,
+int @type@_dec_d(@type@ input[], size_t input_len,
                  Wavelet* wavelet,
-                 @type@ output[], index_t output_len,
+                 @type@ output[], size_t output_len,
                  MODE mode);
 
 /* Single level reconstruction */
-int @type@_rec_a(@type@ coeffs_a[], index_t coeffs_len,
+int @type@_rec_a(@type@ coeffs_a[], size_t coeffs_len,
                  Wavelet* wavelet,
-                 @type@ output[], index_t output_len);
+                 @type@ output[], size_t output_len);
 
-int @type@_rec_d(@type@ coeffs_d[], index_t coeffs_len,
+int @type@_rec_d(@type@ coeffs_d[], size_t coeffs_len,
                  Wavelet* wavelet,
-                 @type@ output[], index_t output_len);
+                 @type@ output[], size_t output_len);
 
 /* Single level IDWT reconstruction */
-int @type@_idwt(@type@ coeffs_a[], index_t coeffs_a_len,
-                @type@ coeffs_d[], index_t coeffs_d_len,
+int @type@_idwt(@type@ coeffs_a[], size_t coeffs_a_len,
+                @type@ coeffs_d[], size_t coeffs_d_len,
                 Wavelet* wavelet,
-                @type@ output[], index_t output_len,
+                @type@ output[], size_t output_len,
                 MODE mode, int fix_size_diff);
 
 /* SWT decomposition at given level */

--- a/pywt/src/wt.h.src
+++ b/pywt/src/wt.h.src
@@ -3,8 +3,7 @@
 
 /* Wavelet transforms using convolution functions defined in convolution.h */
 
-#ifndef _WT_H_
-#define _WT_H_
+#pragma once
 
 #include "common.h"
 #include "convolution.h"
@@ -57,5 +56,3 @@ int @type@_swt_d(@type@ input[], index_t input_len,
                  int level);
 
 /**end repeat**/
-
-#endif

--- a/setup.py
+++ b/setup.py
@@ -12,8 +12,6 @@ MICRO = 0
 ISRELEASED = False
 VERSION = '%d.%d.%d' % (MAJOR, MINOR, MICRO)
 
-# GCC < 5 defaults to c99, so we need to specify c99 to these
-unix_like_compilers = ['unix', 'mingw32', 'cygwin']
 
 # Return the git revision as a string
 def git_version():
@@ -207,22 +205,12 @@ def setup_package():
             import setuptools
 
         from numpy.distutils.core import setup
-        from numpy.distutils.command.build_ext import build_ext
 
         cwd = os.path.abspath(os.path.dirname(__file__))
         if not os.path.exists(os.path.join(cwd, 'PKG-INFO')):
             # Generate Cython sources, unless building from source release
             expand_src_templates()
             generate_cython()
-
-        class build_ext_c99(build_ext):
-            def build_extensions(self):
-                if self.compiler.compiler_type in unix_like_compilers:
-                    for e in self.extensions:
-                        # No damage if specified twice
-                        e.extra_compile_args.append('-std=c99')
-                build_ext.build_extensions(self)
-        metadata['cmdclass'] = {'build_ext': build_ext_c99}
 
     metadata['configuration'] = configuration
 

--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,8 @@ MICRO = 0
 ISRELEASED = False
 VERSION = '%d.%d.%d' % (MAJOR, MINOR, MICRO)
 
+# GCC < 5 defaults to c99, so we need to specify c99 to these
+unix_like_compilers = ['unix', 'mingw32', 'cygwin']
 
 # Return the git revision as a string
 def git_version():
@@ -205,12 +207,22 @@ def setup_package():
             import setuptools
 
         from numpy.distutils.core import setup
+        from numpy.distutils.command.build_ext import build_ext
 
         cwd = os.path.abspath(os.path.dirname(__file__))
         if not os.path.exists(os.path.join(cwd, 'PKG-INFO')):
             # Generate Cython sources, unless building from source release
             expand_src_templates()
             generate_cython()
+
+        class build_ext_c99(build_ext):
+            def build_extensions(self):
+                if self.compiler.compiler_type in unix_like_compilers:
+                    for e in self.extensions:
+                        # No damage if specified twice
+                        e.extra_compile_args.append('-std=c99')
+                build_ext.build_extensions(self)
+        metadata['cmdclass'] = {'build_ext': build_ext_c99}
 
     metadata['configuration'] = configuration
 


### PR DESCRIPTION
Looking into `idwtn` I got somewhat confused by the internals of convolution.c.src. I decided to clean it up for my own benefit, and I think the result is somewhat cleaner (especially for `MODE_PERIODIZATION` cases).

Major changes are:
- Both short (`F <= N`) and long (`F > N`) signals now share the same code
  - There is now no allocation in convolution.c.src
- Loop counters are not re-used throughout a function unless necessary
  - requires -std=c99 for loop initial declarations

Minor changes:
- input arrays are restrict-qualified
  - Allows loop vectorization with -ffast-math
- Variables are const-qualified where possible
- unsigned type used for indices

Questions:
- Some lines marked FIXME/TODO are holdovers to match the original behaviour that I am not sure are correct?
- To what extent is the C-api considered stable?
  - Now that there is no allocation, it would be simple to re-define the convolution functions to be valid for all inputs (i.e. `F%2 != 0`). Size checking could be done in wt.c.src or _pywt.pyx, and they wouldn't have to worry about exceptions from C.
  - Should output sizes be checked? They are currently not, but probably should be.

I did rough measures of relative performance for both up-sampling and down-sampling convolutions, for signal lengths between 7 and 601, and filter lengths between 2 and 32. There were some changes both ways for different modes, though overall it is comparable or better in my opinion. Some examples are below.

Note also that the structure of the loops would allow addition of OpenMP relatively cleanly (though IIRC there were objections last time this was raised re scipy policy).

Down-sampling convolution performance is comparable. There are significant speed-ups for large N and F, especially `MODE_ZEROPAD`. This takes at best 0.4x as long as previously, for `N=601` and `F = 32` (the largest values tested). The worst change is `down-sampling_convolution` for `MODE_SMOOTH` and `N < F`. The worst result is for `N < 10` and `F = 32`, which takes 2.3x as long as previously. I expect this is because the short signal down-sampling convolution allocated a temporary buffer and saved the extension. If necessary, this could be implemented for all lengths of signal now.

Up-sampling convolution performance is overall better. For `N < F`, there is generally an increase. `MODE_PERIODIC` shows the largest increase, taking 0.02x (yes, 0.02x reproducibly) as long as the original for `N=8` and `F=32`, and 0.73x as long as the original for `N=31` and `F=8`. The worst is `MODE_PERIODIZATION`, which takes 1.4x as long for `N=250` and `F=32`, and 0.7x as long for `N=7 and F=12`.