### PR TITLE
complex support in all dwt and idwt related functions

### DIFF
--- a/pywt/src/_pywt.pyx
+++ b/pywt/src/_pywt.pyx
@@ -1177,6 +1177,15 @@ def swt(data, object wavelet, object level=None, int start_level=0):
             [(cAm+n, cDm+n), ..., (cAm+1, cDm+1), (cAm, cDm)]
 
     """
+    if np.iscomplexobj(data):
+        data = np.asarray(data)
+        coeffs_real = swt(data.real, wavelet, level, start_level)
+        coeffs_imag = swt(data.imag, wavelet, level, start_level)
+        coeffs_cplx = []
+        for (cA_r, cD_r), (cA_i, cD_i) in zip(coeffs_real, coeffs_imag):
+            coeffs_cplx.append((cA_r + 1j*cA_i, cD_r + 1j*cD_i))
+        return coeffs_cplx
+
     # accept array_like input; make a copy to ensure a contiguous array
     dt = _check_dtype(data)
     data = np.array(data, dtype=dt)

--- a/pywt/src/_pywt.pyx
+++ b/pywt/src/_pywt.pyx
@@ -950,6 +950,9 @@ def upcoef(part, coeffs, wavelet, level=1, take=0):
     [ 1.  2.  3.  4.  5.  6.]
 
     """
+    if np.iscomplexobj(coeffs):
+        return (upcoef(part, coeffs.real, wavelet, level, take) +
+                1j*upcoef(part, coeffs.imag, wavelet, level, take))
     # accept array_like input; make a copy to ensure a contiguous array
     dt = _check_dtype(coeffs)
     coeffs = np.array(coeffs, dtype=dt)
@@ -1057,6 +1060,9 @@ def downcoef(part, data, wavelet, mode='sym', level=1):
     upcoef
 
     """
+    if np.iscomplexobj(data):
+        return (downcoef(part, data.real, wavelet, mode, level) +
+                1j*downcoef(part, data.imag, wavelet, mode, level))
     # accept array_like input; make a copy to ensure a contiguous array
     dt = _check_dtype(data)
     data = np.array(data, dtype=dt)

--- a/pywt/src/_pywt.pyx
+++ b/pywt/src/_pywt.pyx
@@ -797,42 +797,41 @@ def idwt(cA, cD, object wavelet, object mode='sym', int correct_size=0):
     """
     # accept array_like input; make a copy to ensure a contiguous array
 
-    has_cA = not (cA is None)
-    has_cD = not (cD is None)
-    if not (has_cA or has_cD):
+    if cA is None and cD is None:
         raise ValueError("At least one coefficient parameter must be "
                          "specified.")
 
     # for complex inputs: compute real and imaginary separately then combine
-    if (has_cA and np.iscomplexobj(cA)) or (has_cD and np.iscomplexobj(cD)):
-        if not has_cA:
+    if ((cA is not None) and np.iscomplexobj(cA)) or ((cD is not None) and
+            np.iscomplexobj(cD)):
+        if cA is None:
             cD = np.asarray(cD)
             cA = np.zeros_like(cD)
-        elif not has_cD:
+        elif cD is None:
             cA = np.asarray(cA)
             cD = np.zeros_like(cA)
         return (idwt(cA.real, cD.real, wavelet, mode, correct_size) +
                 1j*idwt(cA.imag, cD.imag, wavelet, mode, correct_size))
 
-    if has_cA:
+    if cA is not None:
         dt = _check_dtype(cA)
         cA = np.array(cA, dtype=dt)
         if cA.ndim != 1:
             raise ValueError("idwt requires 1D coefficient arrays.")
-    if has_cD:
+    if cD is not None:
         dt = _check_dtype(cD)
         cD = np.array(cD, dtype=dt)
         if cD.ndim != 1:
             raise ValueError("idwt requires 1D coefficient arrays.")
 
-    if has_cA and has_cD:
+    if cA is not None and cD is not None:
         if cA.dtype != cD.dtype:
             # need to upcast to common type
             cA = cA.astype(np.float64)
             cD = cD.astype(np.float64)
-    elif has_cD:
+    elif cA is None:
         cA = np.zeros_like(cD)
