### PR TITLE
Faster idwtn/dwtn

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ matrix:
     - python: 2.6
       env:
         - OPTIMIZE=-OO
-        - NUMPYSPEC="numpy==1.6.2"
+        - NUMPYSPEC="numpy==1.7.2"
     - python: 2.7
       env:
         - NUMPYSPEC="--upgrade git+git://github.com/numpy/numpy.git@v1.9.1"

--- a/pywt/multidim.py
+++ b/pywt/multidim.py
@@ -256,14 +256,7 @@ def idwtn(coeffs, wavelet, mode='sym'):
         Wavelet to use
     mode : str, optional
         Signal extension mode used in the decomposition,
-        see MODES (default: 'sym'). Overridden by `take`.
-    take : int or iterable of int or None, optional
-        Number of values to take from the center of the idwtn for each axis.
-        If 0, the entire reverse transformation will be used, including
-        parts generated from padding in the forward transform.
-        If None (default), will be calculated from `mode` to be the size of the
-        original data, rounded up to the nearest multiple of 2.
-        Passed to `upcoef`.
+        see MODES (default: 'sym').
 
     Returns
     -------

--- a/pywt/multidim.py
+++ b/pywt/multidim.py
@@ -16,7 +16,7 @@ from itertools import cycle, product, repeat, islice
 import numpy as np
 
 from ._pywt import Wavelet, MODES
-from ._pywt import dwt, idwt, swt, downcoef, upcoef
+from ._pywt import dwt, dwtn, idwt, swt, downcoef, upcoef
 
 
 def dwt2(data, wavelet, mode='sym'):
@@ -193,59 +193,6 @@ def idwt2(coeffs, wavelet, mode='sym'):
         data.append(idwt(rowL, rowH, wavelet, mode, 1))
 
     return np.array(data)
-
-
-def dwtn(data, wavelet, mode='sym'):
-    """
-    Single-level n-dimensional Discrete Wavelet Transform.
-
-    Parameters
-    ----------
-    data : ndarray
-        n-dimensional array with input data.
-    wavelet : Wavelet object or name string
-        Wavelet to use.
-    mode : str, optional
-        Signal extension mode, see `MODES`.  Default is 'sym'.
-
-    Returns
-    -------
-    coeffs : dict
-        Results are arranged in a dictionary, where key specifies
-        the transform type on each dimension and value is a n-dimensional
-        coefficients array.
-
-        For example, for a 2D case the result will look something like this::
-
-            {'aa': <coeffs>  # A(LL) - approx. on 1st dim, approx. on 2nd dim
-             'ad': <coeffs>  # V(LH) - approx. on 1st dim, det. on 2nd dim
-             'da': <coeffs>  # H(HL) - det. on 1st dim, approx. on 2nd dim
-             'dd': <coeffs>  # D(HH) - det. on 1st dim, det. on 2nd dim
-            }
-
-    """
-    data = np.asarray(data)
-    dim = data.ndim
-    if dim < 1:
-        raise ValueError("Input data must be at least 1D")
-    coeffs = [('', data)]
-
-    def _downcoef(data, wavelet, mode, type):
-        """Adapts pywt.downcoef call for apply_along_axis"""
-        return downcoef(type, data, wavelet, mode, level=1)
-
-    for axis in range(dim):
-        new_coeffs = []
-        for subband, x in coeffs:
-            new_coeffs.extend([
-                (subband + 'a', np.apply_along_axis(_downcoef, axis, x,
-                                                    wavelet, mode, 'a')),
-                (subband + 'd', np.apply_along_axis(_downcoef, axis, x,
-                                                    wavelet, mode, 'd'))])
-
-        coeffs = new_coeffs
-
-    return dict(coeffs)
 
 
 def idwtn(coeffs, wavelet, mode='sym', take=None):

