### PR TITLE
ENH: Faster dwtn and idwtn

### DIFF
--- a/pywt/multidim.py
+++ b/pywt/multidim.py
@@ -14,9 +14,11 @@ __all__ = ['dwt2', 'idwt2', 'swt2', 'dwtn', 'idwtn']
 from itertools import cycle, product, repeat, islice
 
 import numpy as np
+import warnings
 
 from ._pywt import Wavelet, MODES
-from ._pywt import dwt, idwt, swt, downcoef, upcoef
+from ._pywt import (dwt, idwt, swt, downcoef, upcoef, downcoef_lastaxis,
+                    upcoef_lastaxis)
 
 
 def dwt2(data, wavelet, mode='sym'):
@@ -195,7 +197,7 @@ def idwt2(coeffs, wavelet, mode='sym'):
     return np.array(data, np.float64)
 
 
-def dwtn(data, wavelet, mode='sym'):
+def dwtn_slow(data, wavelet, mode='sym'):
     """
     Single-level n-dimensional Discrete Wavelet Transform.
 
@@ -249,7 +251,194 @@ def dwtn(data, wavelet, mode='sym'):
     return dict(coeffs)
 
 
+def dwtn(data, wavelet, mode='sym'):
+    """
+    Single-level n-dimensional Discrete Wavelet Transform.
+    This version does the looping in C if the array is <= 4D.
+
+    Parameters
+    ----------
+    data : ndarray
+        n-dimensional array with input data.
+    wavelet : Wavelet object or name string
+        Wavelet to use.
+    mode : str, optional
+        Signal extension mode, see `MODES`.  Default is 'sym'.
+
+    Returns
+    -------
+    coeffs : dict
+        Results are arranged in a dictionary, where key specifies
+        the transform type on each dimension and value is a n-dimensional
+        coefficients array.
+
+        For example, for a 2D case the result will look something like this::
+
+            {
+                'aa': <coeffs>  # A(LL) - approx. on 1st dim, approx. on 2nd dim
+                'ad': <coeffs>  # V(LH) - approx. on 1st dim, det. on 2nd dim
+                'da': <coeffs>  # H(HL) - det. on 1st dim, approx. on 2nd dim
+                'dd': <coeffs>  # D(HH) - det. on 1st dim, det. on 2nd dim
+            }
+
+    """
+    data = np.asarray(data)
+    dim = data.ndim
+    if dim < 1:
+        raise ValueError("Input data must be at least 1D")
+    if dim > 4:
+        warnings.warn("not implemented for >4D.  falling back to slower "
+                      "nD version")
+        return dwtn_slow(data, wavelet=wavelet, mode=mode)
+
+    # have to upgrade integer types to float
+    if data.dtype != np.float32:
+        data = np.asarray(data, dtype=np.float64)
+
+    # add new axes up to 4D for compatibility with the cython code
+    npad = 0
+    while data.ndim < 4:
+        data = np.ascontiguousarray(data[np.newaxis, ...])
+        npad += 1
+    ndim = data.ndim
+
+    coeffs = [('', data)]
+    for axis in range(npad, ndim):
+        new_coeffs = []
+        for subband, x in coeffs:
+            if axis < ndim:
+                x = np.ascontiguousarray(np.swapaxes(x, axis, -1))
+            a = downcoef_lastaxis('a', x, wavelet=wavelet, mode=mode, level=1)
+            d = downcoef_lastaxis('d', x, wavelet=wavelet, mode=mode, level=1)
+            if axis < ndim:
+                a = np.ascontiguousarray(np.swapaxes(a, -1, axis))
+                d = np.ascontiguousarray(np.swapaxes(d, -1, axis))
+            new_coeffs.extend([(subband + 'a', a), (subband + 'd', d)])
+        coeffs = new_coeffs
+
+    coeff_dict = dict(coeffs)
+    if dim < ndim:
+        # remove any extra singleton dimensions that were added
+        for k, v in coeff_dict.items():
+            coeff_dict[k] = v.reshape(v.shape[npad:], order='C')
+    return coeff_dict
+
+
 def idwtn(coeffs, wavelet, mode='sym', take=None):
+    """
+    Single-level n-dimensional Discrete Wavelet Transform.
+
+    Parameters
+    ----------
+    coeffs: dict
+        Dictionary as in output of `dwtn`. Missing or None items
+        will be treated as zeroes.
+    wavelet : Wavelet object or name string
+        Wavelet to use
+    mode : str, optional
+        Signal extension mode used in the decomposition,
+        see MODES (default: 'sym'). Overridden by `take`.
+    take : int or iterable of int or None, optional
+        Number of values to take from the center of the idwtn for each axis.
+        If 0, the entire reverse transformation will be used, including
+        parts generated from padding in the forward transform.
+        If None (default), will be calculated from `mode` to be the size of the
+        original data, rounded up to the nearest multiple of 2.
+        Passed to `upcoef`.
+
+    Returns
+    -------
+    data: ndarray
+        Original signal reconstructed from input data.
+
+    """
+    if not isinstance(wavelet, Wavelet):
+        wavelet = Wavelet(wavelet)
+    mode = MODES.from_object(mode)
+
+    # Ignore any invalid keys
+    coeffs = dict((k, v) for k, v in coeffs.items() if set(k) <= set('ad'))
+    dims = max(len(key) for key in coeffs.keys())
+
+    if dims > 4:
+        warnings.warn("not implemented for >4D.  falling back to slower "
+                      "nD version")
+        return idwtn_slow(coeffs, wavelet=wavelet, mode=mode, take=take)
+
+    try:
+        coeff_shapes = (v.shape for k, v in coeffs.items()
+                        if v is not None and len(k) == dims)
+        coeff_shape = next(coeff_shapes)
+    except StopIteration:
+        raise ValueError("`coeffs` must contain at least one non-null wavelet "
+                         "band")
+    if any(s != coeff_shape for s in coeff_shapes):
+        raise ValueError("`coeffs` must all be of equal size (or None)")
+
+    if take is not None:
+        try:
+            takes = list(islice(take, dims))
+            takes.reverse()
+        except TypeError:
+            takes = repeat(take, dims)
+    else:
+        # As in src/common.c
+        if mode == MODES.per:
+            takes = [2*s for s in reversed(coeff_shape)]
+        else:
+            takes = [2*s - wavelet.rec_len + 2 for s in reversed(coeff_shape)]
+
+    ndim = 4  # cython set up for 4D case
+    npad = ndim - dims
+    for axis, take in zip(reversed(range(npad, ndim)), takes):
+        new_coeffs = {}
+        new_keys = [''.join(coeff) for coeff in product('ad', repeat=(axis-npad))]
+        for key in new_keys:
+            L = coeffs.get(key + 'a')
+            H = coeffs.get(key + 'd')
+            # add new axes up to 4D for compatibility with the cython code
+            if L is not None:
+                while L.ndim < ndim:
+                    L = L[np.newaxis, ...]
+                if axis < ndim:
+                    L = np.swapaxes(L, axis, -1)
+                L = np.ascontiguousarray(L)
+                # L = np.apply_along_axis(_upcoef, axis, L, wavelet, take, 'a')
+                L = upcoef_lastaxis('a', L, wavelet=wavelet, level=1,
+                                    take=take)
+                if axis < ndim:
+                    L = np.swapaxes(L, -1, axis)
+            if H is not None:
+                while H.ndim < ndim:
+                    H = H[np.newaxis, ...]
+                if axis < ndim:
+                    H = np.swapaxes(H, axis, -1)
+                H = np.ascontiguousarray(H)
+                # H = np.apply_along_axis(_upcoef, axis, H, wavelet, take, 'd')
+                H = upcoef_lastaxis('d', H, wavelet=wavelet, level=1,
+                                    take=take)
+                if axis < ndim:
+                    H = np.swapaxes(H, -1, axis)
+            if H is None and L is None:
+                new_coeffs[key] = None
+            elif H is None:
+                new_coeffs[key] = L
+            elif L is None:
+                new_coeffs[key] = H
+            else:
+                new_coeffs[key] = L + H
+            if not (H is None and L is None):
+                if dims < ndim:
+                    new_coeffs[key] = np.ascontiguousarray(
+                        new_coeffs[key].reshape(new_coeffs[key].shape[npad:],
+                                                order='C'))
+
+        coeffs = new_coeffs
+
+    return coeffs['']
+
+
+def idwtn_slow(coeffs, wavelet, mode='sym', take=None):
     """
     Single-level n-dimensional Discrete Wavelet Transform.
 

