### PR TITLE
make sure transforms respect float32 dtype

### DIFF
--- a/pywt/multidim.py
+++ b/pywt/multidim.py
@@ -74,13 +74,13 @@ def dwt2(data, wavelet, mode='sym'):
 
     LL, HL = [], []
     for row in L:
-        cA, cD = dwt(np.array(row, np.float64), wavelet, mode)
+        cA, cD = dwt(row, wavelet, mode)
         LL.append(cA)
         HL.append(cD)
 
     LH, HH = [], []
     for row in H:
-        cA, cD = dwt(np.array(row, np.float64), wavelet, mode)
+        cA, cD = dwt(row, wavelet, mode)
         LH.append(cA)
         HH.append(cD)
 
@@ -192,7 +192,7 @@ def idwt2(coeffs, wavelet, mode='sym'):
     for rowL, rowH in zip(L, H):
         data.append(idwt(rowL, rowH, wavelet, mode, 1))
 
-    return np.array(data, np.float64)
+    return np.array(data)
 
 
 def dwtn(data, wavelet, mode='sym'):
@@ -398,17 +398,13 @@ def swt2(data, wavelet, level, start_level=0):
 
         LL, LH = [], []
         for row in L:
-            cA, cD = swt(
-                np.array(row, np.float64), wavelet, level=1, start_level=i
-            )[0]
+            cA, cD = swt(row, wavelet, level=1, start_level=i)[0]
             LL.append(cA)
             LH.append(cD)
 
         HL, HH = [], []
         for row in H:
-            cA, cD = swt(
-                np.array(row, np.float64), wavelet, level=1, start_level=i
-            )[0]
+            cA, cD = swt(row, wavelet, level=1, start_level=i)[0]
             HL.append(cA)
             HH.append(cD)
 