--- a/pywt/src/_pywt.pyx
+++ b/pywt/src/_pywt.pyx
@@ -802,18 +802,22 @@ cpdef idwt_axis(np.ndarray coefs_a, np.ndarray coefs_d, object wavelet,
         return None;
 
     if coefs_a is not None:
-        coefs_a = coefs_a.astype(_check_dtype(coefs_a), copy=False)
+        if coefs_d is not None and coefs_d.dtype.itemsize > coefs_a.dtype.itemsize:
+            coefs_a = coefs_a.astype(_check_dtype(coefs_d), copy=False)
+        else:
+            coefs_a = coefs_a.astype(_check_dtype(coefs_a), copy=False)
         a_info.ndim = coefs_a.ndim
         a_info.strides = <index_t *> coefs_a.strides
         a_info.shape = <size_t *> coefs_a.shape
     if coefs_d is not None:
+        if coefs_d is not None and coefs_d.dtype.itemsize > coefs_a.dtype.itemsize:
+            coefs_d = coefs_d.astype(_check_dtype(coefs_a), copy=False)
+        else:
+            coefs_d = coefs_d.astype(_check_dtype(coefs_d), copy=False)
         coefs_d = coefs_d.astype(_check_dtype(coefs_d), copy=False)
         d_info.ndim = coefs_d.ndim
         d_info.strides = <index_t *> coefs_d.strides
         d_info.shape = <size_t *> coefs_d.shape
-
-    if coefs_a.dtype != coefs_d.dtype:
-        raise ValueError("FIXME: Deal with mismatched dtypes.")
 
     # Must be zero-initialized
     output = np.zeros(output_shape, coefs_a.dtype)
@@ -823,14 +827,18 @@ cpdef idwt_axis(np.ndarray coefs_a, np.ndarray coefs_d, object wavelet,
     output_info.shape = <size_t *> output.shape
 
     if coefs_a.dtype == 'float64':
-        if c_wt.double_upcoef_axis(<double *> coefs_a.data, a_info,
-                                   <double *> coefs_d.data, d_info,
+        if c_wt.double_upcoef_axis(<double *> coefs_a.data if coefs_a is not None else NULL,
+                                   a_info,
+                                   <double *> coefs_d.data if coefs_d is not None else NULL,
+                                   d_info,
                                    <double *> output.data, output_info,
                                    w.w, axis):
             raise RuntimeError("C inverse wavelet transform failed")
     if coefs_a.dtype == 'float32':
-        if c_wt.float_upcoef_axis(<float *> coefs_a.data, a_info,
-                                  <float *> coefs_d.data, d_info,
+        if c_wt.float_upcoef_axis(<float *> coefs_a.data if coefs_a is not None else NULL,
+                                  a_info,
+                                  <float *> coefs_d.data if coefs_d is not None else NULL,
+                                  d_info,
                                   <float *> output.data, output_info,
                                   w.w, axis):
             raise RuntimeError("C inverse wavelet transform failed")

--- a/pywt/src/_pywt.pyx
+++ b/pywt/src/_pywt.pyx
@@ -712,7 +712,7 @@ def dwtn(data, wavelet, mode='sym'):
     for axis in range(ndim):
         new_coeffs = []
         for subband, x in coeffs:
-            cA, cD = dwt_axis(data, wavelet, mode, axis)
+            cA, cD = dwt_axis(x, wavelet, mode, axis)
             new_coeffs.extend([(subband + 'a', cA),
                                (subband + 'd', cD)])
         coeffs = new_coeffs

--- a/pywt/src/_pywt.pyx
+++ b/pywt/src/_pywt.pyx
@@ -686,15 +686,6 @@ def _dwt(np.ndarray[data_t, ndim=1] data, object wavelet, object mode='sym'):
 
     return (cA, cD)
 
-cdef np.dtype checkDtype(np.ndarray data):
-    try:
-        if data.dtype in (np.float64, np.float32):
-            return data.dtype
-        else:
-            return np.dtype('float64')
-    except AttributeError:
-        return np.dtype('float64')
-
 def dwtn(data, wavelet, mode='sym'):
     """
     Single-level n-dimensional Discrete Wavelet Transform.
@@ -750,7 +741,7 @@ cpdef dwt_axis(np.ndarray data, object wavelet, object mode='sym', unsigned int 
     cdef Wavelet w = c_wavelet_from_object(wavelet)
     cdef common.MODE _mode = _try_mode(mode)
 
-    data = data.astype(checkDtype(data), copy=False)
+    data = data.astype(_check_dtype(data), copy=False)
 
     cdef np.ndarray cD, cA
     cdef size_t[::1] output_shape
@@ -850,16 +841,16 @@ def _try_mode(mode):
         raise TypeError("Invalid mode: {0}".format(str(mode)))
 
 
-def _check_dtype(data):
+cdef np.dtype _check_dtype(data):
     """Check for cA/cD input what (if any) the dtype is."""
+    cdef np.dtype dt
     try:
         dt = data.dtype
-        if not dt == np.float32:
+        if dt not in (np.float64, np.float32):
             # integer input was always accepted; convert to float64
-            dt = np.float64
+            dt = np.dtype('float64')
     except AttributeError:
-        dt = np.float64
-
+        dt = np.dtype('float64')
     return dt
 
 

--- a/pywt/src/_pywt.pyx
+++ b/pywt/src/_pywt.pyx
@@ -710,7 +710,7 @@ cpdef dwt_axis(np.ndarray data, object wavelet, object mode='sym', unsigned int 
     output_info.strides = <index_t *> cA.strides
     output_info.shape = <size_t *> cA.shape
 
-    if data.dtype == 'float64':
+    if data.dtype == np.float64:
         if c_wt.double_downcoef_axis(<double *> data.data, data_info,
                                      <double *> cA.data, output_info,
                                      w.w, axis, common.COEF_APPROX, _mode):
@@ -719,7 +719,7 @@ cpdef dwt_axis(np.ndarray data, object wavelet, object mode='sym', unsigned int 
                                      <double *> cD.data, output_info,
                                      w.w, axis, common.COEF_DETAIL, _mode):
             raise RuntimeError("C wavelet transform failed")
-    elif data.dtype == 'float32':
+    elif data.dtype == np.float32:
         if c_wt.float_downcoef_axis(<float *> data.data, data_info,
                                     <float *> cA.data, output_info,
                                     w.w, axis, common.COEF_APPROX, _mode):
@@ -777,7 +777,7 @@ cpdef idwt_axis(np.ndarray coefs_a, np.ndarray coefs_d, object wavelet,
     output_info.strides = <index_t *> output.strides
     output_info.shape = <size_t *> output.shape
 
-    if coefs_a.dtype == 'float64':
+    if coefs_a.dtype == np.float64:
         if c_wt.double_upcoef_axis(<double *> coefs_a.data if coefs_a is not None else NULL,
                                    &a_info if coefs_a is not None else NULL,
                                    <double *> coefs_d.data if coefs_d is not None else NULL,
@@ -785,7 +785,7 @@ cpdef idwt_axis(np.ndarray coefs_a, np.ndarray coefs_d, object wavelet,
                                    <double *> output.data, output_info,
                                    w.w, axis):
             raise RuntimeError("C inverse wavelet transform failed")
-    if coefs_a.dtype == 'float32':
+    if coefs_a.dtype == np.float32:
         if c_wt.float_upcoef_axis(<float *> coefs_a.data if coefs_a is not None else NULL,
                                   &a_info if coefs_a is not None else NULL,
                                   <float *> coefs_d.data if coefs_d is not None else NULL,

--- a/pywt/src/_pywt.pyx
+++ b/pywt/src/_pywt.pyx
@@ -686,54 +686,6 @@ def _dwt(np.ndarray[data_t, ndim=1] data, object wavelet, object mode='sym'):
 
     return (cA, cD)
 
-def dwtn(data, wavelet, mode='sym'):
-    """
-    Single-level n-dimensional Discrete Wavelet Transform.
-
-    Parameters
-    ----------
-    data : ndarray
-        n-dimensional array with input data.
-    wavelet : Wavelet object or name string
-        Wavelet to use.
-    mode : str, optional
-        Signal extension mode, see `MODES`.  Default is 'sym'.
-
-    Returns
-    -------
-    coeffs : dict
-        Results are arranged in a dictionary, where key specifies
-        the transform type on each dimension and value is a n-dimensional
-        coefficients array.
-
-        For example, for a 2D case the result will look something like this::
-
-            {'aa': <coeffs>  # A(LL) - approx. on 1st dim, approx. on 2nd dim
-             'ad': <coeffs>  # V(LH) - approx. on 1st dim, det. on 2nd dim
-             'da': <coeffs>  # H(HL) - det. on 1st dim, approx. on 2nd dim
-             'dd': <coeffs>  # D(HH) - det. on 1st dim, det. on 2nd dim
-            }
-
-    """
-    cdef int ndim
-
-    data = np.asarray(data)
-    ndim = data.ndim
-
-    if data.dtype == np.dtype('object'):
-        raise TypeError("Input must be a numeric array-like")
-    if ndim < 1:
-        raise ValueError("Input data must be at least 1D")
-    coeffs = [('', data)]
-
-    for axis in range(ndim):
-        new_coeffs = []
-        for subband, x in coeffs:
-            cA, cD = dwt_axis(x, wavelet, mode, axis)
-            new_coeffs.extend([(subband + 'a', cA),
-                               (subband + 'd', cD)])
-        coeffs = new_coeffs
-    return dict(coeffs)
 
 cpdef dwt_axis(np.ndarray data, object wavelet, object mode='sym', unsigned int axis=0):
     cdef Wavelet w = c_wavelet_from_object(wavelet)

--- a/pywt/src/_pywt.pyx
+++ b/pywt/src/_pywt.pyx
@@ -736,15 +736,13 @@ def dwtn(data, wavelet, mode='sym'):
     return dict(coeffs)
 
 cpdef dwt_axis(np.ndarray data, object wavelet, object mode='sym', unsigned int axis=0):
-    cdef common.ArrayInfo data_info
-    cdef common.ArrayInfo output_info
     cdef Wavelet w = c_wavelet_from_object(wavelet)
     cdef common.MODE _mode = _try_mode(mode)
-
-    data = data.astype(_check_dtype(data), copy=False)
-
+    cdef common.ArrayInfo data_info, output_info
     cdef np.ndarray cD, cA
     cdef size_t[::1] output_shape
+
+    data = data.astype(_check_dtype(data), copy=False)
 
     output_shape = (<size_t [:data.ndim]> <size_t *> data.shape).copy()
     output_shape[axis] = common.dwt_buffer_length(data.shape[axis], w.dec_len, _mode)

--- a/pywt/src/_pywt.pyx
+++ b/pywt/src/_pywt.pyx
@@ -827,17 +827,17 @@ cpdef idwt_axis(np.ndarray coefs_a, np.ndarray coefs_d, object wavelet,
 
     if coefs_a.dtype == 'float64':
         if c_wt.double_upcoef_axis(<double *> coefs_a.data if coefs_a is not None else NULL,
-                                   a_info,
+                                   &a_info if coefs_a is not None else NULL,
                                    <double *> coefs_d.data if coefs_d is not None else NULL,
-                                   d_info,
+                                   &d_info if coefs_d is not None else NULL,
                                    <double *> output.data, output_info,
                                    w.w, axis):
             raise RuntimeError("C inverse wavelet transform failed")
     if coefs_a.dtype == 'float32':
         if c_wt.float_upcoef_axis(<float *> coefs_a.data if coefs_a is not None else NULL,
-                                  a_info,
+                                  &a_info if coefs_a is not None else NULL,
                                   <float *> coefs_d.data if coefs_d is not None else NULL,
-                                  d_info,
+                                  &d_info if coefs_d is not None else NULL,
                                   <float *> output.data, output_info,
                                   w.w, axis):
             raise RuntimeError("C inverse wavelet transform failed")

--- a/pywt/src/_pywt.pyx
+++ b/pywt/src/_pywt.pyx
@@ -810,11 +810,10 @@ cpdef idwt_axis(np.ndarray coefs_a, np.ndarray coefs_d, object wavelet,
         a_info.strides = <index_t *> coefs_a.strides
         a_info.shape = <size_t *> coefs_a.shape
     if coefs_d is not None:
-        if coefs_d is not None and coefs_d.dtype.itemsize > coefs_a.dtype.itemsize:
+        if coefs_a is not None and coefs_a.dtype.itemsize > coefs_d.dtype.itemsize:
             coefs_d = coefs_d.astype(_check_dtype(coefs_a), copy=False)
         else:
             coefs_d = coefs_d.astype(_check_dtype(coefs_d), copy=False)
-        coefs_d = coefs_d.astype(_check_dtype(coefs_d), copy=False)
         d_info.ndim = coefs_d.ndim
         d_info.strides = <index_t *> coefs_d.strides
         d_info.shape = <size_t *> coefs_d.shape
@@ -844,6 +843,7 @@ cpdef idwt_axis(np.ndarray coefs_a, np.ndarray coefs_d, object wavelet,
             raise RuntimeError("C inverse wavelet transform failed")
 
     return output
+
 
 def dwt_coeff_len(data_len, filter_len, mode='sym'):
     """

--- a/pywt/src/_pywt.pyx
+++ b/pywt/src/_pywt.pyx
@@ -770,8 +770,7 @@ cpdef idwt_axis(np.ndarray coefs_a, np.ndarray coefs_d, object wavelet,
         d_info.strides = <index_t *> coefs_d.strides
         d_info.shape = <size_t *> coefs_d.shape
 
-    # Must be zero-initialized
-    output = np.zeros(output_shape, coefs_a.dtype)
+    output = np.empty(output_shape, coefs_a.dtype)
 
     output_info.ndim = output.ndim
     output_info.strides = <index_t *> output.strides

--- a/pywt/src/c_wt.pxd
+++ b/pywt/src/c_wt.pxd
@@ -11,10 +11,11 @@ cdef extern from "wt.h":
                                   double * const output, const ArrayInfo output_info,
                                   const Wavelet * const wavelet, const size_t axis,
                                   const Coefficient detail, const MODE mode)
-    cdef int double_upcoef_axis(const double * const coefs_a, const ArrayInfo * const a_info,
-                                const double * const coefs_d, const ArrayInfo * const d_info,
-                                double * const output, const ArrayInfo output_info,
-                                const Wavelet * const wavelet, const size_t axis)
+    cdef int double_idwt_axis(const double * const coefs_a, const ArrayInfo * const a_info,
+                              const double * const coefs_d, const ArrayInfo * const d_info,
+                              double * const output, const ArrayInfo output_info,
+                              const Wavelet * const wavelet, const size_t axis,
+                              const MODE mode)
     cdef int double_dec_a(const double * const input, const size_t input_len,
                           const Wavelet * const wavelet,
                           double * const output, const size_t output_len,
@@ -47,10 +48,11 @@ cdef extern from "wt.h":
                                  float * const output, const ArrayInfo output_info,
                                  const Wavelet * const wavelet, const size_t axis,
                                  const Coefficient detail, const MODE mode)
-    cdef int float_upcoef_axis(const float * const coefs_a, const ArrayInfo * const a_info,
-                               const float * const coefs_d, const ArrayInfo * const d_info,
-                               float * const output, const ArrayInfo output_info,
-                               const Wavelet * const wavelet, const size_t axis)
+    cdef int float_idwt_axis(const float * const coefs_a, const ArrayInfo * const a_info,
+                             const float * const coefs_d, const ArrayInfo * const d_info,
+                             float * const output, const ArrayInfo output_info,
+                             const Wavelet * const wavelet, const size_t axis,
+                             const MODE mode)
     cdef int float_dec_a(const float * const input, const size_t input_len,
                          const Wavelet * const wavelet,
                          float * const output, const size_t output_len,

--- a/pywt/src/c_wt.pxd
+++ b/pywt/src/c_wt.pxd
@@ -14,7 +14,7 @@ cdef extern from "wt.h":
     cdef int double_upcoef_axis(const double * const coefs_a, const ArrayInfo a_info,
                                 const double * const coefs_d, const ArrayInfo d_info,
                                 double * const output, const ArrayInfo output_info,
-                                const Wavelet * const wavelet, const size_t axis);
+                                const Wavelet * const wavelet, const size_t axis)
     cdef int double_dec_a(const double * const input, const size_t input_len,
                           const Wavelet * const wavelet,
                           double * const output, const size_t output_len,
@@ -50,7 +50,7 @@ cdef extern from "wt.h":
     cdef int float_upcoef_axis(const float * const coefs_a, const ArrayInfo a_info,
                                const float * const coefs_d, const ArrayInfo d_info,
                                float * const output, const ArrayInfo output_info,
-                               const Wavelet * const wavelet, const size_t axis);
+                               const Wavelet * const wavelet, const size_t axis)
     cdef int float_dec_a(const float * const input, const size_t input_len,
                          const Wavelet * const wavelet,
                          float * const output, const size_t output_len,

--- a/pywt/src/c_wt.pxd
+++ b/pywt/src/c_wt.pxd
@@ -11,6 +11,10 @@ cdef extern from "wt.h":
                                   double * const output, const ArrayInfo output_info,
                                   const Wavelet * const wavelet, const size_t axis,
                                   const Coefficient detail, const MODE mode)
+    cdef int double_upcoef_axis(const double * const coefs_a, const ArrayInfo a_info,
+                                const double * const coefs_d, const ArrayInfo d_info,
+                                double * const output, const ArrayInfo output_info,
+                                const Wavelet * const wavelet, const size_t axis);
     cdef int double_dec_a(const double * const input, const size_t input_len,
                           const Wavelet * const wavelet,
                           double * const output, const size_t output_len,
@@ -43,6 +47,10 @@ cdef extern from "wt.h":
                                  float * const output, const ArrayInfo output_info,
                                  const Wavelet * const wavelet, const size_t axis,
                                  const Coefficient detail, const MODE mode)
+    cdef int float_upcoef_axis(const float * const coefs_a, const ArrayInfo a_info,
+                               const float * const coefs_d, const ArrayInfo d_info,
+                               float * const output, const ArrayInfo output_info,
+                               const Wavelet * const wavelet, const size_t axis);
     cdef int float_dec_a(const float * const input, const size_t input_len,
                          const Wavelet * const wavelet,
                          float * const output, const size_t output_len,

--- a/pywt/src/c_wt.pxd
+++ b/pywt/src/c_wt.pxd
@@ -11,8 +11,8 @@ cdef extern from "wt.h":
                                   double * const output, const ArrayInfo output_info,
                                   const Wavelet * const wavelet, const size_t axis,
                                   const Coefficient detail, const MODE mode)
-    cdef int double_upcoef_axis(const double * const coefs_a, const ArrayInfo a_info,
-                                const double * const coefs_d, const ArrayInfo d_info,
+    cdef int double_upcoef_axis(const double * const coefs_a, const ArrayInfo * const a_info,
+                                const double * const coefs_d, const ArrayInfo * const d_info,
                                 double * const output, const ArrayInfo output_info,
                                 const Wavelet * const wavelet, const size_t axis)
     cdef int double_dec_a(const double * const input, const size_t input_len,
@@ -47,8 +47,8 @@ cdef extern from "wt.h":
                                  float * const output, const ArrayInfo output_info,
                                  const Wavelet * const wavelet, const size_t axis,
                                  const Coefficient detail, const MODE mode)
-    cdef int float_upcoef_axis(const float * const coefs_a, const ArrayInfo a_info,
-                               const float * const coefs_d, const ArrayInfo d_info,
+    cdef int float_upcoef_axis(const float * const coefs_a, const ArrayInfo * const a_info,
+                               const float * const coefs_d, const ArrayInfo * const d_info,
                                float * const output, const ArrayInfo output_info,
                                const Wavelet * const wavelet, const size_t axis)
     cdef int float_dec_a(const float * const input, const size_t input_len,

--- a/pywt/src/c_wt.pxd
+++ b/pywt/src/c_wt.pxd
@@ -1,12 +1,16 @@
 # Copyright (c) 2006-2012 Filip Wasilewski <http://en.ig.ma/>
 # See COPYING for license details.
 
-from common cimport MODE, index_t
+from common cimport MODE, index_t, ArrayInfo, Coefficient
 from wavelet cimport Wavelet
 
 
 cdef extern from "wt.h":
     # Cython does not know the 'restrict' keyword
+    cdef int double_downcoef_axis(const double * const input, const ArrayInfo input_info,
+                                  double * const output, const ArrayInfo output_info,
+                                  const Wavelet * const wavelet, const size_t axis,
+                                  const Coefficient detail, const MODE mode)
     cdef int double_dec_a(const double * const input, const size_t input_len,
                           const Wavelet * const wavelet,
                           double * const output, const size_t output_len,
@@ -35,6 +39,10 @@ cdef extern from "wt.h":
                           double output[], index_t output_len, int level)
 
 
+    cdef int float_downcoef_axis(const float * const input, const ArrayInfo input_info,
+                                 float * const output, const ArrayInfo output_info,
+                                 const Wavelet * const wavelet, const size_t axis,
+                                 const Coefficient detail, const MODE mode)
     cdef int float_dec_a(const float * const input, const size_t input_len,
                          const Wavelet * const wavelet,
                          float * const output, const size_t output_len,

--- a/pywt/src/common.h
+++ b/pywt/src/common.h
@@ -41,6 +41,16 @@
     #include <intrin.h>
 #endif
 
+typedef struct {
+    size_t * shape;
+    size_t * strides;
+    size_t ndim;
+} ArrayInfo;
+
+typedef enum {
+    COEF_APPROX = 0,
+    COEF_DETAIL = 1,
+} Coefficient;
 
 /* Signal extension modes */
 typedef enum {

--- a/pywt/src/common.h
+++ b/pywt/src/common.h
@@ -43,7 +43,7 @@
 
 typedef struct {
     size_t * shape;
-    size_t * strides;
+    index_t * strides;
     size_t ndim;
 } ArrayInfo;
 

--- a/pywt/src/common.pxd
+++ b/pywt/src/common.pxd
@@ -5,6 +5,15 @@ cdef extern from "common.h":
     cdef void* wtcalloc(long len, long size)
     cdef void wtfree(void* ptr)
 
+    ctypedef struct ArrayInfo:
+        size_t * shape
+        index_t * strides
+        size_t ndim
+
+    ctypedef enum Coefficient:
+        COEF_APPROX = 0
+        COEF_DETAIL = 1
+
     ctypedef enum MODE:
         MODE_INVALID = -1
         MODE_ZEROPAD = 0

--- a/pywt/src/wt.h
+++ b/pywt/src/wt.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <stdbool.h>
 #include "common.h"
 #include "convolution.h"
 #include "wavelets.h"

--- a/pywt/src/wt.h
+++ b/pywt/src/wt.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <stdbool.h>
 #include "common.h"
 #include "convolution.h"
 #include "wavelets.h"

--- a/pywt/src/wt.template.c
+++ b/pywt/src/wt.template.c
@@ -220,16 +220,12 @@ int CAT(TYPE, _upcoef_axis)(const TYPE * const restrict coefs_a, const ArrayInfo
                 temp_coefs_d[j] = *(TYPE *)((char *) coefs_d + d_offset
                                             + j * d_info->strides[axis]);
 
-        // upsampling_convolution adds to input, so copy
-        if (make_temp_output)
-            for (j = 0; j < output_info.shape[axis]; ++j)
-                // Offsets are byte offsets, to need to cast to char and back
-                temp_output[j] = *(TYPE *)((char *) output + output_offset
-                                           + j * output_info.strides[axis]);
-
         // Select temporary or direct output
         output_row = make_temp_output ? temp_output
             : (TYPE *)((char *) output + output_offset);
+
+        // upsampling_convolution adds to input, so zero
+        memset(output_row, 0, output_info.shape[axis] * sizeof(TYPE));
 
         if (have_a){
             // Pointer arithmetic on NULL is undefined

--- a/pywt/src/wt.template.c
+++ b/pywt/src/wt.template.c
@@ -23,8 +23,10 @@ int CAT(TYPE, _downcoef_axis)(const TYPE * const restrict input, const ArrayInfo
                               const Coefficient coef, const MODE mode){
     size_t i;
     size_t num_loops = 1;
-    bool make_temp_input, make_temp_output;
     TYPE * temp_input = NULL, * temp_output = NULL;
+
+    // These are boolean values, but MSVC does not have <stdbool.h>
+    int make_temp_input, make_temp_output;
 
     if (input_info.ndim != output_info.ndim)
         return 1;
@@ -127,10 +129,12 @@ int CAT(TYPE, _upcoef_axis)(const TYPE * const restrict coefs_a, const ArrayInfo
                             const Wavelet * const restrict wavelet, const size_t axis){
     size_t i;
     size_t num_loops = 1;
-    bool make_temp_coefs_a, make_temp_coefs_d, make_temp_output;
-    bool have_a = ((coefs_a != NULL) && (a_info != NULL));
-    bool have_d = ((coefs_d != NULL) && (d_info != NULL));
     TYPE * temp_coefs_a = NULL, * temp_coefs_d = NULL, * temp_output = NULL;
+
+    // These are boolean values, but MSVC does not have <stdbool.h>
+    int make_temp_coefs_a, make_temp_coefs_d, make_temp_output;
+    int have_a = ((coefs_a != NULL) && (a_info != NULL));
+    int have_d = ((coefs_d != NULL) && (d_info != NULL));
 
 
     if (!have_a && !have_d)

--- a/pywt/src/wt.template.c
+++ b/pywt/src/wt.template.c
@@ -51,9 +51,9 @@ int CAT(TYPE, _downcoef_axis)(const TYPE * const restrict input, const ArrayInfo
         if ((temp_output = malloc(output_info.shape[axis] * sizeof(TYPE))) == NULL)
             goto cleanup;
 
-    for (i = 0; i < input_info.ndim; ++i){
+    for (i = 0; i < output_info.ndim; ++i){
         if (i != axis)
-            num_loops *= input_info.shape[i];
+            num_loops *= output_info.shape[i];
     }
 
     for (i = 0; i < num_loops; ++i){
@@ -65,11 +65,11 @@ int CAT(TYPE, _downcoef_axis)(const TYPE * const restrict input, const ArrayInfo
         // Calculate offset into linear buffer
         {
             size_t reduced_idx = i;
-            for (j = 0; j < input_info.ndim; ++j){
-                size_t j_rev = input_info.ndim - 1 - j;
+            for (j = 0; j < output_info.ndim; ++j){
+                size_t j_rev = output_info.ndim - 1 - j;
                 if (j_rev != axis){
-                    size_t axis_idx = reduced_idx % input_info.shape[j_rev];
-                    reduced_idx /= input_info.shape[j_rev];
+                    size_t axis_idx = reduced_idx % output_info.shape[j_rev];
+                    reduced_idx /= output_info.shape[j_rev];
 
                     input_offset += (axis_idx * input_info.strides[j_rev]);
                     output_offset += (axis_idx * output_info.strides[j_rev]);
@@ -86,7 +86,7 @@ int CAT(TYPE, _downcoef_axis)(const TYPE * const restrict input, const ArrayInfo
 
         // Select temporary or direct output and input
         input_row = make_temp_input ? temp_input
-            : (TYPE *)((char *) input + input_offset);
+            : (const TYPE *)((const char *) input + input_offset);
         output_row = make_temp_output ? temp_output
             : (TYPE *)((char *) output + output_offset);
 
@@ -119,6 +119,142 @@ int CAT(TYPE, _downcoef_axis)(const TYPE * const restrict input, const ArrayInfo
     free(temp_output);
     return 2;
 }
+
+
+int CAT(TYPE, _upcoef_axis)(const TYPE * const restrict coefs_a, const ArrayInfo a_info,
+                            const TYPE * const restrict coefs_d, const ArrayInfo d_info,
+                            TYPE * const restrict output, const ArrayInfo output_info,
+                            const Wavelet * const restrict wavelet, const size_t axis){
+    size_t i;
+    size_t num_loops = 1;
+    bool make_temp_coefs_a, make_temp_coefs_d, make_temp_output;
+    TYPE * temp_coefs_a = NULL, * temp_coefs_d = NULL, * temp_output = NULL;
+
+
+    if ((coefs_a == NULL) && (coefs_d == NULL))
+        return 3;
+
+    if (((coefs_a != NULL) && (a_info.ndim != output_info.ndim)) ||
+        ((coefs_d != NULL) && (d_info.ndim != output_info.ndim)))
+        return 1;
+    if (axis >= output_info.ndim)
+        return 1;
+
+    for (i = 0; i < output_info.ndim; ++i){
+        if (i == axis){
+            size_t input_shape;
+            if ((coefs_a != NULL) && (coefs_d != NULL) &&
+                (d_info.shape[i] != a_info.shape[i]))
+                return 1;
+            input_shape = (coefs_a != NULL) ? a_info.shape[i] : d_info.shape[i];
+
+            /* TODO: reconstruction_buffer_length should take a & d shapes
+             *       - for odd output_len, d_len == (a_len - 1)
+             */
+            if (reconstruction_buffer_length(input_shape, wavelet->rec_len)
+                != output_info.shape[i])
+                return 1;
+        } else {
+            if (((coefs_a != NULL) && (a_info.shape[i] != output_info.shape[i])) ||
+                ((coefs_d != NULL) && (d_info.shape[i] != output_info.shape[i])))
+                return 1;
+        }
+    }
+
+    make_temp_coefs_a = (coefs_a != NULL) && a_info.strides[axis] != sizeof(TYPE);
+    make_temp_coefs_d = (coefs_d != NULL) && d_info.strides[axis] != sizeof(TYPE);
+    make_temp_output = output_info.strides[axis] != sizeof(TYPE);
+    if (make_temp_coefs_a)
+        if ((temp_coefs_a = malloc(a_info.shape[axis] * sizeof(TYPE))) == NULL)
+            goto cleanup;
+    if (make_temp_coefs_d)
+        if ((temp_coefs_d = malloc(d_info.shape[axis] * sizeof(TYPE))) == NULL)
+            goto cleanup;
+    if (make_temp_output)
+        if ((temp_output = malloc(output_info.shape[axis] * sizeof(TYPE))) == NULL)
+            goto cleanup;
+
+    for (i = 0; i < a_info.ndim; ++i){
+        if (i != axis)
+            num_loops *= output_info.shape[i];
+    }
+
+    for (i = 0; i < num_loops; ++i){
+        size_t j;
+        size_t a_offset = 0, d_offset = 0, output_offset = 0;
+        TYPE * output_row;
+
+        // Calculate offset into linear buffer
+        {
+            size_t reduced_idx = i;
+            for (j = 0; j < output_info.ndim; ++j){
+                size_t j_rev = output_info.ndim - 1 - j;
+                if (j_rev != axis){
+                    size_t axis_idx = reduced_idx % output_info.shape[j_rev];
+                    reduced_idx /= output_info.shape[j_rev];
+
+                    a_offset += (axis_idx * a_info.strides[j_rev]);
+                    d_offset += (axis_idx * d_info.strides[j_rev]);
+                    output_offset += (axis_idx * output_info.strides[j_rev]);
+                }
+            }
+        }
+
+        // Copy to temporary input if necessary
+        if (make_temp_coefs_a)
+            for (j = 0; j < a_info.shape[axis]; ++j)
+                // Offsets are byte offsets, to need to cast to char and back
+                temp_coefs_a[j] = *(TYPE *)(((char *) coefs_a) + a_offset
+                                            + j * a_info.strides[axis]);
+        if (make_temp_coefs_d)
+            for (j = 0; j < d_info.shape[axis]; ++j)
+                // Offsets are byte offsets, to need to cast to char and back
+                temp_coefs_d[j] = *(TYPE *)(((char *) coefs_d) + d_offset
+                                            + j * d_info.strides[axis]);
+
+        // Select temporary or direct output
+        output_row = make_temp_output ? temp_output
+            : (TYPE *)((char *) output + output_offset);
+
+        // upsampling_convolution adds to input, so clear
+        if (make_temp_output)
+            memset(temp_output, 0, output_info.shape[axis] * sizeof(TYPE));
+
+        if ((coefs_a != NULL)){
+            // Pointer arithmetic on NULL is undefined
+            const TYPE * a_row = make_temp_coefs_a ? temp_coefs_a
+                : (const TYPE *)((const char *) coefs_a + a_offset);
+            CAT(TYPE, _rec_a)(a_row, a_info.shape[axis], wavelet,
+                              output_row, output_info.shape[axis]);
+        }
+        if ((coefs_d != NULL)){
+            // Pointer arithmetic on NULL is undefined
+            const TYPE * d_row = make_temp_coefs_d ? temp_coefs_d
+                : (const TYPE *)((const char *) coefs_d + d_offset);
+            CAT(TYPE, _rec_d)(d_row, d_info.shape[axis], wavelet,
+                              output_row, output_info.shape[axis]);
+        }
+
+        // Copy from temporary output if necessary
+        if (make_temp_output)
+            for (j = 0; j < output_info.shape[axis]; ++j)
+                // Offsets are byte offsets, to need to cast to char and back
+                *(TYPE *)((char *) output + output_offset
+                          + j * output_info.strides[axis]) = output_row[j];
+    }
+
+    free(temp_coefs_a);
+    free(temp_coefs_d);
+    free(temp_output);
+    return 0;
+
+ cleanup:
+    free(temp_coefs_a);
+    free(temp_coefs_d);
+    free(temp_output);
+    return 2;
+}
+
 
 int CAT(TYPE, _dec_a)(const TYPE * const restrict input, const size_t input_len,
                       const Wavelet * const restrict wavelet,
@@ -187,6 +323,7 @@ int CAT(TYPE, _rec_d)(const TYPE * const restrict coeffs_d, const size_t coeffs_
                                                    wavelet->rec_len, output,
                                                    output_len);
 }
+
 
 /*
  * IDWT reconstruction from approximation and detail coeffs

--- a/pywt/src/wt.template.h
+++ b/pywt/src/wt.template.h
@@ -25,6 +25,11 @@ int CAT(TYPE, _downcoef_axis)(const TYPE * const restrict input, const ArrayInfo
                               const Wavelet * const restrict wavelet, const size_t axis,
                               const Coefficient detail, const MODE mode);
 
+int CAT(TYPE, _upcoef_axis)(const TYPE * const restrict coefs_a, const ArrayInfo a_info,
+                            const TYPE * const restrict coefs_d, const ArrayInfo d_info,
+                            TYPE * const restrict output, const ArrayInfo output_info,
+                            const Wavelet * const restrict wavelet, const size_t axis);
+
 /* Single level decomposition */
 int CAT(TYPE, _dec_a)(const TYPE * const restrict input, const size_t input_len,
                       const Wavelet * const restrict wavelet,

--- a/pywt/src/wt.template.h
+++ b/pywt/src/wt.template.h
@@ -26,10 +26,11 @@ int CAT(TYPE, _downcoef_axis)(const TYPE * const restrict input, const ArrayInfo
                               const Coefficient detail, const MODE mode);
 
 // a_info and d_info are pointers, as they may be NULL
-int CAT(TYPE, _upcoef_axis)(const TYPE * const restrict coefs_a, const ArrayInfo * a_info,
-                            const TYPE * const restrict coefs_d, const ArrayInfo * d_info,
-                            TYPE * const restrict output, const ArrayInfo output_info,
-                            const Wavelet * const restrict wavelet, const size_t axis);
+int CAT(TYPE, _idwt_axis)(const TYPE * const restrict coefs_a, const ArrayInfo * a_info,
+                          const TYPE * const restrict coefs_d, const ArrayInfo * d_info,
+                          TYPE * const restrict output, const ArrayInfo output_info,
+                          const Wavelet * const restrict wavelet,
+                          const size_t axis, const MODE mode);
 
 /* Single level decomposition */
 int CAT(TYPE, _dec_a)(const TYPE * const restrict input, const size_t input_len,

--- a/pywt/src/wt.template.h
+++ b/pywt/src/wt.template.h
@@ -25,8 +25,9 @@ int CAT(TYPE, _downcoef_axis)(const TYPE * const restrict input, const ArrayInfo
                               const Wavelet * const restrict wavelet, const size_t axis,
                               const Coefficient detail, const MODE mode);
 
-int CAT(TYPE, _upcoef_axis)(const TYPE * const restrict coefs_a, const ArrayInfo a_info,
-                            const TYPE * const restrict coefs_d, const ArrayInfo d_info,
+// a_info and d_info are pointers, as they may be NULL
+int CAT(TYPE, _upcoef_axis)(const TYPE * const restrict coefs_a, const ArrayInfo * a_info,
+                            const TYPE * const restrict coefs_d, const ArrayInfo * d_info,
                             TYPE * const restrict output, const ArrayInfo output_info,
                             const Wavelet * const restrict wavelet, const size_t axis);
 

--- a/pywt/src/wt.template.h
+++ b/pywt/src/wt.template.h
@@ -20,6 +20,11 @@
 /* _a suffix - wavelet transform approximations */
 /* _d suffix - wavelet transform details */
 
+int CAT(TYPE, _downcoef_axis)(const TYPE * const restrict input, const ArrayInfo input_info,
+                              TYPE * const restrict output, const ArrayInfo output_info,
+                              const Wavelet * const restrict wavelet, const size_t axis,
+                              const Coefficient detail, const MODE mode);
+
 /* Single level decomposition */
 int CAT(TYPE, _dec_a)(const TYPE * const restrict input, const size_t input_len,
                       const Wavelet * const restrict wavelet,

--- a/pywt/tests/test_multidim.py
+++ b/pywt/tests/test_multidim.py
@@ -38,6 +38,7 @@ def test_3D_reconstruct():
     assert_allclose(data, pywt.idwtn(d, wavelet)[original_shape],
                     rtol=1e-13, atol=1e-13)
 
+
 def test_stride():
     wavelet = pywt.Wavelet('haar')
 
@@ -54,6 +55,7 @@ def test_stride():
             strided_dwtn = pywt.dwtn(strided[::-1, ::2], wavelet)
             for key in expected.keys():
                 assert_allclose(strided_dwtn[key], expected[key])
+
 
 def test_byte_offset():
     wavelet = pywt.Wavelet('haar')

--- a/pywt/tests/test_multidim.py
+++ b/pywt/tests/test_multidim.py
@@ -38,6 +38,40 @@ def test_3D_reconstruct():
     assert_allclose(data, pywt.idwtn(d, wavelet)[original_shape],
                     rtol=1e-13, atol=1e-13)
 
+def test_stride():
+    wavelet = pywt.Wavelet('haar')
+
+    for dtype in ('float32', 'float64'):
+        data = np.array([[0, 4, 1, 5, 1, 4],
+                         [0, 5, 6, 3, 2, 1],
+                         [2, 5, 19, 4, 19, 1]],
+                        dtype=dtype)
+
+        for mode in pywt.MODES.modes:
+            expected = pywt.dwtn(data, wavelet)
+            strided = np.ones((3, 12), dtype=data.dtype)
+            strided[::-1, ::2] = data
+            strided_dwtn = pywt.dwtn(strided[::-1, ::2], wavelet)
+            for key in expected.keys():
+                assert_allclose(strided_dwtn[key], expected[key])
+
+def test_byte_offset():
+    wavelet = pywt.Wavelet('haar')
+    for dtype in ('float32', 'float64'):
+        data = np.array([[0, 4, 1, 5, 1, 4],
+                         [0, 5, 6, 3, 2, 1],
+                         [2, 5, 19, 4, 19, 1]],
+                        dtype=dtype)
+
+        for mode in pywt.MODES.modes:
+            expected = pywt.dwtn(data, wavelet)
+            padded = np.ones((3, 6), dtype=np.dtype([('data', data.dtype),
+                                                     ('pad', 'byte')]))
+            padded[:] = data
+            padded_dwtn = pywt.dwtn(padded['data'], wavelet)
+            for key in expected.keys():
+                assert_allclose(padded_dwtn[key], expected[key])
+
 
 def test_idwtn_idwt2():
     data = np.array([

--- a/pywt/tests/test_multidim.py
+++ b/pywt/tests/test_multidim.py
@@ -9,9 +9,14 @@ from numpy.testing import (run_module_suite, assert_allclose, assert_,
 import pywt
 
 
-def test_dwtn_input_error():
+def test_dwtn_input():
+    # Array-like must be accepted
+    pywt.dwtn([1, 2, 3, 4], 'haar')
+    # Others must not
     data = dict()
-    assert_raises(ValueError, pywt.dwtn, data, 'haar')
+    assert_raises(TypeError, pywt.dwtn, data, 'haar')
+    # Must be at least 1D
+    assert_raises(ValueError, pywt.dwtn, 2, 'haar')
 
 
 def test_3D_reconstruct():

--- a/pywt/tests/test_multidim.py
+++ b/pywt/tests/test_multidim.py
@@ -20,7 +20,6 @@ def test_dwtn_input():
 
 
 def test_3D_reconstruct():
-    # All dimensions even length so `take` does not need to be specified
     data = np.array([
         [[0, 4, 1, 5, 1, 4],
          [0, 5, 26, 3, 2, 1],
@@ -32,11 +31,10 @@ def test_3D_reconstruct():
          [5, 2, 6, 78, 12, 2]]])
 
     wavelet = pywt.Wavelet('haar')
-    d = pywt.dwtn(data, wavelet)
-    # idwtn creates even-length shapes (2x dwtn size)
-    original_shape = [slice(None, s) for s in data.shape]
-    assert_allclose(data, pywt.idwtn(d, wavelet)[original_shape],
-                    rtol=1e-13, atol=1e-13)
+    for mode in pywt.MODES.modes:
+        d = pywt.dwtn(data, wavelet, mode=mode)
+        assert_allclose(data, pywt.idwtn(d, wavelet, mode=mode),
+                        rtol=1e-13, atol=1e-13)
 
 
 def test_stride():
@@ -106,27 +104,6 @@ def test_idwtn_missing():
 
     assert_allclose(pywt.idwt2((LL, (HL, None, HH)), wavelet),
                     pywt.idwtn(d, 'haar'), atol=1e-15)
-
-
-def test_idwtn_take():
-    data = np.array([
-        [[1, 4, 1, 5, 1, 4],
-         [0, 5, 6, 3, 2, 1],
-         [2, 5, 19, 4, 19, 1]],
-        [[1, 5, 1, 2, 3, 4],
-         [7, 12, 6, 52, 7, 8],
-         [5, 2, 6, 78, 12, 2]]])
-    wavelet = pywt.Wavelet('haar')
-    d = pywt.dwtn(data, wavelet)
-
-    assert_(data.shape != pywt.idwtn(d, wavelet).shape)
-    assert_allclose(data, pywt.idwtn(d, wavelet, take=data.shape), atol=1e-15)
-
-    # Check shape for take not equal to data.shape
-    data = np.random.randn(51, 17, 68)
-    d = pywt.dwtn(data, wavelet)
-    assert_equal((2, 2, 2), pywt.idwtn(d, wavelet, take=2).shape)
-    assert_equal((52, 18, 68), pywt.idwtn(d, wavelet, take=0).shape)
 
 
 def test_ignore_invalid_keys():


### PR DESCRIPTION
This essentially moves `np.apply_along_axis` into C. It beats @grlee77's implementation in #68 by 40% for a 2D `dwtn`, though I have not profiled the `idwtn`. This is based of #102, so consider it blocked until that is merged. In the meantime, I'm opening this for discussion and CI.

Two main questions:

1. Should we change `idwtn` to match the behaviour of `idwt`, where the `take` parameter is applied automagically (by using `upsampling_convolution_valid_sf` rather than `upsampling_convolution_full`)? Unless there is a good use-case for reconstructing the values of the padding, I vote for doing this. Dealing with the `take` parameter is annoying.
2. Can we nuke `upcoef` and `downcoef`? They were previously used for `idwtn` and `dwtn`, but are no longer. `downcoef` very similar to `_dwt`. `upcoef` is slightly different from `idwt` as described above, but if we change that behaviour then it will be similar.