--- a/pywt/multidim.py
+++ b/pywt/multidim.py
@@ -198,7 +198,6 @@ def idwt2(coeffs, wavelet, mode='sym'):
 def dwtn(data, wavelet, mode='sym'):
     """
     Single-level n-dimensional Discrete Wavelet Transform.
-    This version does the looping in C if the array is <= 4D.
 
     Parameters
     ----------
@@ -310,7 +309,6 @@ def idwtn(coeffs, wavelet, mode='sym', take=None):
         for key in new_keys:
             L = coeffs.get(key + 'a')
             H = coeffs.get(key + 'd')
-            # add new axes up to 4D for compatibility with the cython code
             if L is not None:
                 L = upcoef('a', L, wavelet=wavelet, level=1, take=take,
                            axis=axis)

--- a/pywt/multidim.py
+++ b/pywt/multidim.py
@@ -17,8 +17,7 @@ import numpy as np
 import warnings
 
 from ._pywt import Wavelet, MODES
-from ._pywt import (dwt, idwt, swt, downcoef, upcoef, downcoef_lastaxis,
-                    upcoef_lastaxis)
+from ._pywt import (dwt, idwt, swt, downcoef, upcoef)
 
 
 def dwt2(data, wavelet, mode='sym'):
@@ -232,43 +231,19 @@ def dwtn(data, wavelet, mode='sym'):
     dim = data.ndim
     if dim < 1:
         raise ValueError("Input data must be at least 1D")
-    if dim != 2:
-        do_reshape = True
-    else:
-        do_reshape = False
 
     # have to upgrade integer types to float
     if data.dtype != np.float32:
         data = np.asarray(data, dtype=np.float64)
 
-    if dim == 1:
-        # will add new axis in 1D for compatibility with the cython code
-        npad = 1
-    else:
-        npad = 0
-
     coeffs = [('', data)]
     for axis in range(dim):
         new_coeffs = []
         for subband, x in coeffs:
-            if axis < (dim - 1):
-                # place axis to filter last so it will be contiguous
-                x = np.swapaxes(x, axis, -1)
-            if do_reshape:
-                # reshape all other axes into the first dimension of a 2D array
-                orig_shape = x.shape
-                x = x.reshape((-1, x.shape[-1]), order='C')
-            x = np.ascontiguousarray(x)
-            a = downcoef_lastaxis('a', x, wavelet=wavelet, mode=mode, level=1)
-            d = downcoef_lastaxis('d', x, wavelet=wavelet, mode=mode, level=1)
-            if do_reshape:
-                # restore original number of dimensions
-                a = a.reshape(orig_shape[npad:-1] + (a.shape[-1], ), order='C')
-                d = d.reshape(orig_shape[npad:-1] + (a.shape[-1], ), order='C')
-            if axis < (dim - 1):
-                # swap axes back to their original order
-                a = np.ascontiguousarray(np.swapaxes(a, -1, axis))
-                d = np.ascontiguousarray(np.swapaxes(d, -1, axis))
+            a = downcoef('a', x, wavelet=wavelet, mode=mode, level=1,
+                         axis=axis)
+            d = downcoef('d', x, wavelet=wavelet, mode=mode, level=1,
+                         axis=axis)
             new_coeffs.extend([(subband + 'a', a), (subband + 'd', d)])
         coeffs = new_coeffs
     return dict(coeffs)
@@ -333,56 +308,21 @@ def idwtn(coeffs, wavelet, mode='sym', take=None):
         else:
             takes = [2*s - wavelet.rec_len + 2 for s in reversed(coeff_shape)]
 
-    if dims == 1:
-        # an extra dimension will have to be added for the 1D case
-        npad = 1
-    else:
-        npad = 0
-    if dims != 2:
-        do_reshape = True
-    else:
-        do_reshape = False
-    lastaxis = dims - 1
     for axis, take in zip(reversed(range(dims)), takes):
         new_coeffs = {}
         new_keys = \
             [''.join(coeff) for coeff in product('ad', repeat=axis)]
         for key in new_keys:
             L = coeffs.get(key + 'a')
+            print(L.shape)
             H = coeffs.get(key + 'd')
             # add new axes up to 4D for compatibility with the cython code
             if L is not None:
-                if axis < lastaxis:
-                    L = np.swapaxes(L, axis, -1)
-                if do_reshape:
-                    orig_shape_L = L.shape
-                    L = L.reshape((-1, L.shape[-1]), order='C')
-                L = np.ascontiguousarray(L)
-                # L = np.apply_along_axis(_upcoef, axis, L, wavelet, take, 'a')
-                L = upcoef_lastaxis('a', L, wavelet=wavelet, level=1,
-                                    take=take)
-                L = np.ascontiguousarray(L)
-                if do_reshape:
-                    L = L.reshape(orig_shape_L[npad:-1] + (L.shape[-1], ),
-                                  order='C')
-                if axis < lastaxis:
-                    L = np.swapaxes(L, -1, axis)
+                L = upcoef('a', L, wavelet=wavelet, level=1, take=take,
+                           axis=axis)
             if H is not None:
-                if axis < lastaxis:
-                    H = np.swapaxes(H, axis, -1)
-                if do_reshape:
-                    orig_shape_H = H.shape
-                    H = H.reshape((-1, H.shape[-1]), order='C')
-                H = np.ascontiguousarray(H)
-                # H = np.apply_along_axis(_upcoef, axis, H, wavelet, take, 'd')
-                H = upcoef_lastaxis('d', H, wavelet=wavelet, level=1,
-                                    take=take)
-                H = np.ascontiguousarray(H)
-                if do_reshape:
-                    H = H.reshape(orig_shape_H[npad:-1] + (H.shape[-1], ),
-                                  order='C')
-                if axis < lastaxis:
-                    H = np.swapaxes(H, -1, axis)
+                H = upcoef('d', H, wavelet=wavelet, level=1, take=take,
+                           axis=axis)
             if H is None and L is None:
                 new_coeffs[key] = None
             elif H is None:
@@ -391,7 +331,6 @@ def idwtn(coeffs, wavelet, mode='sym', take=None):
                 new_coeffs[key] = H
             else:
                 new_coeffs[key] = L + H
-
         coeffs = new_coeffs
 
     return coeffs['']

--- a/pywt/multidim.py
+++ b/pywt/multidim.py
@@ -314,7 +314,6 @@ def idwtn(coeffs, wavelet, mode='sym', take=None):
             [''.join(coeff) for coeff in product('ad', repeat=axis)]
         for key in new_keys:
             L = coeffs.get(key + 'a')
-            print(L.shape)
             H = coeffs.get(key + 'd')
             # add new axes up to 4D for compatibility with the cython code
             if L is not None:

--- a/pywt/multidim.py
+++ b/pywt/multidim.py
@@ -14,10 +14,9 @@ __all__ = ['dwt2', 'idwt2', 'swt2', 'dwtn', 'idwtn']
 from itertools import cycle, product, repeat, islice
 
 import numpy as np
-import warnings
 
 from ._pywt import Wavelet, MODES
-from ._pywt import (dwt, idwt, swt, downcoef, upcoef)
+from ._pywt import dwt, idwt, swt, downcoef, upcoef
 
 
 def dwt2(data, wavelet, mode='sym'):
@@ -231,10 +230,6 @@ def dwtn(data, wavelet, mode='sym'):
     dim = data.ndim
     if dim < 1:
         raise ValueError("Input data must be at least 1D")
-
-    # have to upgrade integer types to float
-    if data.dtype != np.float64:
-        data = np.asarray(data, dtype=np.float64)
 
     coeffs = [('', data)]
     for axis in range(dim):

--- a/pywt/multidim.py
+++ b/pywt/multidim.py
@@ -233,7 +233,7 @@ def dwtn(data, wavelet, mode='sym'):
         raise ValueError("Input data must be at least 1D")
 
     # have to upgrade integer types to float
-    if data.dtype != np.float32:
+    if data.dtype != np.float64:
         data = np.asarray(data, dtype=np.float64)
 
     coeffs = [('', data)]

--- a/pywt/setup.py
+++ b/pywt/setup.py
@@ -15,6 +15,8 @@ def configuration(parent_package='', top_path=None):
         '_pywt',
         sources=["src/_pywt.c", "src/common.c", "src/convolution.c",
                  "src/wavelets.c", "src/wt.c"],
+        # extra_compile_args=['-fopenmp'],
+        # extra_link_args=['-fopenmp'],
         include_dirs=["src", np.get_include()],
         define_macros=[("PY_EXTENSION", None)],
     )

--- a/pywt/setup.py
+++ b/pywt/setup.py
@@ -15,8 +15,6 @@ def configuration(parent_package='', top_path=None):
         '_pywt',
         sources=["src/_pywt.c", "src/common.c", "src/convolution.c",
                  "src/wavelets.c", "src/wt.c"],
-        # extra_compile_args=['-fopenmp'],
-        # extra_link_args=['-fopenmp'],
         include_dirs=["src", np.get_include()],
         define_macros=[("PY_EXTENSION", None)],
     )

--- a/pywt/src/_pywt.pyx
+++ b/pywt/src/_pywt.pyx
@@ -993,18 +993,11 @@ def _upcoef(part, np.ndarray[data_t, ndim=1, mode="c"] coeffs, wavelet,
     for i from 0 <= i < level:
         # output len
         rec_len = c_wt.reconstruction_buffer_length(coeffs.size, w.dec_len)
-        # print("rec_len = {}".format(rec_len))
-        # print("coeffs_len = {}".format(coeffs.size))
-        # print("coeffs.__array_interface__['data']={}".format(coeffs.__array_interface__['data']))
-        # print("coeffs={}".format(coeffs))
-        # print("coeffs.flags = {}".format(coeffs.flags))
         if rec_len < 1:
             raise RuntimeError("Invalid output length.")
 
         # reconstruct
         rec = np.zeros(rec_len, dtype=coeffs.dtype)
-        # print("rec_pre.__array_interface__['data']={}".format(rec.__array_interface__['data']))
-        # print("rec_pre={}".format(rec))
         if do_rec_a:
             if data_t is np.float64_t:
                 if c_wt.double_rec_a(&coeffs[0], coeffs.size, w.w,
@@ -1030,8 +1023,6 @@ def _upcoef(part, np.ndarray[data_t, ndim=1, mode="c"] coeffs, wavelet,
             do_rec_a = 1
 
         # TODO: this algorithm needs some explaining
-        # print("rec_post.__array_interface__['data']={}".format(rec.__array_interface__['data']))
-        # print("rec_post={}".format(rec))
         coeffs = rec
 
     if take > 0 and take < rec_len:
@@ -1242,9 +1233,6 @@ def _downcoef_lastaxis(part, data_t[:, ::1] data, object wavelet,
     the other axis.
     """
     coeffs = np.zeros((nfilt, output_len), dtype=arr_dtype, order='C')
