### PR TITLE
TST: don't build .exe installers on Appveyor anymore, only wheels.

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -42,8 +42,8 @@ install:
   # Setuptools too old on Appveyor, messes up PEP 440 version string (replaces
   # + with -) which prevents pip from installing the built wheel.
   - "pip install -U --no-deps setuptools"
-  # Build a wheel and a .exe installer
-  - "%CMD_IN_ENV% python setup.py bdist_wheel bdist_wininst"
+  # Build a wheel (installer)
+  - "%CMD_IN_ENV% python setup.py bdist_wheel"
   - ps: "ls dist"
 
   # Install the generated wheel package to test it

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,6 @@
 # AppVeyor.com is a Continuous Integration service to build and run tests under
 # Windows
-# https://ci.appveyor.com/project/rgommers/pywt
+# https://ci.appveyor.com/project/PyWavelets/pywt
 
 environment:
   global:


### PR DESCRIPTION
The .exe installers aren't needed on PyPi anymore - if anyone still
uses easy_install then it's time they learn to use pip.