-    elif has_cA:
+    elif cD is None:
         cD = np.zeros_like(cA)
 
     return _idwt(cA, cD, wavelet, mode, correct_size)

--- a/pywt/src/_pywt.pyx
+++ b/pywt/src/_pywt.pyx
@@ -642,6 +642,12 @@ def dwt(object data, object wavelet, object mode='sym'):
     [-0.70710678 -0.70710678 -0.70710678]
 
     """
+    if np.iscomplexobj(data):
+        data = np.asarray(data)
+        cA_r, cD_r = dwt(data.real, wavelet, mode)
+        cA_i, cD_i = dwt(data.imag, wavelet, mode)
+        return  (cA_r + 1j*cA_i, cD_r + 1j*cD_i)
+
     # accept array_like input; make a copy to ensure a contiguous array
     dt = _check_dtype(data)
     data = np.array(data, dtype=dt)
@@ -791,30 +797,43 @@ def idwt(cA, cD, object wavelet, object mode='sym', int correct_size=0):
     """
     # accept array_like input; make a copy to ensure a contiguous array
 
-    if cA is None and cD is None:
+    has_cA = not (cA is None)
+    has_cD = not (cD is None)
+    if not (has_cA or has_cD):
         raise ValueError("At least one coefficient parameter must be "
                          "specified.")
 
-    if cA is not None:
+    # for complex inputs: compute real and imaginary separately then combine
+    if (has_cA and np.iscomplexobj(cA)) or (has_cD and np.iscomplexobj(cD)):
+        if not has_cA:
+            cD = np.asarray(cD)
+            cA = np.zeros_like(cD)
+        elif not has_cD:
+            cA = np.asarray(cA)
+            cD = np.zeros_like(cA)
+        return (idwt(cA.real, cD.real, wavelet, mode, correct_size) +
+                1j*idwt(cA.imag, cD.imag, wavelet, mode, correct_size))
+
+    if has_cA:
         dt = _check_dtype(cA)
         cA = np.array(cA, dtype=dt)
         if cA.ndim != 1:
             raise ValueError("idwt requires 1D coefficient arrays.")
-    if cD is not None:
+    if has_cD:
         dt = _check_dtype(cD)
         cD = np.array(cD, dtype=dt)
         if cD.ndim != 1:
             raise ValueError("idwt requires 1D coefficient arrays.")
 
-    if cA is not None and cD is not None:
+    if has_cA and has_cD:
         if cA.dtype != cD.dtype:
             # need to upcast to common type
             cA = cA.astype(np.float64)
             cD = cD.astype(np.float64)
-    elif cA is None:
-        cA = np.zeros(cD.shape, dtype=cD.dtype)
-    elif cD is None:
-        cD = np.zeros(cA.shape, dtype=cA.dtype)
+    elif has_cD:
+        cA = np.zeros_like(cD)
+    elif has_cA:
+        cD = np.zeros_like(cA)
 
     return _idwt(cA, cD, wavelet, mode, correct_size)
 

--- a/pywt/tests/test_dwt_idwt.py
+++ b/pywt/tests/test_dwt_idwt.py
@@ -37,6 +37,23 @@ def test_dwt_idwt_dtypes():
         assert_(x_roundtrip.dtype == dt_out, "idwt: " + errmsg)
 
 
+def test_dwt_idwt_basic_complex():
+    x = np.asarray([3, 7, 1, 1, -2, 5, 4, 6])
+    x = x + 0.5j*x
+    cA, cD = pywt.dwt(x, 'db2')
+    cA_expect = np.asarray([5.65685425, 7.39923721, 0.22414387, 3.33677403,
+                            7.77817459])
+    cA_expect = cA_expect + 0.5j*cA_expect
+    cD_expect = np.asarray([-2.44948974, -1.60368225, -4.44140056, -0.41361256,
+                            1.22474487])
+    cD_expect = cD_expect + 0.5j*cD_expect
+    assert_allclose(cA, cA_expect)
+    assert_allclose(cD, cD_expect)
+
+    x_roundtrip = pywt.idwt(cA, cD, 'db2')
+    assert_allclose(x_roundtrip, x, rtol=1e-10)
+
+
 def test_dwt_input_error():
     data = np.ones((16, 1))
     assert_raises(ValueError, pywt.dwt, data, 'haar')