-    # TODO: use of prange made it much slower.  why?
-    # with nogil, parallel():
-    #     for x in prange(nfilt):
     for x in range(nfilt):
         _downcoef(do_dec_a, &data[x,  0], data_len, &coeffs[x, 0],
                   output_len, wav, mode_, level)

--- a/pywt/src/_pywt.pyx
+++ b/pywt/src/_pywt.pyx
@@ -1094,7 +1094,7 @@ cdef void _upcoef_v2(int do_rec_a, data_t *coeffs, c_wt.index_t coeff_len,
     if do_rec_a:
         if data_t is np.float64_t:
             if c_wt.double_rec_a(coeffs, coeff_len, w,
-                                  rec, rec_len) < 0:
+                                 rec, rec_len) < 0:
                 with gil:
                     raise RuntimeError("C double_rec_a failed.")
 
@@ -1207,12 +1207,9 @@ def _downcoef_lastaxis(part, data_t[:, ::1] data, object wavelet,
         int axis = -1
         c_wt.index_t output_len
 
-    dt = _check_dtype(data)
-    data = np.array(data, dtype=dt)
-    _try_mode(mode)
     w = c_wavelet_from_object(wavelet)
     wav = w.w
-    mode_ = MODES.from_object(mode)
+    mode_ = _try_mode(mode)
     if (part == 'a'):
         do_dec_a = 1
     else:

--- a/pywt/src/_pywt.pyx
+++ b/pywt/src/_pywt.pyx
@@ -1209,7 +1209,7 @@ def _downcoef_lastaxis(part, data_t[:, ::1] data, object wavelet,
 
     dt = _check_dtype(data)
     data = np.array(data, dtype=dt)
-    _check_mode_input(mode)
+    _try_mode(mode)
     w = c_wavelet_from_object(wavelet)
     wav = w.w
     mode_ = MODES.from_object(mode)

--- a/pywt/src/_pywt.pyx
+++ b/pywt/src/_pywt.pyx
@@ -963,7 +963,8 @@ def upcoef(part, coeffs, wavelet, level=1, take=0, axis=-1):
         rec = _upcoef_lastaxis(part, coeffs, wavelet, level, take)
 
         # restore original dimensions
-        rec = rec.reshape(original_shape[npad:-1] + (rec.shape[-1], ), order='C')
+        rec = rec.reshape(original_shape[npad:-1] + (rec.shape[-1], ),
+                          order='C')
 
         # restore original axis order
         if axis != lastaxis:
@@ -1116,10 +1117,9 @@ cdef void _upcoef_v2(int do_rec_a, data_t *coeffs, c_wt.index_t coeff_len,
     return
 
 
-# TODO: depricate this function
 def downcoef(part, data, wavelet, mode='sym', level=1, axis=-1):
     """
-    downcoef(part, data, wavelet, mode='sym', level=1)
+    downcoef(part, data, wavelet, mode='sym', level=1, axis=-1)
 
     Partial Discrete Wavelet Transform data decomposition.
 

--- a/pywt/src/_pywt.pyx
+++ b/pywt/src/_pywt.pyx
@@ -3,8 +3,8 @@
 
 __doc__ = """Pyrex wrapper for low-level C wavelet transform implementation."""
 __all__ = ['MODES', 'Wavelet', 'dwt', 'dwt_coeff_len', 'dwt_max_level',
-           'idwt', 'swt', 'swt_max_level', 'upcoef', 'downcoef',
-           'upcoef_lastaxis', 'downcoef_lastaxis', 'wavelist', 'families']
+           'idwt', 'swt', 'swt_max_level', 'upcoef', 'downcoef', 'wavelist',
+           'families']
 
 ###############################################################################
 # imports
@@ -882,9 +882,9 @@ def _idwt(np.ndarray[data_t, ndim=1, mode="c"] cA,
 # upcoef & downcoef
 
 
-def upcoef(part, coeffs, wavelet, level=1, take=0):
+def upcoef(part, coeffs, wavelet, level=1, take=0, axis=-1):
     """
-    upcoef(part, coeffs, wavelet, level=1, take=0)
+    upcoef(part, coeffs, wavelet, level=1, take=0, axis=-1)
 
     Direct reconstruction from coefficients.
 
@@ -895,7 +895,8 @@ def upcoef(part, coeffs, wavelet, level=1, take=0):
         * 'a' - approximations reconstruction is performed
         * 'd' - details reconstruction is performed
     coeffs : array_like
-        Coefficients array to recontruct
+        Coefficients array to recontruct.  Reconstruction is performed only
+        along the specified axis of the array (default=last).
     wavelet : Wavelet object or name
         Wavelet to use
     level : int, optional
@@ -903,15 +904,17 @@ def upcoef(part, coeffs, wavelet, level=1, take=0):
     take : int, optional
         Take central part of length equal to 'take' from the result.
         Default is 0.
+    axis : integer
+        Axis along which the reconstruction is applied.
 
     Returns
     -------
     rec : ndarray
-        1-D array with reconstructed data from coefficients.
+        n-D array with reconstructed data from coefficients.
 
     See Also
     --------
-    downcoef_lastaxis
+    downcoef
 
     Examples
     --------
@@ -926,10 +929,47 @@ def upcoef(part, coeffs, wavelet, level=1, take=0):
     [ 1.  2.  3.  4.  5.  6.]
 
     """
+    if level < 1:
+        raise ValueError("Value of level must be greater than 0.")
     # accept array_like input; make a copy to ensure a contiguous array
     dt = _check_dtype(coeffs)
     coeffs = np.array(coeffs, dtype=dt)
-    return _upcoef(part, coeffs, wavelet, level, take)
+    if level > 1:
+        return _upcoef(part, coeffs, wavelet, level, take)
+    else:
+        # TODO: fix this code for level > 1 case to remove need for the old
+        # _upcoef function
+        if axis < 0:
+            axis = coeffs.ndim + axis
+        if coeffs.ndim == 1:
+            npad = 1
+            coeffs = coeffs[np.newaxis, :]
+            axis += npad
+        else:
+            npad = 0
+        ndim = coeffs.ndim
+        lastaxis = ndim - 1
+
+        # axis to filter must come last
+        if axis != lastaxis:
+            coeffs = np.swapaxes(coeffs, axis, -1)
+
+        # _upcoef_lastaxis requires a 2D contiguous input
+        original_shape = coeffs.shape
+        coeffs = coeffs.reshape((-1, coeffs.shape[-1]), order='C')
+        coeffs = np.ascontiguousarray(coeffs)
+
+        # call cython function to filter along last axis
+        rec = _upcoef_lastaxis(part, coeffs, wavelet, level, take)
+
+        # restore original dimensions
+        rec = rec.reshape(original_shape[npad:-1] + (rec.shape[-1], ), order='C')
+
+        # restore original axis order
+        if axis != lastaxis:
+            rec = np.swapaxes(rec, -1, axis)
+
+    return np.ascontiguousarray(rec)
 
 
 def _upcoef(part, np.ndarray[data_t, ndim=1, mode="c"] coeffs, wavelet,
@@ -953,12 +993,18 @@ def _upcoef(part, np.ndarray[data_t, ndim=1, mode="c"] coeffs, wavelet,
     for i from 0 <= i < level:
         # output len
         rec_len = c_wt.reconstruction_buffer_length(coeffs.size, w.dec_len)
+        # print("rec_len = {}".format(rec_len))
+        # print("coeffs_len = {}".format(coeffs.size))
+        # print("coeffs.__array_interface__['data']={}".format(coeffs.__array_interface__['data']))
+        # print("coeffs={}".format(coeffs))
+        # print("coeffs.flags = {}".format(coeffs.flags))
         if rec_len < 1:
             raise RuntimeError("Invalid output length.")
 
         # reconstruct
         rec = np.zeros(rec_len, dtype=coeffs.dtype)
-
+        # print("rec_pre.__array_interface__['data']={}".format(rec.__array_interface__['data']))
+        # print("rec_pre={}".format(rec))
         if do_rec_a:
             if data_t is np.float64_t:
                 if c_wt.double_rec_a(&coeffs[0], coeffs.size, w.w,
@@ -984,6 +1030,8 @@ def _upcoef(part, np.ndarray[data_t, ndim=1, mode="c"] coeffs, wavelet,
             do_rec_a = 1
 
         # TODO: this algorithm needs some explaining
+        # print("rec_post.__array_interface__['data']={}".format(rec.__array_interface__['data']))
+        # print("rec_post={}".format(rec))
         coeffs = rec
 
     if take > 0 and take < rec_len:
@@ -1000,42 +1048,12 @@ def _upcoef(part, np.ndarray[data_t, ndim=1, mode="c"] coeffs, wavelet,
 @cython.wraparound(False)
 @cython.boundscheck(False)
 @cython.cdivision(True)
-def upcoef_lastaxis(part, data_t[:, ::1] coeffs, object  wavelet, int level=1, int take=0):
+def _upcoef_lastaxis(part, data_t[:, ::1] coeffs, object wavelet, level=1,
+                     int take=0):
     """
-    upcoef(part, coeffs, wavelet, level=1, take=0)
-
-    Direct reconstruction from coefficients.
-
-    Parameters
-    ----------
-    part : str
-        Coefficients type:
-        * 'a' - approximations reconstruction is performed
-        * 'd' - details reconstruction is performed
-    coeffs : array_like
-        Coefficients array to recontruct
-    wavelet : Wavelet object or name
-        Wavelet to use
-    level : int, optional
-        Multilevel reconstruction level.  Default is 1.
-    take : int, optional
-        Take central part of length equal to 'take' from the result.
-        Default is 0.
-
-    Returns
-    -------
-    rec : ndarray
-        1-D array with reconstructed data from coefficients.
-
-    See Also
-    --------
-    downcoef
-
+    called by upcoef to quickly loop over the first dimension of the coeffs
+    array.
     """
-    # # accept array_like input; make a copy to ensure a contiguous array
-    # dt = _check_dtype(coeffs)
-    # coeffs = np.array(coeffs, dtype=dt)
-    # return _upcoef(part, coeffs, wavelet, level, take)
     cdef:
         Wavelet w
         c_wt.Wavelet* wav
@@ -1044,46 +1062,36 @@ def upcoef_lastaxis(part, data_t[:, ::1] coeffs, object  wavelet, int level=1, i
         int nfilt = coeffs.shape[0]
         int axis = -1
         c_wt.index_t coeff_len, rec_len, left_bound, right_bound
-
     w = c_wavelet_from_object(wavelet)
+    if level < 1:
+        raise ValueError("Value of level must be greater than 0.")
     wav = w.w
     if (part == 'a'):
         do_rec_a = 1
     else:
         do_rec_a = 0
-
     if part not in ('a', 'd'):
         raise ValueError("Argument 1 must be 'a' or 'd', not '%s'." % part)
-    if level < 1:
-        raise ValueError("Value of level must be greater than 0.")
-
-    coeff_len = coeffs.shape[1]
-    rec_len = c_wt.reconstruction_buffer_length(coeff_len, w.dec_len)
-    if rec_len < 1:
-        raise RuntimeError("Invalid output length.")
-
     if data_t is np.float64_t:
         arr_dtype = np.float64
     elif data_t is np.float32_t:
         arr_dtype = np.float32
+    for lev in range(level):
+        rec_len = c_wt.reconstruction_buffer_length(coeffs.shape[1], w.dec_len)
+        if rec_len < 1:
+            raise RuntimeError("Invalid output length.")
 
-    rec = np.zeros((nfilt, rec_len), dtype=arr_dtype, order='C')
-    # TODO: use of prange made it much slower.  why?
-    # with nogil, parallel():
-    #     for x in prange(nfilt):
-    for x in range(nfilt):
-        _upcoef_v2(do_rec_a, &coeffs[x, 0], coeff_len, &rec[x, 0], rec_len,
-                   wav)
-
-    rec = np.asarray(rec)
+        rec = np.zeros((nfilt, rec_len), dtype=arr_dtype, order='C')
+        for x in range(nfilt):
+            _upcoef_v2(do_rec_a, &coeffs[x, 0], coeffs.shape[1], &rec[x, 0],
+                       rec_len, wav)
+        coeffs = rec.copy()
     if take > 0 and take < rec_len:
         left_bound = right_bound = (rec_len-take) // 2
         if (rec_len-take) % 2:
-            # right_bound must never be zero for indexing to work
             right_bound = right_bound + 1
-
-        return rec[..., left_bound:-right_bound]
-    return rec
+        return np.asarray(rec[..., left_bound:-right_bound])
+    return np.asarray(rec)
 
 
 @cython.wraparound(False)
@@ -1091,8 +1099,6 @@ def upcoef_lastaxis(part, data_t[:, ::1] coeffs, object  wavelet, int level=1, i
 @cython.cdivision(True)
 cdef void _upcoef_v2(int do_rec_a, data_t *coeffs, c_wt.index_t coeff_len,
                      data_t *rec, c_wt.index_t rec_len, c_wt.Wavelet* w) nogil:
-    # hardcoded at level = 1 only for this case
-    cdef c_wt.index_t left_bound, right_bound
     if do_rec_a:
         if data_t is np.float64_t:
             if c_wt.double_rec_a(coeffs, coeff_len, w,
@@ -1120,7 +1126,7 @@ cdef void _upcoef_v2(int do_rec_a, data_t *coeffs, c_wt.index_t coeff_len,
 
 
 # TODO: depricate this function
-def downcoef(part, data, wavelet, mode='sym', level=1):
+def downcoef(part, data, wavelet, mode='sym', level=1, axis=-1):
     """
     downcoef(part, data, wavelet, mode='sym', level=1)
 
@@ -1138,18 +1144,21 @@ def downcoef(part, data, wavelet, mode='sym', level=1):
         * 'd' - details reconstruction is performed
 
     data : array_like
-        Input signal.
+        Input signal.  The decomposition is only performed along the specified
+        axis (default=last).
     wavelet : Wavelet object or name
         Wavelet to use
     mode : str, optional
         Signal extension mode, see `MODES`.  Default is 'sym'.
     level : int, optional
         Decomposition level.  Default is 1.
+    axis : integer
+        Axis along which the decomposition is applied.
 
     Returns
     -------
     coeffs : ndarray
-        1-D array of coefficients.
+        n-D array of coefficients.
 
     See Also
     --------
@@ -1159,100 +1168,44 @@ def downcoef(part, data, wavelet, mode='sym', level=1):
     # accept array_like input; make a copy to ensure a contiguous array
     dt = _check_dtype(data)
     data = np.array(data, dtype=dt)
-    return _downcoef(part, data, wavelet, mode, level)
+    if axis < 0:
+        axis = data.ndim + axis
+    if data.ndim == 1:
+        npad = 1
+        data = data[np.newaxis, :]
+        axis += npad
+    else:
+        npad = 0
+    ndim = data.ndim
+    lastaxis = ndim - 1
 
+    # axis to filter must come last
+    if axis != lastaxis:
+        data = np.swapaxes(data, axis, -1)
 
-# TODO: depricate this function
-def _downcoef(part, np.ndarray[data_t, ndim=1, mode="c"] data,
-              object wavelet, object mode='sym', int level=1):
-    cdef np.ndarray[data_t, ndim=1, mode="c"] coeffs
-    cdef int i, do_dec_a
-    cdef index_t dec_len
-    cdef Wavelet w
-    cdef c_wt.MODE mode_
+    # _downcoef_lastaxis requires a 2D contiguous input
+    original_shape = data.shape
+    data = data.reshape((-1, data.shape[-1]), order='C')
+    data = np.ascontiguousarray(data)
 
-    _check_mode_input(mode)
-    w = c_wavelet_from_object(wavelet)
-    mode_ = MODES.from_object(mode)
+    # call cython function to filter along last axis
+    coeffs = _downcoef_lastaxis(part, data, wavelet, mode, level)
 
-    if part not in ('a', 'd'):
-        raise ValueError("Argument 1 must be 'a' or 'd', not '%s'." % part)
-    do_dec_a = (part == 'a')
-
-    if level < 1:
-        raise ValueError("Value of level must be greater than 0.")
-
-    for i from 0 <= i < level:
-        output_len = c_wt.dwt_buffer_length(data.size, w.dec_len, mode_)
-        if output_len < 1:
-            raise RuntimeError("Invalid output length.")
-        coeffs = np.zeros(output_len, dtype=data.dtype)
-
-        if do_dec_a:
-            if data_t is np.float64_t:
-                if c_wt.double_dec_a(&data[0], data.size, w.w,
-                                     &coeffs[0], coeffs.size, mode_) < 0:
-                    raise RuntimeError("C dec_a failed.")
-            elif data_t is np.float32_t:
-                if c_wt.float_dec_a(&data[0], data.size, w.w,
-                                    &coeffs[0], coeffs.size, mode_) < 0:
-                    raise RuntimeError("C dec_a failed.")
-            else:
-                raise RuntimeError("Invalid data type.")
-        else:
-            if data_t is np.float64_t:
-                if c_wt.double_dec_d(&data[0], data.size, w.w,
-                                     &coeffs[0], coeffs.size, mode_) < 0:
-                    raise RuntimeError("C dec_a failed.")
-            elif data_t is np.float32_t:
-                if c_wt.float_dec_d(&data[0], data.size, w.w,
-                                    &coeffs[0], coeffs.size, mode_) < 0:
-                    raise RuntimeError("C dec_a failed.")
-            else:
-                raise RuntimeError("Invalid data type.")
-
+    # restore original dimensions
+    coeffs = coeffs.reshape(original_shape[npad:-1] + (coeffs.shape[-1], ),
+                            order='C')
+    # restore original axis order
+    if axis != lastaxis:
+        coeffs = np.swapaxes(coeffs, -1, axis)
     return coeffs
 
 
 @cython.wraparound(False)
 @cython.boundscheck(False)
 @cython.cdivision(True)
-def downcoef_lastaxis(part, data_t[:, ::1] data, object wavelet, object mode='sym', int level=1):
-    """
-    downcoef(part, data, wavelet, mode='sym', level=1)
-
-    Partial Discrete Wavelet Transform data decomposition.
-
-    Similar to `pywt.dwt`, but computes only one set of coefficients.
-    Useful when you need only approximation or only details at the given level.
-
-    Parameters
-    ----------
-    part : str
-        Coefficients type:
-
-        * 'a' - approximations reconstruction is performed
-        * 'd' - details reconstruction is performed
-
-    data : array_like
-        Input signal.
-    wavelet : Wavelet object or name
-        Wavelet to use
-    mode : str, optional
-        Signal extension mode, see `MODES`.  Default is 'sym'.
-    level : int, optional
-        Decomposition level.  Default is 1.
-
-    Returns
-    -------
-    coeffs : ndarray
-        1-D array of coefficients.
-
-    See Also
-    --------
-    upcoef
-
-    """
+def _downcoef_lastaxis(part, data_t[:, ::1] data, object wavelet,
+                       object mode='sym', int level=1):
+    """ Used by downcoef to quickly loop over the first dimension of data."""
     cdef:
         Wavelet w
         c_wt.MODE mode_
@@ -1263,6 +1216,8 @@ def downcoef_lastaxis(part, data_t[:, ::1] data, object wavelet, object mode='sy
         int axis = -1
         c_wt.index_t output_len
 
+    dt = _check_dtype(data)
+    data = np.array(data, dtype=dt)
     _check_mode_input(mode)
     w = c_wavelet_from_object(wavelet)
     wav = w.w
@@ -1271,22 +1226,18 @@ def downcoef_lastaxis(part, data_t[:, ::1] data, object wavelet, object mode='sy
         do_dec_a = 1
     else:
         do_dec_a = 0
-
     if part not in ('a', 'd'):
         raise ValueError("Argument 1 must be 'a' or 'd', not '%s'." % part)
     if level < 1:
         raise ValueError("Value of level must be greater than 0.")
-
     data_len = data.shape[1]
     output_len = c_wt.dwt_buffer_length(data_len, w.dec_len, mode_)
     if output_len < 1:
         raise RuntimeError("Invalid output length.")
-
     if data_t is np.float64_t:
         arr_dtype = np.float64
     elif data_t is np.float32_t:
         arr_dtype = np.float32
-
     """ Can filter over the last axis because it is contiguous.  Loop over
     the other axis.
     """
@@ -1295,17 +1246,17 @@ def downcoef_lastaxis(part, data_t[:, ::1] data, object wavelet, object mode='sy
     # with nogil, parallel():
     #     for x in prange(nfilt):
     for x in range(nfilt):
-        _downcoef_v2(do_dec_a, &data[x,  0], data_len, &coeffs[x, 0],
-                     output_len, wav, mode_, level)
+        _downcoef(do_dec_a, &data[x,  0], data_len, &coeffs[x, 0],
+                  output_len, wav, mode_, level)
     return np.asarray(coeffs)
 
 
 @cython.wraparound(False)
 @cython.boundscheck(False)
 @cython.cdivision(True)
-cdef void _downcoef_v2(int do_dec_a, data_t *data, c_wt.index_t data_len,
-                       data_t *coeffs, c_wt.index_t output_len,
-                       c_wt.Wavelet* w, c_wt.MODE mode, int level) nogil:
+cdef void _downcoef(int do_dec_a, data_t *data, c_wt.index_t data_len,
+                    data_t *coeffs, c_wt.index_t output_len,
+                    c_wt.Wavelet* w, c_wt.MODE mode, int level) nogil:
     cdef int i
     for i in range(level):
         if do_dec_a:

--- a/pywt/src/c_wt.pxd
+++ b/pywt/src/c_wt.pxd
@@ -9,7 +9,7 @@ cdef extern from "common.h":
     cdef void* wtmalloc(long size)
     cdef void* wtcalloc(long len, long size)
     cdef void wtfree(void* ptr)
-    
+
     ctypedef enum MODE:
         MODE_INVALID = -1
         MODE_ZEROPAD = 0
@@ -21,18 +21,21 @@ cdef extern from "common.h":
         MODE_PERIODIZATION
         MODE_MAX
 
-
     # buffers lengths
-    cdef index_t dwt_buffer_length(index_t input_len, index_t filter_len, MODE mode)
-    cdef index_t upsampling_buffer_length(index_t coeffs_len, index_t filter_len,   
-                                          MODE mode)
-    cdef index_t idwt_buffer_length(index_t coeffs_len, index_t filter_len, MODE mode)
-    cdef index_t swt_buffer_length(index_t coeffs_len)
-    cdef index_t reconstruction_buffer_length(index_t coeffs_len, index_t filter_len)
+    cdef index_t dwt_buffer_length(index_t input_len, index_t filter_len,
+                                   MODE mode) nogil
+    cdef index_t upsampling_buffer_length(index_t coeffs_len,
+                                          index_t filter_len,
+                                          MODE mode) nogil
+    cdef index_t idwt_buffer_length(index_t coeffs_len, index_t filter_len,
+                                    MODE mode) nogil
+    cdef index_t swt_buffer_length(index_t coeffs_len) nogil
+    cdef index_t reconstruction_buffer_length(index_t coeffs_len,
+                                              index_t filter_len) nogil
 
     # max dec levels
-    cdef int dwt_max_level(index_t input_len, index_t filter_len)
-    cdef int swt_max_level(index_t input_len)
+    cdef int dwt_max_level(index_t input_len, index_t filter_len) nogil
+    cdef int swt_max_level(index_t input_len) nogil
 
 
 cdef extern from "wavelets.h":
@@ -48,13 +51,13 @@ cdef extern from "wavelets.h":
         double* dec_lo_double      # lowpass   decomposition
         double* rec_hi_double      # highpass reconstruction
         double* rec_lo_double      # lowpass   reconstruction
-        
+
         float* dec_hi_float
         float* dec_lo_float
         float* rec_hi_float
         float* rec_lo_float
-        
-        
+
+
         index_t dec_len         # length of decomposition filter
         index_t rec_len         # length of reconstruction filter
 
@@ -80,53 +83,54 @@ cdef extern from "wavelets.h":
         char* short_name
 
 
-    cdef Wavelet* wavelet(char name, int type)
-    cdef Wavelet* blank_wavelet(index_t filter_length)
-    cdef void free_wavelet(Wavelet* wavelet)
+    cdef Wavelet* wavelet(char name, int type) nogil
+    cdef Wavelet* blank_wavelet(index_t filter_length) nogil
+    cdef void free_wavelet(Wavelet* wavelet) nogil
 
 
 cdef extern from "wt.h":
 
     cdef int double_dec_a(double input[], index_t input_len, Wavelet* wavelet,
-                          double output[], index_t output_len, MODE mode)
+                          double output[], index_t output_len, MODE mode) nogil
     cdef int double_dec_d(double input[], index_t input_len, Wavelet* wavelet,
-                          double output[], index_t output_len, MODE mode)
+                          double output[], index_t output_len, MODE mode) nogil
 
-    cdef int double_rec_a(double coeffs_a[], index_t coeffs_len, Wavelet* wavelet,
-                          double output[], index_t output_len)
-    cdef int double_rec_d(double coeffs_d[], index_t coeffs_len, Wavelet* wavelet,
-                          double output[], index_t output_len)
+    cdef int double_rec_a(double coeffs_a[], index_t coeffs_len,
+                          Wavelet* wavelet, double output[],
+                          index_t output_len) nogil
+    cdef int double_rec_d(double coeffs_d[], index_t coeffs_len,
+                          Wavelet* wavelet, double output[],
+                          index_t output_len) nogil
 
-    cdef int double_idwt(double coeffs_a[], index_t coeffs_a_len, 
+    cdef int double_idwt(double coeffs_a[], index_t coeffs_a_len,
                          double coeffs_d[], index_t coeffs_d_len,
                          Wavelet* wavelet, double output[], index_t output_len,
-                         MODE mode, int correct_size)
+                         MODE mode, int correct_size) nogil
 
     cdef int double_swt_a(double input[], index_t input_len, Wavelet* wavelet,
-                          double output[], index_t output_len, int level)
+                          double output[], index_t output_len, int level) nogil
     cdef int double_swt_d(double input[], index_t input_len, Wavelet* wavelet,
-                          double output[], index_t output_len, int level)
+                          double output[], index_t output_len, int level) nogil
 
 
     cdef int float_dec_a(float input[], index_t input_len, Wavelet* wavelet,
-                         float output[], index_t output_len, MODE mode)
+                         float output[], index_t output_len, MODE mode) nogil
     cdef int float_dec_d(float input[], index_t input_len, Wavelet* wavelet,
-                         float output[], index_t output_len, MODE mode)
+                         float output[], index_t output_len, MODE mode) nogil
 
