### PR TITLE
MAINT: make LH, HL variable names in idwt2 consistent with dwt2

### DIFF
--- a/pywt/multidim.py
+++ b/pywt/multidim.py
@@ -36,7 +36,7 @@ def dwt2(data, wavelet, mode='sym'):
     -------
     (cA, (cH, cV, cD)) : tuple
         Approximation, horizontal detail, vertical detail and diagonal
-        detail coefficients respectively.
+        detail coefficients respectively.  Horizontal refers to array axis 0.
 
     Examples
     --------
@@ -122,7 +122,7 @@ def idwt2(coeffs, wavelet, mode='sym'):
         raise ValueError("Invalid coeffs param")
 
     # L -low-pass data, H - high-pass data
-    LL, (LH, HL, HH) = coeffs
+    LL, (HL, LH, HH) = coeffs
 
     if LL is not None:
         LL = np.transpose(LL)
@@ -151,29 +151,29 @@ def idwt2(coeffs, wavelet, mode='sym'):
 
     # idwt columns
     L = []
-    if LL is None and LH is None:
+    if LL is None and HL is None:
         L = None
     else:
         if LL is None:
             # IDWT can handle None input values - equals to zero-array
             LL = cycle([None])
-        if LH is None:
-            # IDWT can handle None input values - equals to zero-array
-            LH = cycle([None])
-        for rowL, rowH in zip(LL, LH):
-            L.append(idwt(rowL, rowH, wavelet, mode, 1))
-
-    H = []
-    if HL is None and HH is None:
-        H = None
-    else:
         if HL is None:
             # IDWT can handle None input values - equals to zero-array
             HL = cycle([None])
+        for rowL, rowH in zip(LL, HL):
+            L.append(idwt(rowL, rowH, wavelet, mode, 1))
+
+    H = []
+    if LH is None and HH is None:
+        H = None
+    else:
+        if LH is None:
+            # IDWT can handle None input values - equals to zero-array
+            LH = cycle([None])
         if HH is None:
             # IDWT can handle None input values - equals to zero-array
             HH = cycle([None])
-        for rowL, rowH in zip(HL, HH):
+        for rowL, rowH in zip(LH, HH):
             H.append(idwt(rowL, rowH, wavelet, mode, 1))
 
     if L is not None:

--- a/pywt/wavelet_packets.py
+++ b/pywt/wavelet_packets.py
@@ -441,16 +441,16 @@ class Node2D(BaseNode):
     """
     WaveletPacket tree node.
 
-    Subnodes are called 'a' (LL), 'h' (LH), 'v' (HL) and  'd' (HH), like
+    Subnodes are called 'a' (LL), 'h' (HL), 'v' (LH) and  'd' (HH), like
     approximation and detail coefficients in the 2D Discrete Wavelet Transform
     """
 
     LL = 'a'
-    LH = 'h'
-    HL = 'v'
+    HL = 'h'
+    LH = 'v'
     HH = 'd'
 
-    PARTS = LL, LH, HL, HH
+    PARTS = LL, HL, LH, HH
     PART_LEN = 1
 
     def _create_subnode(self, part, data=None, overwrite=True):
@@ -466,14 +466,14 @@ class Node2D(BaseNode):
         if self.is_empty:
             data_ll, data_lh, data_hl, data_hh = None, None, None, None
         else:
-            data_ll, (data_lh, data_hl, data_hh) =\
+            data_ll, (data_hl, data_lh, data_hh) =\
                 dwt2(self.data, self.wavelet, self.mode)
         self._create_subnode(self.LL, data_ll)
         self._create_subnode(self.LH, data_lh)
         self._create_subnode(self.HL, data_hl)
         self._create_subnode(self.HH, data_hh)
-        return (self._get_node(self.LL), self._get_node(self.LH),
-                self._get_node(self.HL), self._get_node(self.HH))
+        return (self._get_node(self.LL), self._get_node(self.HL),
+                self._get_node(self.LH), self._get_node(self.HH))
 
     def _reconstruct(self, update):
         data_ll, data_lh, data_hl, data_hh = None, None, None, None
@@ -498,7 +498,7 @@ class Node2D(BaseNode):
                 "are None. Cannot reconstruct node." % self.path
             )
         else:
-            coeffs = data_ll, (data_lh, data_hl, data_hh)
+            coeffs = data_ll, (data_hl, data_lh, data_hh)
             rec = idwt2(coeffs, self.wavelet, self.mode)
             if update:
                 self.data = rec


### PR DESCRIPTION
This swaps the LH and HL variable names internal to `idwt2` so they match the changes to the naming convention that were introduced for `dwt2` in dffa7ff
I closed #62 in which had proposed swapping the horizontal and vertical naming.  Here I have left it as in dffa7ff because that matches the existing convention in `dwtn` as well.  

A potential source of confusion is that axis 0 is 'horizontal' and axis 1 is 'vertical', but if the user views the image using matplotlib's imshow, axis 1 is the one that gets displayed horizontally.  To partially avoid the potential source of confusion, I updated the dwt2 docstring to explicitly state that "horizontal" refers to array axis 0.