--- a/pywt/tests/test_dwt_idwt.py
+++ b/pywt/tests/test_dwt_idwt.py
@@ -7,6 +7,11 @@ from numpy.testing import (run_module_suite, assert_allclose, assert_,
 
 import pywt
 
+# Check that float32 and complex64 are preserved.  Other real types get
+# converted to float64.
+dtypes_in = [np.int8, np.float32, np.float64, np.complex64, np.complex128]
+dtypes_out = [np.float64, np.float32, np.float64, np.complex64, np.complex128]
+
 
 def test_dwt_idwt_basic():
     x = [3, 7, 1, 1, -2, 5, 4, 6]
@@ -22,9 +27,6 @@ def test_dwt_idwt_basic():
 
 
 def test_dwt_idwt_dtypes():
-    # Check that float32 is preserved.  Other types get converted to float64.
-    dtypes_in = [np.int8, np.float32, np.float64]
-    dtypes_out = [np.float64, np.float32, np.float64]
     wavelet = pywt.Wavelet('haar')
     for dt_in, dt_out in zip(dtypes_in, dtypes_out):
         x = np.ones(4, dtype=dt_in)

--- a/pywt/tests/test_multidim.py
+++ b/pywt/tests/test_multidim.py
@@ -8,6 +8,11 @@ from numpy.testing import (run_module_suite, assert_allclose, assert_,
 
 import pywt
 
+# Check that float32 and complex64 are preserved.  Other real types get
+# converted to float64.
+dtypes_in = [np.int8, np.float32, np.float64, np.complex64, np.complex128]
+dtypes_out = [np.float64, np.float32, np.float64, np.complex64, np.complex128]
+
 
 def test_dwtn_input_error():
     data = dict()
@@ -165,9 +170,6 @@ def test_error_mismatched_size():
 
 
 def test_dwt2_idwt2_dtypes():
-    # Check that float32 is preserved.  Other types get converted to float64.
-    dtypes_in = [np.int8, np.float32, np.float64]
-    dtypes_out = [np.float64, np.float32, np.float64]
     wavelet = pywt.Wavelet('haar')
     for dt_in, dt_out in zip(dtypes_in, dtypes_out):
         x = np.ones((4, 4), dtype=dt_in)
@@ -182,9 +184,6 @@ def test_dwt2_idwt2_dtypes():
 
 
 def test_dwtn_idwtn_dtypes():
-    # Check that float32 is preserved.  Other types get converted to float64.
-    dtypes_in = [np.int8, np.float32, np.float64]
-    dtypes_out = [np.float64, np.float32, np.float64]
     wavelet = pywt.Wavelet('haar')
     for dt_in, dt_out in zip(dtypes_in, dtypes_out):
         x = np.ones((4, 4), dtype=dt_in)

--- a/pywt/tests/test_multidim.py
+++ b/pywt/tests/test_multidim.py
@@ -34,12 +34,50 @@ def test_3D_reconstruct():
                     rtol=1e-13, atol=1e-13)
 
 
+def test_3D_reconstruct_complex():
+    # All dimensions even length so `take` does not need to be specified
+    data = np.array([
+        [[0, 4, 1, 5, 1, 4],
+         [0, 5, 26, 3, 2, 1],
+         [5, 8, 2, 33, 4, 9],
+         [2, 5, 19, 4, 19, 1]],
+        [[1, 5, 1, 2, 3, 4],
+         [7, 12, 6, 52, 7, 8],
+         [2, 12, 3, 52, 6, 8],
+         [5, 2, 6, 78, 12, 2]]])
+    data = data + 1j
+
+    wavelet = pywt.Wavelet('haar')
+    d = pywt.dwtn(data, wavelet)
+    # idwtn creates even-length shapes (2x dwtn size)
+    original_shape = [slice(None, s) for s in data.shape]
+    assert_allclose(data, pywt.idwtn(d, wavelet)[original_shape],
+                    rtol=1e-13, atol=1e-13)
+
+
 def test_idwtn_idwt2():
     data = np.array([
         [0, 4, 1, 5, 1, 4],
         [0, 5, 6, 3, 2, 1],
         [2, 5, 19, 4, 19, 1]])
 
+    wavelet = pywt.Wavelet('haar')
+
+    LL, (HL, LH, HH) = pywt.dwt2(data, wavelet)
+    d = {'aa': LL, 'da': HL, 'ad': LH, 'dd': HH}
+
+    for mode in pywt.MODES.modes:
+        assert_allclose(pywt.idwt2((LL, (HL, LH, HH)), wavelet, mode=mode),
+                        pywt.idwtn(d, wavelet, mode=mode),
+                        rtol=1e-14, atol=1e-14)
+
+
+def test_idwtn_idwt2_complex():
+    data = np.array([
+        [0, 4, 1, 5, 1, 4],
+        [0, 5, 6, 3, 2, 1],
+        [2, 5, 19, 4, 19, 1]])
+    data = data + 1j
     wavelet = pywt.Wavelet('haar')
 
     LL, (HL, LH, HH) = pywt.dwt2(data, wavelet)

--- a/pywt/tests/test_multilevel.py
+++ b/pywt/tests/test_multilevel.py
@@ -8,6 +8,11 @@ from numpy.testing import (run_module_suite, assert_almost_equal,
 
 import pywt
 
+# Check that float32 and complex64 are preserved.  Other real types get
+# converted to float64.
+dtypes_in = [np.int8, np.float32, np.float64, np.complex64, np.complex128]
+dtypes_out = [np.float64, np.float32, np.float64, np.complex64, np.complex128]
+
 
 def test_wavedec():
     x = [3, 7, 1, 1, -2, 5, 4, 6]
@@ -58,9 +63,6 @@ def test_swt_decomposition():
 
 
 def test_swt_dtypes():
-    # Check that float32 is preserved.  Other types get converted to float64.
-    dtypes_in = [np.int8, np.float32, np.float64]
-    dtypes_out = [np.float64, np.float32, np.float64]
     wavelet = pywt.Wavelet('haar')
     for dt_in, dt_out in zip(dtypes_in, dtypes_out):
         errmsg = "wrong dtype returned for {0} input".format(dt_in)
@@ -85,9 +87,6 @@ def test_wavedec2():
 
 
 def test_multilevel_dtypes():
-    # Check that float32 is preserved.  Other types get converted to float64.
-    dtypes_in = [np.int8, np.float32, np.float64]
-    dtypes_out = [np.float64, np.float32, np.float64]
     wavelet = pywt.Wavelet('haar')
     for dt_in, dt_out in zip(dtypes_in, dtypes_out):
         # wavedec, waverec

--- a/pywt/tests/test_multilevel.py
+++ b/pywt/tests/test_multilevel.py
@@ -26,6 +26,13 @@ def test_waverec():
     assert_allclose(pywt.waverec(coeffs, 'db1'), x, rtol=1e-12)
 
 
+def test_waverec_complex():
+    x = np.array([3, 7, 1, 1, -2, 5, 4, 6])
+    x = x + 1j
+    coeffs = pywt.wavedec(x, 'db1')
+    assert_allclose(pywt.waverec(coeffs, 'db1'), x, rtol=1e-12)
+
+
 def test_swt_decomposition():
     x = [3, 7, 1, 3, -2, 6, 4, 6]
     db1 = pywt.Wavelet('db1')
@@ -103,6 +110,13 @@ def test_multilevel_dtypes():
             assert_(c.dtype == dt_out, "wavedec2: " + errmsg)
         x_roundtrip = pywt.waverec2([cA, coeffsD2, coeffsD1], wavelet)
         assert_(x_roundtrip.dtype == dt_out, "waverec2: " + errmsg)
+
+
+def test_wavedec2_complex():
+    data = np.ones((4, 4)) + 1j
+    coeffs = pywt.wavedec2(data, 'db1')
+    assert_(len(coeffs) == 3)
+    assert_allclose(pywt.waverec2(coeffs, 'db1'), data, rtol=1e-12)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This PR adds complex dtype support to ``downcoef``, ``upcoef``, ``dwt``, ``idwt`` and by extension, their corresponding multidim and multilevel variants.  This is useful for magnetic resonance imaging applications where images are often stored with both magnitude and phase information.

The same strategy can easily be applied to the stationary wavelet transforms as well.

This is an implementation of option 2 as discussed in #96.  any feedback appreciated