-    cdef int float_rec_a(float coeffs_a[], index_t coeffs_len, Wavelet* wavelet,
-                         float output[], index_t output_len)
-    cdef int float_rec_d(float coeffs_d[], index_t coeffs_len, Wavelet* wavelet,
-                         float output[], index_t output_len)
+    cdef int float_rec_a(float coeffs_a[], index_t coeffs_len,
+                         Wavelet* wavelet, float output[],
+                         index_t output_len) nogil
+    cdef int float_rec_d(float coeffs_d[], index_t coeffs_len,
+                         Wavelet* wavelet, float output[],
+                         index_t output_len) nogil
 
-    cdef int float_idwt(float coeffs_a[], index_t coeffs_a_len, 
+    cdef int float_idwt(float coeffs_a[], index_t coeffs_a_len,
                         float coeffs_d[], index_t coeffs_d_len,
                         Wavelet* wavelet, float output[], index_t output_len,
-                        MODE mode, int correct_size)
+                        MODE mode, int correct_size) nogil
 
     cdef int float_swt_a(float input[], index_t input_len, Wavelet* wavelet,
-                         float output[], index_t output_len, int level)
+                         float output[], index_t output_len, int level) nogil
     cdef int float_swt_d(float input[], index_t input_len, Wavelet* wavelet,
-                         float output[], index_t output_len, int level)
-
-
-
+                         float output[], index_t output_len, int level) nogil