--- a/pywt/multilevel.py
+++ b/pywt/multilevel.py
@@ -150,7 +150,7 @@ def wavedec2(data, wavelet, mode='sym', level=None):
            [ 1.,  1.,  1.,  1.]])
     """
 
-    data = np.asarray(data, np.float64)
+    data = np.asarray(data)
 
     if data.ndim != 2:
         raise ValueError("Expected 2D input data.")

--- a/pywt/tests/test_dwt_idwt.py
+++ b/pywt/tests/test_dwt_idwt.py
@@ -26,9 +26,8 @@ def test_dwt_idwt_dtypes():
     dtypes_in = [np.int8, np.float32, np.float64]
     dtypes_out = [np.float64, np.float32, np.float64]
     wavelet = pywt.Wavelet('haar')
-    for n, dt in enumerate(dtypes_in):
-        dt_out = dtypes_out[n]
-        x = np.ones(4, dtype=dt)
+    for dt_in, dt_out in zip(dtypes_in, dtypes_out):
+        x = np.ones(4, dtype=dt_in)
         cA, cD = pywt.dwt(x, wavelet)
         assert_(cA.dtype == dt_out)
         assert_(cD.dtype == dt_out)

--- a/pywt/tests/test_dwt_idwt.py
+++ b/pywt/tests/test_dwt_idwt.py
@@ -21,6 +21,22 @@ def test_dwt_idwt_basic():
     assert_allclose(x_roundtrip, x, rtol=1e-10)
 
 
+def test_dwt_idwt_dtypes():
+    # Check that float32 is preserved.  Other types get converted to float64.
+    dtypes_in = [np.int8, np.float32, np.float64]
+    dtypes_out = [np.float64, np.float32, np.float64]
+    wavelet = pywt.Wavelet('haar')
+    for n, dt in enumerate(dtypes_in):
+        dt_out = dtypes_out[n]
+        x = np.ones(4, dtype=dt)
+        cA, cD = pywt.dwt(x, wavelet)
+        assert_(cA.dtype == dt_out)
+        assert_(cD.dtype == dt_out)
+
+        x_roundtrip = pywt.idwt(cA, cD, wavelet)
+        assert_(x_roundtrip.dtype == dt_out)
+
+
 def test_dwt_input_error():
     data = np.ones((16, 1))
     assert_raises(ValueError, pywt.dwt, data, 'haar')

--- a/pywt/tests/test_dwt_idwt.py
+++ b/pywt/tests/test_dwt_idwt.py
@@ -28,7 +28,7 @@ def test_dwt_idwt_dtypes():
     wavelet = pywt.Wavelet('haar')
     for dt_in, dt_out in zip(dtypes_in, dtypes_out):
         x = np.ones(4, dtype=dt_in)
-        errmsg = "wrong dtype returned for {} input".format(dt_in)
+        errmsg = "wrong dtype returned for {0} input".format(dt_in)
 
         cA, cD = pywt.dwt(x, wavelet)
         assert_(cA.dtype == cD.dtype == dt_out, "dwt: " + errmsg)

--- a/pywt/tests/test_dwt_idwt.py
+++ b/pywt/tests/test_dwt_idwt.py
@@ -28,12 +28,13 @@ def test_dwt_idwt_dtypes():
     wavelet = pywt.Wavelet('haar')
     for dt_in, dt_out in zip(dtypes_in, dtypes_out):
         x = np.ones(4, dtype=dt_in)
+        errmsg = "wrong dtype returned for {} input".format(dt_in)
+
         cA, cD = pywt.dwt(x, wavelet)
-        assert_(cA.dtype == dt_out)
-        assert_(cD.dtype == dt_out)
+        assert_(cA.dtype == cD.dtype == dt_out, "dwt: " + errmsg)
 
         x_roundtrip = pywt.idwt(cA, cD, wavelet)
-        assert_(x_roundtrip.dtype == dt_out)
+        assert_(x_roundtrip.dtype == dt_out, "idwt: " + errmsg)
 
 
 def test_dwt_input_error():

--- a/pywt/tests/test_multidim.py
+++ b/pywt/tests/test_multidim.py
@@ -126,5 +126,38 @@ def test_error_mismatched_size():
     assert_raises(ValueError, pywt.idwtn, d, wavelet)
 
 
+def test_dwt2_idwt2_dtypes():
+    # Check that float32 is preserved.  Other types get converted to float64.
+    dtypes_in = [np.int8, np.float32, np.float64]
+    dtypes_out = [np.float64, np.float32, np.float64]
+    wavelet = pywt.Wavelet('haar')
+    for n, dt in enumerate(dtypes_in):
+        dt_out = dtypes_out[n]
+        x = np.ones((4, 4), dtype=dt)
+
+        cA, (cH, cV, cD) = pywt.dwt2(x, wavelet)
+        assert_(cA.dtype == cH.dtype == cV.dtype == cD.dtype)
+
+        x_roundtrip = pywt.idwt2((cA, (cH, cV, cD)), wavelet)
+        assert_(x_roundtrip.dtype == dt_out)
+
+
+def test_dwtn_idwtn_dtypes():
+    # Check that float32 is preserved.  Other types get converted to float64.
+    dtypes_in = [np.int8, np.float32, np.float64]
+    dtypes_out = [np.float64, np.float32, np.float64]
+    wavelet = pywt.Wavelet('haar')
+    for n, dt in enumerate(dtypes_in):
+        dt_out = dtypes_out[n]
+        x = np.ones((4, 4), dtype=dt)
+
+        coeffs = pywt.dwtn(x, wavelet)
+        for k, v in coeffs.items():
+            assert_(v.dtype == dt_out)
+
+        x_roundtrip = pywt.idwtn(coeffs, wavelet)
+        assert_(x_roundtrip.dtype == dt_out)
+
+
 if __name__ == '__main__':
     run_module_suite()

--- a/pywt/tests/test_multidim.py
+++ b/pywt/tests/test_multidim.py
@@ -133,12 +133,14 @@ def test_dwt2_idwt2_dtypes():
     wavelet = pywt.Wavelet('haar')
     for dt_in, dt_out in zip(dtypes_in, dtypes_out):
         x = np.ones((4, 4), dtype=dt_in)
+        errmsg = "wrong dtype returned for {} input".format(dt_in)
 
         cA, (cH, cV, cD) = pywt.dwt2(x, wavelet)
-        assert_(cA.dtype == cH.dtype == cV.dtype == cD.dtype)
+        assert_(cA.dtype == cH.dtype == cV.dtype == cD.dtype,
+                "dwt2: " + errmsg)
 
         x_roundtrip = pywt.idwt2((cA, (cH, cV, cD)), wavelet)
-        assert_(x_roundtrip.dtype == dt_out)
+        assert_(x_roundtrip.dtype == dt_out, "idwt2: " + errmsg)
 
 
 def test_dwtn_idwtn_dtypes():
@@ -148,13 +150,14 @@ def test_dwtn_idwtn_dtypes():
     wavelet = pywt.Wavelet('haar')
     for dt_in, dt_out in zip(dtypes_in, dtypes_out):
         x = np.ones((4, 4), dtype=dt_in)
+        errmsg = "wrong dtype returned for {} input".format(dt_in)
 
         coeffs = pywt.dwtn(x, wavelet)
         for k, v in coeffs.items():
-            assert_(v.dtype == dt_out)
+            assert_(v.dtype == dt_out, "dwtn: " + errmsg)
 
         x_roundtrip = pywt.idwtn(coeffs, wavelet)
-        assert_(x_roundtrip.dtype == dt_out)
+        assert_(x_roundtrip.dtype == dt_out, "idwtn: " + errmsg)
 
 
 if __name__ == '__main__':

--- a/pywt/tests/test_multidim.py
+++ b/pywt/tests/test_multidim.py
@@ -133,7 +133,7 @@ def test_dwt2_idwt2_dtypes():
     wavelet = pywt.Wavelet('haar')
     for dt_in, dt_out in zip(dtypes_in, dtypes_out):
         x = np.ones((4, 4), dtype=dt_in)
-        errmsg = "wrong dtype returned for {} input".format(dt_in)
+        errmsg = "wrong dtype returned for {0} input".format(dt_in)
 
         cA, (cH, cV, cD) = pywt.dwt2(x, wavelet)
         assert_(cA.dtype == cH.dtype == cV.dtype == cD.dtype,
@@ -150,7 +150,7 @@ def test_dwtn_idwtn_dtypes():
     wavelet = pywt.Wavelet('haar')
     for dt_in, dt_out in zip(dtypes_in, dtypes_out):
         x = np.ones((4, 4), dtype=dt_in)
-        errmsg = "wrong dtype returned for {} input".format(dt_in)
+        errmsg = "wrong dtype returned for {0} input".format(dt_in)
 
         coeffs = pywt.dwtn(x, wavelet)
         for k, v in coeffs.items():

--- a/pywt/tests/test_multidim.py
+++ b/pywt/tests/test_multidim.py
@@ -131,9 +131,8 @@ def test_dwt2_idwt2_dtypes():
     dtypes_in = [np.int8, np.float32, np.float64]
     dtypes_out = [np.float64, np.float32, np.float64]
     wavelet = pywt.Wavelet('haar')
-    for n, dt in enumerate(dtypes_in):
-        dt_out = dtypes_out[n]
-        x = np.ones((4, 4), dtype=dt)
+    for dt_in, dt_out in zip(dtypes_in, dtypes_out):
+        x = np.ones((4, 4), dtype=dt_in)
 
         cA, (cH, cV, cD) = pywt.dwt2(x, wavelet)
         assert_(cA.dtype == cH.dtype == cV.dtype == cD.dtype)
@@ -147,9 +146,8 @@ def test_dwtn_idwtn_dtypes():
     dtypes_in = [np.int8, np.float32, np.float64]
     dtypes_out = [np.float64, np.float32, np.float64]
     wavelet = pywt.Wavelet('haar')
-    for n, dt in enumerate(dtypes_in):
-        dt_out = dtypes_out[n]
-        x = np.ones((4, 4), dtype=dt)
+    for dt_in, dt_out in zip(dtypes_in, dtypes_out):
+        x = np.ones((4, 4), dtype=dt_in)
 
         coeffs = pywt.dwtn(x, wavelet)
         for k, v in coeffs.items():

--- a/pywt/tests/test_multilevel.py
+++ b/pywt/tests/test_multilevel.py
@@ -56,7 +56,7 @@ def test_swt_dtypes():
     dtypes_out = [np.float64, np.float32, np.float64]
     wavelet = pywt.Wavelet('haar')
     for dt_in, dt_out in zip(dtypes_in, dtypes_out):
-        errmsg = "wrong dtype returned for {} input".format(dt_in)
+        errmsg = "wrong dtype returned for {0} input".format(dt_in)
 
         # swt
         x = np.ones(8, dtype=dt_in)
@@ -85,7 +85,7 @@ def test_multilevel_dtypes():
     for dt_in, dt_out in zip(dtypes_in, dtypes_out):
         # wavedec, waverec
         x = np.ones(8, dtype=dt_in)
-        errmsg = "wrong dtype returned for {} input".format(dt_in)
+        errmsg = "wrong dtype returned for {0} input".format(dt_in)
 
         coeffs = pywt.wavedec(x, wavelet, level=2)
         for c in coeffs:

--- a/pywt/tests/test_multilevel.py
+++ b/pywt/tests/test_multilevel.py
@@ -50,10 +50,57 @@ def test_swt_decomposition():
     assert_(pywt.swt_max_level(len(x)) == 3)
 
 
+def test_swt_dtypes():
+    # Check that float32 is preserved.  Other types get converted to float64.
+    dtypes_in = [np.int8, np.float32, np.float64]
+    dtypes_out = [np.float64, np.float32, np.float64]
+    wavelet = pywt.Wavelet('haar')
+    for n, dt in enumerate(dtypes_in):
+        dt_out = dtypes_out[n]
+
+        # swt
+        x = np.ones(8, dtype=dt)
+        (cA2, cD2), (cA1, cD1) = pywt.swt(x, wavelet, level=2)
+        assert_(cA2.dtype == cD2.dtype == cA1.dtype == cD1.dtype == dt_out)
+
+        # swt2
+        x = np.ones((8, 8), dtype=dt)
+        cA, (cH, cV, cD) = pywt.swt2(x, wavelet, level=1)[0]
+        assert_(cA.dtype == cH.dtype == cV.dtype == cD.dtype == dt_out)
+
+
 def test_wavedec2():
     coeffs = pywt.wavedec2(np.ones((4, 4)), 'db1')
     assert_(len(coeffs) == 3)
     assert_allclose(pywt.waverec2(coeffs, 'db1'), np.ones((4, 4)), rtol=1e-12)
+
+
+def test_multilevel_dtypes():
+    # Check that float32 is preserved.  Other types get converted to float64.
+    dtypes_in = [np.int8, np.float32, np.float64]
+    dtypes_out = [np.float64, np.float32, np.float64]
+    wavelet = pywt.Wavelet('haar')
+    for n, dt in enumerate(dtypes_in):
+        dt_out = dtypes_out[n]
+
+        # wavedec, waverec
+        x = np.ones(8, dtype=dt)
+        coeffs = pywt.wavedec(x, wavelet, level=2)
+        for c in coeffs:
+            assert_(c.dtype == dt_out)
+        x_roundtrip = pywt.waverec(coeffs, wavelet)
+        assert_(x_roundtrip.dtype == dt_out)
+
+        # wavedec2, waverec2
+        x = np.ones((8, 8), dtype=dt)
+        cA, coeffsD2, coeffsD1 = pywt.wavedec2(x, wavelet, level=2)
+        assert_(cA.dtype == dt_out)
+        for c in coeffsD1:
+            assert_(c.dtype == dt_out)
+        for c in coeffsD2:
+            assert_(c.dtype == dt_out)
+        x_roundtrip = pywt.waverec2([cA, coeffsD2, coeffsD1], wavelet)
+        assert_(x_roundtrip.dtype == dt_out)
 
 
 if __name__ == '__main__':

--- a/pywt/tests/test_multilevel.py
+++ b/pywt/tests/test_multilevel.py
@@ -55,16 +55,14 @@ def test_swt_dtypes():
     dtypes_in = [np.int8, np.float32, np.float64]
     dtypes_out = [np.float64, np.float32, np.float64]
     wavelet = pywt.Wavelet('haar')
-    for n, dt in enumerate(dtypes_in):
-        dt_out = dtypes_out[n]
-
+    for dt_in, dt_out in zip(dtypes_in, dtypes_out):
         # swt
-        x = np.ones(8, dtype=dt)
+        x = np.ones(8, dtype=dt_in)
         (cA2, cD2), (cA1, cD1) = pywt.swt(x, wavelet, level=2)
         assert_(cA2.dtype == cD2.dtype == cA1.dtype == cD1.dtype == dt_out)
 
         # swt2
-        x = np.ones((8, 8), dtype=dt)
+        x = np.ones((8, 8), dtype=dt_in)
         cA, (cH, cV, cD) = pywt.swt2(x, wavelet, level=1)[0]
         assert_(cA.dtype == cH.dtype == cV.dtype == cD.dtype == dt_out)
 
@@ -80,11 +78,9 @@ def test_multilevel_dtypes():
     dtypes_in = [np.int8, np.float32, np.float64]
     dtypes_out = [np.float64, np.float32, np.float64]
     wavelet = pywt.Wavelet('haar')
-    for n, dt in enumerate(dtypes_in):
-        dt_out = dtypes_out[n]
-
+    for dt_in, dt_out in zip(dtypes_in, dtypes_out):
         # wavedec, waverec
-        x = np.ones(8, dtype=dt)
+        x = np.ones(8, dtype=dt_in)
         coeffs = pywt.wavedec(x, wavelet, level=2)
         for c in coeffs:
             assert_(c.dtype == dt_out)
@@ -92,7 +88,7 @@ def test_multilevel_dtypes():
         assert_(x_roundtrip.dtype == dt_out)
 
         # wavedec2, waverec2
-        x = np.ones((8, 8), dtype=dt)
+        x = np.ones((8, 8), dtype=dt_in)
         cA, coeffsD2, coeffsD1 = pywt.wavedec2(x, wavelet, level=2)
         assert_(cA.dtype == dt_out)
         for c in coeffsD1:

--- a/pywt/tests/test_multilevel.py
+++ b/pywt/tests/test_multilevel.py
@@ -56,15 +56,19 @@ def test_swt_dtypes():
     dtypes_out = [np.float64, np.float32, np.float64]
     wavelet = pywt.Wavelet('haar')
     for dt_in, dt_out in zip(dtypes_in, dtypes_out):
+        errmsg = "wrong dtype returned for {} input".format(dt_in)
+
         # swt
         x = np.ones(8, dtype=dt_in)
         (cA2, cD2), (cA1, cD1) = pywt.swt(x, wavelet, level=2)
-        assert_(cA2.dtype == cD2.dtype == cA1.dtype == cD1.dtype == dt_out)
+        assert_(cA2.dtype == cD2.dtype == cA1.dtype == cD1.dtype == dt_out,
+                "swt: " + errmsg)
 
         # swt2
         x = np.ones((8, 8), dtype=dt_in)
         cA, (cH, cV, cD) = pywt.swt2(x, wavelet, level=1)[0]
-        assert_(cA.dtype == cH.dtype == cV.dtype == cD.dtype == dt_out)
+        assert_(cA.dtype == cH.dtype == cV.dtype == cD.dtype == dt_out,
+                "swt2: " + errmsg)
 
 
 def test_wavedec2():
@@ -81,22 +85,24 @@ def test_multilevel_dtypes():
     for dt_in, dt_out in zip(dtypes_in, dtypes_out):
         # wavedec, waverec
         x = np.ones(8, dtype=dt_in)
+        errmsg = "wrong dtype returned for {} input".format(dt_in)
+
         coeffs = pywt.wavedec(x, wavelet, level=2)
         for c in coeffs:
-            assert_(c.dtype == dt_out)
+            assert_(c.dtype == dt_out, "wavedec: " + errmsg)
         x_roundtrip = pywt.waverec(coeffs, wavelet)
-        assert_(x_roundtrip.dtype == dt_out)
+        assert_(x_roundtrip.dtype == dt_out, "waverec: " + errmsg)
 
         # wavedec2, waverec2
         x = np.ones((8, 8), dtype=dt_in)
         cA, coeffsD2, coeffsD1 = pywt.wavedec2(x, wavelet, level=2)
-        assert_(cA.dtype == dt_out)
+        assert_(cA.dtype == dt_out, "wavedec2: " + errmsg)
         for c in coeffsD1:
-            assert_(c.dtype == dt_out)
+            assert_(c.dtype == dt_out, "wavedec2: " + errmsg)
         for c in coeffsD2:
-            assert_(c.dtype == dt_out)
+            assert_(c.dtype == dt_out, "wavedec2: " + errmsg)
         x_roundtrip = pywt.waverec2([cA, coeffsD2, coeffsD1], wavelet)
-        assert_(x_roundtrip.dtype == dt_out)
+        assert_(x_roundtrip.dtype == dt_out, "waverec2: " + errmsg)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This PR adds several tests that verify that float32 inputs result in float32 outputs for all transforms.  They also check that both float64 and int8 inputs give float64 outputs.

Bugs where float32 input resulted in float64 output were uncovered and fixed for the following four transforms:  ``dwt2``, ``idwt2``, `wavedec2``, ``swt2``.  
