### PR TITLE
Update links to point to PyWavelets github repo

### DIFF
--- a/doc/source/_templates/editdocument.html
+++ b/doc/source/_templates/editdocument.html
@@ -1,4 +1,4 @@
-{% set repo="nigma/pywt" %}
+{% set repo="PyWavelets/pywt" %}
 {% set branch="develop" %}
 
 <div id="edit-instructions">

--- a/doc/source/_templates/quicklinks.html
+++ b/doc/source/_templates/quicklinks.html
@@ -4,7 +4,7 @@
 <p><a href="http://en.ig.ma/">Quality Python development and scientific applications.</a></p>
 <h3>Quick links</h3>
 <ul>
-<li><a href="https://github.com/nigma/pywt"><img src="{{ pathto("_static/github.png", 1) }}" height="16" width="16" alt="" /> Fork on Github</a></li>
+<li><a href="https://github.com/PyWavelets/pywt"><img src="{{ pathto("_static/github.png", 1) }}" height="16" width="16" alt="" /> Fork on Github</a></li>
 <li><a href="http://groups.google.com/group/pywavelets"><img src="{{ pathto("_static/comments.png", 1) }}" height="16" width="16" alt="" /> Discussion Group</a></li>
 <li><a href="http://wavelets.pybytes.com/"><img src="{{ pathto("_static/wave.png", 1) }}" height="16" width="16" alt="" /> Explore Wavelets</a></li>
 </ul>

--- a/doc/source/_templates/quicklinks.html
+++ b/doc/source/_templates/quicklinks.html
@@ -1,7 +1,4 @@
 <div>
-<h3>Python Development</h3>
-<p><a href="http://en.ig.ma/">Django web development for startups and businesses.</a></p>
-<p><a href="http://en.ig.ma/">Quality Python development and scientific applications.</a></p>
 <h3>Quick links</h3>
 <ul>
 <li><a href="https://github.com/PyWavelets/pywt"><img src="{{ pathto("_static/github.png", 1) }}" height="16" width="16" alt="" /> Fork on Github</a></li>

--- a/doc/source/dev/building_extension.rst
+++ b/doc/source/dev/building_extension.rst
@@ -6,10 +6,10 @@ Building and installing PyWavelets
 Installing from source code
 ---------------------------
 
-Go to https://github.com/nigma/pywt GitHub project page, fork and clone the
+Go to https://github.com/PyWavelets/pywt GitHub project page, fork and clone the
 repository or use the upstream repository to get the source code::
 
-    git clone https://github.com/nigma/pywt.git PyWavelets
+    git clone https://github.com/PyWavelets/pywt.git PyWavelets
 
 Activate your Python virtual environment, go to the cloned source directory
 and type the following commands to build and install the package::
@@ -31,7 +31,7 @@ Installing a development version
 
 You can also install directly from the source repository::
 
-    pip install -e git+https://github.com/nigma/pywt.git#egg=PyWavelets
+    pip install -e git+https://github.com/PyWavelets/pywt.git#egg=PyWavelets
 
 or::
 

--- a/doc/source/dev/index.rst
+++ b/doc/source/dev/index.rst
@@ -24,4 +24,4 @@ If these instructions are not clear or you need help setting up your
 development environment, go ahead and ask on the PyWavelets discussion
 group at http://groups.google.com/group/pywavelets or open a ticket on GitHub_.
 
-.. _GitHub: https://github.com/nigma/pywt
+.. _GitHub: https://github.com/PyWavelets/pywt


### PR DESCRIPTION
Missed a few links to github in the docs. Fixes #90.