--- a/pywt/tests/test__pywt.py
+++ b/pywt/tests/test__pywt.py
@@ -31,5 +31,29 @@ def test_upcoef_reconstruct():
     assert_allclose(rec, data)
 
 
+def test_downcoef_multilevel():
+    r = np.random.randn(16)
+    nlevels = 3
+    # calling with level=1 nlevels times
+    a1 = r.copy()
+    for i in range(nlevels):
+        a1 = pywt.downcoef('a', a1, 'haar', level=1)
+    # call with level=nlevels once
+    a3 = pywt.downcoef('a', r, 'haar', level=3)
+    assert_allclose(a1, a3)
+
+
+def test_upcoef_multilevel():
+    r = np.random.randn(4)
+    nlevels = 3
+    # calling with level=1 nlevels times
+    a1 = r.copy()
+    for i in range(nlevels):
+        a1 = pywt.upcoef('a', a1, 'haar', level=1)
+    # call with level=nlevels once
+    a3 = pywt.upcoef('a', r, 'haar', level=3)
+    assert_allclose(a1, a3)
+
+
 if __name__ == '__main__':
     run_module_suite()

--- a/pywt/tests/test_multidim.py
+++ b/pywt/tests/test_multidim.py
@@ -27,11 +27,13 @@ def test_3D_reconstruct():
          [5, 2, 6, 78, 12, 2]]])
 
     wavelet = pywt.Wavelet('haar')
-    d = pywt.dwtn(data, wavelet)
-    # idwtn creates even-length shapes (2x dwtn size)
-    original_shape = [slice(None, s) for s in data.shape]
-    assert_allclose(data, pywt.idwtn(d, wavelet)[original_shape],
-                    rtol=1e-13, atol=1e-13)
+
+    for dt, tol in [('float32', 3e-6), ('float64', 1e-13)]:
+        d = pywt.dwtn(data.astype(dt), wavelet)
+        # idwtn creates even-length shapes (2x dwtn size)
+        original_shape = [slice(None, s) for s in data.shape]
+        assert_allclose(data, pywt.idwtn(d, wavelet)[original_shape],
+                        rtol=tol, atol=tol)
 
 
 def test_idwtn_idwt2():


### PR DESCRIPTION
Much faster implementations for dwtn and idwtn.  This was split out of #52 as it is independent of the ``waverecn`` or ``wavedecn`` functionaility, but obviosly makes those routines much faster as well.


The key modification here is refactoring the functions ``downcoef`` and ``upcoef`` to do the looping on the cython side rather than the prior implementation that used numpy's ``apply_along_axis`` to do the looping on the python side in ``dwtn`` and ``idwtn``.

To quote myself from the prior pull request:

From testing on my machine on a 256x256 image, dwtn was taking approximately 70 ms prior to these changes and only about 1ms afterwards. This is comparable in performance to the Rice Wavelet Toolbox (https://github.com/ricedsp/rwt), but without the limitation to only 1D or 2D signals.

