### PR TITLE
[RFC] ENH: Add axis argument to dwt

### DIFF
--- a/doc/source/dev/testing.rst
+++ b/doc/source/dev/testing.rst
@@ -42,5 +42,5 @@ To for example run tests for Python 2.7 and Python 3.4 use::
 For more information see the `Tox`_ documentation.
 
 
-.. _nose: http://nose.readthedocs.org/en/latest/ 
-.. _Tox: http://tox.testrun.org/ 
+.. _nose: http://nose.readthedocs.org/en/latest/
+.. _Tox: http://tox.testrun.org/

--- a/doc/source/ref/dwt-discrete-wavelet-transform.rst
+++ b/doc/source/ref/dwt-discrete-wavelet-transform.rst
@@ -15,7 +15,7 @@ functions used to perform single- and multilevel Discrete Wavelet Transforms.
 Single level ``dwt``
 --------------------
 
-.. function:: dwt(data, wavelet[, mode='symmetric'])
+.. function:: dwt(data, wavelet[, mode='symmetric', axis=-1])
 
   The :func:`dwt` function is used to perform single level, one dimensional
   Discrete Wavelet Transform.
@@ -29,6 +29,8 @@ Single level ``dwt``
   :param wavelet: |wavelet|
 
   :param mode: |mode|
+
+  :param axis: |axis|
 
   The transform coefficients are returned as two arrays containing
   approximation (*cA*) and detail (*cD*) coefficients respectively. Length
@@ -44,6 +46,10 @@ Single level ``dwt``
   * for :ref:`periodization <Modes.periodization>` mode (``"periodization"``)::
 
       len(cA) == len(cD) == ceil(len(data) / 2)
+
+  The transform can be performed over one axis of multi-dimensional
+  data. By default this is the last axis. For multi-dimensional transforms
+  see the :ref:`2D transforms <ref-dwt2>` section.
 
   **Example:**
 

--- a/doc/source/ref/idwt-inverse-discrete-wavelet-transform.rst
+++ b/doc/source/ref/idwt-inverse-discrete-wavelet-transform.rst
@@ -11,7 +11,7 @@ Inverse Discrete Wavelet Transform (IDWT)
 Single level ``idwt``
 ---------------------
 
-.. function:: idwt(cA, cD, wavelet[, mode='symmetric'[, correct_size=0]])
+.. function:: idwt(cA, cD, wavelet[, mode='symmetric'])
 
   The :func:`idwt` function reconstructs data from the given coefficients by
   performing single level Inverse Discrete Wavelet Transform.
@@ -24,16 +24,6 @@ Single level ``idwt``
 
   :param mode: |mode| This is only important when DWT was performed in
                :ref:`periodization <Modes.periodization>` mode.
-
-  :param correct_size: Typically, *cA* and *cD* coefficients lists must have
-                       equal lengths in order to perform IDWT. Setting
-                       *correct_size* to `True` allows *cA* to be greater in
-                       size by one element compared to the *cD* size. This
-                       option is very useful when doing multilevel decomposition
-                       and reconstruction (as for example with the
-                       :func:`wavedec` function) of non-dyadic length signals
-                       when such minor differences can occur at various levels
-                       of IDWT.
 
   **Example:**
 

--- a/doc/source/ref/idwt-inverse-discrete-wavelet-transform.rst
+++ b/doc/source/ref/idwt-inverse-discrete-wavelet-transform.rst
@@ -89,7 +89,7 @@ Direct reconstruction with ``upcoef``
   Direct reconstruction from coefficients.
 
   :param part: Defines the input coefficients type:
-  
+
       - **'a'** - approximations reconstruction is performed
       - **'d'** - details reconstruction is performed
 

--- a/doc/source/ref/idwt-inverse-discrete-wavelet-transform.rst
+++ b/doc/source/ref/idwt-inverse-discrete-wavelet-transform.rst
@@ -11,7 +11,7 @@ Inverse Discrete Wavelet Transform (IDWT)
 Single level ``idwt``
 ---------------------
 
-.. function:: idwt(cA, cD, wavelet[, mode='symmetric'])
+.. function:: idwt(cA, cD, wavelet[, mode='symmetric', axis=-1])
 
   The :func:`idwt` function reconstructs data from the given coefficients by
   performing single level Inverse Discrete Wavelet Transform.
@@ -24,6 +24,9 @@ Single level ``idwt``
 
   :param mode: |mode| This is only important when DWT was performed in
                :ref:`periodization <Modes.periodization>` mode.
+
+  :param axis: |axis| This should be the same as the axis used in the
+               DWT that produced the coefficients.
 
   **Example:**
 

--- a/doc/source/ref/other-functions.rst
+++ b/doc/source/ref/other-functions.rst
@@ -22,7 +22,7 @@ Single-level n-dimensional Discrete Wavelet Transform.
    Results are arranged in a dictionary, where key specifies
    the transform type on each dimension and value is a n-dimensional
    coefficients array.
-    
+
    For example, for a 2D case the result will look something like this::
 
       {

--- a/doc/source/regression/dwt-idwt.rst
+++ b/doc/source/regression/dwt-idwt.rst
@@ -138,19 +138,6 @@ must have the same size.
     ...
     ValueError: Coefficients arrays must have the same size.
 
-But for some applications like multilevel DWT and IDWT it is sometimes convenient
-to allow for a small departure from this behaviour. When the *correct_size* flag
-is set, the approximation coefficients array can be larger from the details
-coefficient array by one element:
-
-    >>> print pywt.idwt([1, 2, 3, 4, 5], [1, 2, 3, 4], 'db2', 'symmetric', correct_size=True)
-    [ 1.76776695  0.61237244  3.18198052  0.61237244  4.59619408  0.61237244]
-
-    >>> print pywt.idwt([1, 2, 3, 4], [1, 2, 3, 4, 5], 'db2', 'symmetric', correct_size=True)
-    Traceback (most recent call last):
-    ...
-    ValueError: Coefficients arrays must satisfy (0 <= len(cA) - len(cD) <= 1).
-
 
 Not every coefficient array can be used in :func:`IDWT <idwt>`. In the
 following example the :func:`idwt` will fail because the input arrays are

--- a/doc/source/substitutions.rst
+++ b/doc/source/substitutions.rst
@@ -5,3 +5,6 @@
 
 .. |wavelet| replace::
    Wavelet to use in the transform. This can be a name of the wavelet from the :func:`wavelist` list or a :class:`Wavelet` object instance.
+
+.. |axis| replace::
+   Axis to perform the transform over, in the case of multi-dimensional input.

--- a/pywt/src/_pywt.pyx
+++ b/pywt/src/_pywt.pyx
@@ -898,13 +898,9 @@ def idwt(cA, cD, object wavelet, object mode='symmetric', int axis=-1):
     if cA is not None:
         dt = _check_dtype(cA)
         cA = np.array(cA, dtype=dt)
-        if cA.ndim != 1:
-            raise ValueError("idwt requires 1D coefficient arrays.")
     if cD is not None:
         dt = _check_dtype(cD)
         cD = np.array(cD, dtype=dt)
-        if cD.ndim != 1:
-            raise ValueError("idwt requires 1D coefficient arrays.")
 
     if cA is not None and cD is not None:
         if cA.dtype != cD.dtype:

--- a/pywt/src/_pywt.pyx
+++ b/pywt/src/_pywt.pyx
@@ -755,6 +755,43 @@ def _dwt(np.ndarray data, object wavelet, object mode='symmetric', int axis=-1):
     return (cA, cD)
 
 
+def dwt_single(np.ndarray[data_t, ndim=1] data, object wavelet,
+                                                object mode='symmetric'):
+    cdef np.ndarray[data_t, ndim=1, mode="c"] cA, cD
+    cdef Wavelet w = c_wavelet_from_object(wavelet)
+    cdef common.MODE mode_ = _try_mode(mode)
+
+    cdef size_t output_len
+
+    data = data.astype(_check_dtype(data), copy=True)
+
+    output_len = common.dwt_buffer_length(data.size, w.dec_len, mode_)
+    if output_len < 1:
+        raise RuntimeError("Invalid output length.")
+
+    cA = np.zeros(output_len, data.dtype)
+    cD = np.zeros(output_len, data.dtype)
+
+    if data_t == np.float64_t:
+        if (c_wt.double_dec_a(&data[0], data.size, w.w,
+                              &cA[0], cA.size, mode_) < 0
+            or
+            c_wt.double_dec_d(&data[0], data.size, w.w,
+                              &cD[0], cD.size, mode_) < 0):
+            raise RuntimeError("C dwt failed.")
+    elif data_t == np.float32_t:
+        if (c_wt.float_dec_a(&data[0], data.size, w.w,
+                             &cA[0], cA.size, mode_) < 0
+            or
+            c_wt.float_dec_d(&data[0], data.size, w.w,
+                             &cD[0], cD.size, mode_) < 0):
+            raise RuntimeError("C dwt failed.")
+    else:
+        raise RuntimeError("Invalid data type.")
+
+    return (cA, cD)
+
+
 cpdef dwt_axis(np.ndarray data, object wavelet, object mode='symmetric', unsigned int axis=0):
     cdef Wavelet w = c_wavelet_from_object(wavelet)
     cdef common.MODE _mode = _try_mode(mode)

--- a/pywt/src/_pywt.pyx
+++ b/pywt/src/_pywt.pyx
@@ -816,74 +816,6 @@ cpdef dwt_axis(np.ndarray data, object wavelet, object mode='symmetric', unsigne
     return (cA, cD)
 
 
-cpdef idwt_axis(np.ndarray coefs_a, np.ndarray coefs_d, object wavelet,
-                object mode='symmetric', unsigned int axis=0):
-    cdef Wavelet w = c_wavelet_from_object(wavelet)
-    cdef common.ArrayInfo a_info, d_info, output_info
-    cdef np.ndarray output
-    cdef np.dtype output_dtype
-    cdef size_t[::1] output_shape
-    cdef common.MODE _mode = _try_mode(mode)
-
-    if coefs_a is not None:
-        if coefs_d is not None and coefs_d.dtype.itemsize > coefs_a.dtype.itemsize:
-            coefs_a = coefs_a.astype(_check_dtype(coefs_d), copy=False)
-        else:
-            coefs_a = coefs_a.astype(_check_dtype(coefs_a), copy=False)
-        a_info.ndim = coefs_a.ndim
-        a_info.strides = <index_t *> coefs_a.strides
-        a_info.shape = <size_t *> coefs_a.shape
-    if coefs_d is not None:
-        if coefs_a is not None and coefs_a.dtype.itemsize > coefs_d.dtype.itemsize:
-            coefs_d = coefs_d.astype(_check_dtype(coefs_a), copy=False)
-        else:
-            coefs_d = coefs_d.astype(_check_dtype(coefs_d), copy=False)
-        d_info.ndim = coefs_d.ndim
-        d_info.strides = <index_t *> coefs_d.strides
-        d_info.shape = <size_t *> coefs_d.shape
-
-    if coefs_a is not None:
-        output_shape = (<size_t [:coefs_a.ndim]> <size_t *> coefs_a.shape).copy()
-        output_shape[axis] = common.idwt_buffer_length(coefs_a.shape[axis],
-                                                       w.rec_len, _mode)
-        output_dtype = coefs_a.dtype
-    elif coefs_d is not None:
-        output_shape = (<size_t [:coefs_d.ndim]> <size_t *> coefs_d.shape).copy()
-        output_shape[axis] = common.idwt_buffer_length(coefs_d.shape[axis],
-                                                       w.rec_len, _mode)
-        output_dtype = coefs_d.dtype
-    else:
-        return None;
-
-    output = np.empty(output_shape, output_dtype)
-
-    output_info.ndim = output.ndim
-    output_info.strides = <index_t *> output.strides
-    output_info.shape = <size_t *> output.shape
-
-    if output.dtype == np.float64:
-        if c_wt.double_idwt_axis(<double *> coefs_a.data if coefs_a is not None else NULL,
-                                 &a_info if coefs_a is not None else NULL,
-                                 <double *> coefs_d.data if coefs_d is not None else NULL,
-                                 &d_info if coefs_d is not None else NULL,
-                                 <double *> output.data, output_info,
-                                 w.w, axis, _mode):
-            raise RuntimeError("C inverse wavelet transform failed")
-    elif output.dtype == np.float32:
-        if c_wt.float_idwt_axis(<float *> coefs_a.data if coefs_a is not None else NULL,
-                                &a_info if coefs_a is not None else NULL,
-                                <float *> coefs_d.data if coefs_d is not None else NULL,
-                                &d_info if coefs_d is not None else NULL,
-                                <float *> output.data, output_info,
-                                w.w, axis, _mode):
-            raise RuntimeError("C inverse wavelet transform failed")
-    else:
-        raise TypeError("Array must be floating point, not {}"
-                        .format(output.dtype))
-
-    return output
-
-
 def dwt_coeff_len(data_len, filter_len, mode='symmetric'):
     """
     dwt_coeff_len(data_len, filter_len, mode='symmetric')
@@ -1052,6 +984,74 @@ def _idwt(np.ndarray[data_t, ndim=1, mode="c"] cA,
         raise RuntimeError("Invalid data type.")
 
     return rec
+
+
+cpdef idwt_axis(np.ndarray coefs_a, np.ndarray coefs_d, object wavelet,
+                object mode='symmetric', unsigned int axis=0):
+    cdef Wavelet w = c_wavelet_from_object(wavelet)
+    cdef common.ArrayInfo a_info, d_info, output_info
+    cdef np.ndarray output
+    cdef np.dtype output_dtype
+    cdef size_t[::1] output_shape
+    cdef common.MODE _mode = _try_mode(mode)
+
+    if coefs_a is not None:
+        if coefs_d is not None and coefs_d.dtype.itemsize > coefs_a.dtype.itemsize:
+            coefs_a = coefs_a.astype(_check_dtype(coefs_d), copy=False)
+        else:
+            coefs_a = coefs_a.astype(_check_dtype(coefs_a), copy=False)
+        a_info.ndim = coefs_a.ndim
+        a_info.strides = <index_t *> coefs_a.strides
+        a_info.shape = <size_t *> coefs_a.shape
+    if coefs_d is not None:
+        if coefs_a is not None and coefs_a.dtype.itemsize > coefs_d.dtype.itemsize:
+            coefs_d = coefs_d.astype(_check_dtype(coefs_a), copy=False)
+        else:
+            coefs_d = coefs_d.astype(_check_dtype(coefs_d), copy=False)
+        d_info.ndim = coefs_d.ndim
+        d_info.strides = <index_t *> coefs_d.strides
+        d_info.shape = <size_t *> coefs_d.shape
+
+    if coefs_a is not None:
+        output_shape = (<size_t [:coefs_a.ndim]> <size_t *> coefs_a.shape).copy()
+        output_shape[axis] = common.idwt_buffer_length(coefs_a.shape[axis],
+                                                       w.rec_len, _mode)
+        output_dtype = coefs_a.dtype
+    elif coefs_d is not None:
+        output_shape = (<size_t [:coefs_d.ndim]> <size_t *> coefs_d.shape).copy()
+        output_shape[axis] = common.idwt_buffer_length(coefs_d.shape[axis],
+                                                       w.rec_len, _mode)
+        output_dtype = coefs_d.dtype
+    else:
+        return None;
+
+    output = np.empty(output_shape, output_dtype)
+
+    output_info.ndim = output.ndim
+    output_info.strides = <index_t *> output.strides
+    output_info.shape = <size_t *> output.shape
+
+    if output.dtype == np.float64:
+        if c_wt.double_idwt_axis(<double *> coefs_a.data if coefs_a is not None else NULL,
+                                 &a_info if coefs_a is not None else NULL,
+                                 <double *> coefs_d.data if coefs_d is not None else NULL,
+                                 &d_info if coefs_d is not None else NULL,
+                                 <double *> output.data, output_info,
+                                 w.w, axis, _mode):
+            raise RuntimeError("C inverse wavelet transform failed")
+    elif output.dtype == np.float32:
+        if c_wt.float_idwt_axis(<float *> coefs_a.data if coefs_a is not None else NULL,
+                                &a_info if coefs_a is not None else NULL,
+                                <float *> coefs_d.data if coefs_d is not None else NULL,
+                                &d_info if coefs_d is not None else NULL,
+                                <float *> output.data, output_info,
+                                w.w, axis, _mode):
+            raise RuntimeError("C inverse wavelet transform failed")
+    else:
+        raise TypeError("Array must be floating point, not {}"
+                        .format(output.dtype))
+
+    return output
 
 
 ###############################################################################

--- a/pywt/src/_pywt.pyx
+++ b/pywt/src/_pywt.pyx
@@ -869,7 +869,7 @@ cpdef idwt_axis(np.ndarray coefs_a, np.ndarray coefs_d, object wavelet,
                                  <double *> output.data, output_info,
                                  w.w, axis, _mode):
             raise RuntimeError("C inverse wavelet transform failed")
-    if output.dtype == np.float32:
+    elif output.dtype == np.float32:
         if c_wt.float_idwt_axis(<float *> coefs_a.data if coefs_a is not None else NULL,
                                 &a_info if coefs_a is not None else NULL,
                                 <float *> coefs_d.data if coefs_d is not None else NULL,
@@ -877,6 +877,9 @@ cpdef idwt_axis(np.ndarray coefs_a, np.ndarray coefs_d, object wavelet,
                                 <float *> output.data, output_info,
                                 w.w, axis, _mode):
             raise RuntimeError("C inverse wavelet transform failed")
+    else:
+        raise TypeError("Array must be floating point, not {}"
+                        .format(output.dtype))
 
     return output
 

--- a/pywt/src/_pywt.pyx
+++ b/pywt/src/_pywt.pyx
@@ -731,8 +731,6 @@ def dwt(object data, object wavelet, object mode='symmetric', int axis=-1):
     # accept array_like input; make a copy to ensure a contiguous array
     dt = _check_dtype(data)
     data = np.array(data, dtype=dt)
-    if data.ndim != 1:
-        raise ValueError("dwt requires a 1D data array.")
 
     return _dwt(data, wavelet, mode, axis=axis)
 

--- a/pywt/src/_pywt.pyx
+++ b/pywt/src/_pywt.pyx
@@ -746,6 +746,8 @@ def _dwt(np.ndarray data, object wavelet, object mode='symmetric', int axis=-1):
     if output_len < 1:
         raise RuntimeError("Invalid output length.")
 
+    if axis >= data.ndim:
+        raise ValueError("Axis greater than data dimensions")
     # convert negative axes
     axis = axis % data.ndim
 
@@ -938,6 +940,8 @@ def _idwt(np.ndarray cA, np.ndarray cD,
                "Wavelet and mode must be the same as used for decomposition.")
         raise ValueError(msg)
 
+    if axis >= cA.ndim:
+        raise ValueError("Axis greater than coefficient dimension")
     # convert negative axes
     axis = axis % cA.ndim
 

--- a/pywt/src/_pywt.pyx
+++ b/pywt/src/_pywt.pyx
@@ -680,7 +680,7 @@ def dwt_max_level(data_len, filter_len):
         return common.dwt_max_level(data_len, filter_len)
 
 
-def dwt(object data, object wavelet, object mode='symmetric'):
+def dwt(object data, object wavelet, object mode='symmetric', int axis=-1):
     """
     (cA, cD) = dwt(data, wavelet, mode='symmetric')
 
@@ -729,12 +729,13 @@ def dwt(object data, object wavelet, object mode='symmetric'):
     data = np.array(data, dtype=dt)
     if data.ndim != 1:
         raise ValueError("dwt requires a 1D data array.")
-    return _dwt(data, wavelet, mode)
+
+    return _dwt(data, wavelet, mode, axis=axis)
 
 
-def _dwt(np.ndarray[data_t, ndim=1] data, object wavelet, object mode='symmetric'):
+def _dwt(np.ndarray data, object wavelet, object mode='symmetric', int axis=-1):
     """See `dwt` docstring for details."""
-    cdef np.ndarray[data_t, ndim=1, mode="c"] cA, cD
+    cdef np.ndarray cA, cD
 
     cdef Wavelet w = c_wavelet_from_object(wavelet)
     cdef common.MODE mode_ = _try_mode(mode)
@@ -743,7 +744,10 @@ def _dwt(np.ndarray[data_t, ndim=1] data, object wavelet, object mode='symmetric
     if output_len < 1:
         raise RuntimeError("Invalid output length.")
 
-    cA, cD = dwt_axis(data, wavelet, mode)
+    # convert negative axes
+    axis = axis % data.ndim
+
+    cA, cD = dwt_axis(data, wavelet, mode, axis=axis)
     return (cA, cD)
 
 

--- a/pywt/src/_pywt.pyx
+++ b/pywt/src/_pywt.pyx
@@ -868,6 +868,10 @@ def idwt(cA, cD, object wavelet, object mode='symmetric', int axis=-1):
         Wavelet to use
     mode : str, optional (default: 'symmetric')
         Signal extension mode, see Modes
+    axis: int, optional
+        Axis over which to compute the inverse DWT. If not given, the
+        last axis is used.
+
 
     Returns
     -------

--- a/pywt/src/_pywt.pyx
+++ b/pywt/src/_pywt.pyx
@@ -942,38 +942,20 @@ def idwt(cA, cD, object wavelet, object mode='symmetric', int axis=-1):
     elif cD is None:
         cD = np.zeros_like(cA)
 
-    return _idwt(cA, cD, wavelet, mode, axis=axis)
+    # cA and cD should be same dimension by here
+    ndim = cA.ndim
 
+    if axis >= ndim or abs(axis) > ndim:
+        raise ValueError("Axis greater than coefficient dimensions")
 
-def _idwt(np.ndarray cA, np.ndarray cD,
-          object wavelet, object mode='symmetric', int axis=-1):
-    """See `idwt` for details"""
-
-    cdef index_t input_len
-    cdef index_t rec_len
-
-    cdef Wavelet w = c_wavelet_from_object(wavelet)
-    cdef common.MODE  mode_ = _try_mode(mode)
-
-    # check for size difference between arrays
-    if cA.size != cD.size:
-        raise ValueError("Coefficients arrays must have the same size.")
-    else:
-        input_len = cA.size
-
-    # find reconstruction buffer length
-    rec_len = common.idwt_buffer_length(input_len, w.rec_len, mode_)
-    if rec_len < 1:
-        msg = ("Invalid coefficient arrays length for specified wavelet. "
-               "Wavelet and mode must be the same as used for decomposition.")
-        raise ValueError(msg)
-
-    if axis >= cA.ndim:
-        raise ValueError("Axis greater than coefficient dimension")
     # convert negative axes
-    axis = axis % cA.ndim
+    axis = axis % ndim
 
-    rec = idwt_axis(cA, cD, wavelet, mode, axis=axis)
+    if ndim == 1:
+        rec = idwt_single(cA, cD, wavelet, mode)
+    else:
+        rec = idwt_axis(cA, cD, wavelet, mode, axis=axis)
+
     return rec
 
 

--- a/pywt/src/_pywt.pyx
+++ b/pywt/src/_pywt.pyx
@@ -850,7 +850,7 @@ def dwt_coeff_len(data_len, filter_len, mode='symmetric'):
 
 ###############################################################################
 # idwt
-def idwt(cA, cD, object wavelet, object mode='symmetric'):
+def idwt(cA, cD, object wavelet, object mode='symmetric', int axis=-1):
     """
     idwt(cA, cD, wavelet, mode='symmetric')
 
@@ -914,12 +914,11 @@ def idwt(cA, cD, object wavelet, object mode='symmetric'):
     elif cD is None:
         cD = np.zeros_like(cA)
 
-    return _idwt(cA, cD, wavelet, mode)
+    return _idwt(cA, cD, wavelet, mode, axis=axis)
 
 
-def _idwt(np.ndarray[data_t, ndim=1, mode="c"] cA,
-          np.ndarray[data_t, ndim=1, mode="c"] cD,
-          object wavelet, object mode='symmetric'):
+def _idwt(np.ndarray cA, np.ndarray cD,
+          object wavelet, object mode='symmetric', int axis=-1):
     """See `idwt` for details"""
 
     cdef index_t input_len
@@ -941,7 +940,10 @@ def _idwt(np.ndarray[data_t, ndim=1, mode="c"] cA,
                "Wavelet and mode must be the same as used for decomposition.")
         raise ValueError(msg)
 
-    rec = idwt_axis(cA, cD, wavelet, mode)
+    # convert negative axes
+    axis = axis % cA.ndim
+
+    rec = idwt_axis(cA, cD, wavelet, mode, axis=axis)
     return rec
 
 

--- a/pywt/src/_pywt.pyx
+++ b/pywt/src/_pywt.pyx
@@ -620,6 +620,30 @@ cdef c_wavelet_from_object(wavelet):
         return Wavelet(wavelet)
 
 
+def _try_mode(mode):
+    try:
+        return Modes.from_object(mode)
+    except ValueError as e:
+        if "Unknown mode name" in str(e):
+            raise
+        raise TypeError("Invalid mode: {0}".format(str(mode)))
+
+
+cdef np.dtype _check_dtype(data):
+    """Check for cA/cD input what (if any) the dtype is."""
+    cdef np.dtype dt
+    try:
+        dt = data.dtype
+        if dt not in (np.float64, np.float32):
+            # integer input was always accepted; convert to float64
+            dt = np.dtype('float64')
+    except AttributeError:
+        dt = np.dtype('float64')
+    return dt
+
+
+
+
 ###############################################################################
 # DWT
 
@@ -905,29 +929,6 @@ def dwt_coeff_len(data_len, filter_len, mode='symmetric'):
 
 ###############################################################################
 # idwt
-
-def _try_mode(mode):
-    try:
-        return Modes.from_object(mode)
-    except ValueError as e:
-        if "Unknown mode name" in str(e):
-            raise
-        raise TypeError("Invalid mode: {0}".format(str(mode)))
-
-
-cdef np.dtype _check_dtype(data):
-    """Check for cA/cD input what (if any) the dtype is."""
-    cdef np.dtype dt
-    try:
-        dt = data.dtype
-        if dt not in (np.float64, np.float32):
-            # integer input was always accepted; convert to float64
-            dt = np.dtype('float64')
-    except AttributeError:
-        dt = np.dtype('float64')
-    return dt
-
-
 def idwt(cA, cD, object wavelet, object mode='symmetric'):
     """
     idwt(cA, cD, wavelet, mode='symmetric')

--- a/pywt/src/_pywt.pyx
+++ b/pywt/src/_pywt.pyx
@@ -694,6 +694,10 @@ def dwt(object data, object wavelet, object mode='symmetric', int axis=-1):
         Wavelet to use
     mode : str, optional (default: 'symmetric')
         Signal extension mode, see Modes
+    axis: int, optional
+        Axis over which to compute the DWT. If not given, the
+        last axis is used.
+
 
     Returns
     -------

--- a/pywt/src/_pywt.pyx
+++ b/pywt/src/_pywt.pyx
@@ -732,26 +732,17 @@ def dwt(object data, object wavelet, object mode='symmetric', int axis=-1):
     dt = _check_dtype(data)
     data = np.array(data, dtype=dt)
 
-    return _dwt(data, wavelet, mode, axis=axis)
-
-
-def _dwt(np.ndarray data, object wavelet, object mode='symmetric', int axis=-1):
-    """See `dwt` docstring for details."""
-    cdef np.ndarray cA, cD
-
-    cdef Wavelet w = c_wavelet_from_object(wavelet)
-    cdef common.MODE mode_ = _try_mode(mode)
-
-    output_len = common.dwt_buffer_length(data.size, w.dec_len, mode_)
-    if output_len < 1:
-        raise RuntimeError("Invalid output length.")
-
-    if axis >= data.ndim:
+    if axis >= data.ndim or abs(axis) > data.ndim:
         raise ValueError("Axis greater than data dimensions")
+
     # convert negative axes
     axis = axis % data.ndim
 
-    cA, cD = dwt_axis(data, wavelet, mode, axis=axis)
+    if data.ndim == 1:
+        cA, cD = dwt_single(data, wavelet, mode)
+    else:
+        cA, cD = dwt_axis(data, wavelet, mode, axis=axis)
+
     return (cA, cD)
 
 

--- a/pywt/src/_pywt.pyx
+++ b/pywt/src/_pywt.pyx
@@ -735,37 +735,15 @@ def dwt(object data, object wavelet, object mode='symmetric'):
 def _dwt(np.ndarray[data_t, ndim=1] data, object wavelet, object mode='symmetric'):
     """See `dwt` docstring for details."""
     cdef np.ndarray[data_t, ndim=1, mode="c"] cA, cD
-    cdef Wavelet w
-    cdef common.MODE mode_
 
-    w = c_wavelet_from_object(wavelet)
-    mode_ = _try_mode(mode)
+    cdef Wavelet w = c_wavelet_from_object(wavelet)
+    cdef common.MODE mode_ = _try_mode(mode)
 
-    data = np.array(data)
     output_len = common.dwt_buffer_length(data.size, w.dec_len, mode_)
     if output_len < 1:
         raise RuntimeError("Invalid output length.")
 
-    cA = np.zeros(output_len, data.dtype)
-    cD = np.zeros(output_len, data.dtype)
-
-    if data_t == np.float64_t:
-        if (c_wt.double_dec_a(&data[0], data.size, w.w,
-                              &cA[0], cA.size, mode_) < 0
-            or
-            c_wt.double_dec_d(&data[0], data.size, w.w,
-                              &cD[0], cD.size, mode_) < 0):
-            raise RuntimeError("C dwt failed.")
-    elif data_t == np.float32_t:
-        if (c_wt.float_dec_a(&data[0], data.size, w.w,
-                             &cA[0], cA.size, mode_) < 0
-            or
-            c_wt.float_dec_d(&data[0], data.size, w.w,
-                             &cD[0], cD.size, mode_) < 0):
-            raise RuntimeError("C dwt failed.")
-    else:
-        raise RuntimeError("Invalid data type.")
-
+    cA, cD = dwt_axis(data, wavelet, mode)
     return (cA, cD)
 
 

--- a/pywt/src/_pywt.pyx
+++ b/pywt/src/_pywt.pyx
@@ -915,15 +915,10 @@ def _idwt(np.ndarray[data_t, ndim=1, mode="c"] cA,
     """See `idwt` for details"""
 
     cdef index_t input_len
-
-    cdef Wavelet w
-    cdef common.MODE mode_
-
-    w = c_wavelet_from_object(wavelet)
-    mode_ = _try_mode(mode)
-
-    cdef np.ndarray[data_t, ndim=1, mode="c"] rec
     cdef index_t rec_len
+
+    cdef Wavelet w = c_wavelet_from_object(wavelet)
+    cdef common.MODE  mode_ = _try_mode(mode)
 
     # check for size difference between arrays
     if cA.size != cD.size:
@@ -938,29 +933,7 @@ def _idwt(np.ndarray[data_t, ndim=1, mode="c"] cA,
                "Wavelet and mode must be the same as used for decomposition.")
         raise ValueError(msg)
 
-    # allocate buffer
-    if cA is not None:
-        rec = np.zeros(rec_len, dtype=cA.dtype)
-    else:
-        rec = np.zeros(rec_len, dtype=cD.dtype)
-
-    # call idwt func.  one of cA/cD can be None, then only
-    # reconstruction of non-null part will be performed
-    if data_t is np.float64_t:
-        if c_wt.double_idwt(&cA[0], cA.size,
-                            &cD[0], cD.size,
-                            &rec[0], rec.size,
-                            w.w, mode_) < 0:
-            raise RuntimeError("C idwt failed.")
-    elif data_t == np.float32_t:
-        if c_wt.float_idwt(&cA[0], cA.size,
-                           &cD[0], cD.size,
-                           &rec[0], rec.size,
-                           w.w, mode_) < 0:
-            raise RuntimeError("C idwt failed.")
-    else:
-        raise RuntimeError("Invalid data type.")
-
+    rec = idwt_axis(cA, cD, wavelet, mode)
     return rec
 
 

--- a/pywt/tests/test_dwt_idwt.py
+++ b/pywt/tests/test_dwt_idwt.py
@@ -56,14 +56,6 @@ def test_dwt_idwt_basic_complex():
     assert_allclose(x_roundtrip, x, rtol=1e-10)
 
 
-def test_dwt_input_error():
-    data = np.ones((16, 1))
-    assert_raises(ValueError, pywt.dwt, data, 'haar')
-
-    cA, cD = pywt.dwt(data[:, 0], 'haar')
-    assert_raises(ValueError, pywt.idwt, cA[:, np.newaxis], cD, 'haar')
-
-
 def test_dwt_wavelet_kwd():
     x = np.array([3, 7, 1, 1, -2, 5, 4, 6])
     w = pywt.Wavelet('sym3')

--- a/pywt/tests/test_dwt_idwt.py
+++ b/pywt/tests/test_dwt_idwt.py
@@ -97,5 +97,32 @@ def test_idwt_invalid_input():
     assert_raises(ValueError, pywt.idwt, [1, 2, 4], [4, 1, 3], 'db4', 'symmetric')
 
 
+def test_dwt_idwt_axis():
+    x = [[3, 7, 1, 1],
+         [-2, 5, 4, 6]]
+
+    cA, cD = pywt.dwt(x, 'db2', axis=-1)
+
+    cA0, cD0 = pywt.dwt(x[0], 'db2')
+    cA1, cD1 = pywt.dwt(x[1], 'db2')
+
+    assert_allclose(cA[0], cA0)
+    assert_allclose(cA[1], cA1)
+
+    assert_allclose(cD[0], cD0)
+    assert_allclose(cD[1], cD1)
+
+
+def test_dwt_idwt_axis_excess():
+    x = [[3, 7, 1, 1],
+         [-2, 5, 4, 6]]
+    # can't transform over axes that aren't there
+    assert_raises(ValueError,
+                  pywt.dwt, x, 'db2', 'symmetric', axis=2)
+
+    assert_raises(ValueError,
+                  pywt.idwt, [1, 2, 4], [4, 1, 3], 'db2', 'symmetric', axis=1)
+
+
 if __name__ == '__main__':
     run_module_suite()

--- a/pywt/tests/test_dwt_idwt.py
+++ b/pywt/tests/test_dwt_idwt.py
@@ -113,6 +113,42 @@ def test_dwt_single_axis():
     assert_allclose(cD[1], cD1)
 
 
+def test_idwt_single_axis():
+    x = [[3, 7, 1, 1],
+         [-2, 5, 4, 6]]
+
+    cA, cD = pywt.dwt(x, 'db2', axis=-1)
+
+    x0 = pywt.idwt(cA[0], cD[0], 'db2', axis=-1)
+    x1 = pywt.idwt(cA[1], cD[1], 'db2', axis=-1)
+
+    assert_allclose(x[0], x0)
+    assert_allclose(x[1], x1)
+
+
+def test_dwt_axis_arg():
+    x = [[3, 7, 1, 1],
+         [-2, 5, 4, 6]]
+
+    cA_, cD_ = pywt.dwt(x, 'db2', axis=-1)
+    cA, cD = pywt.dwt(x, 'db2', axis=1)
+
+    assert_allclose(cA_, cA)
+    assert_allclose(cD_, cD)
+
+
+def test_idwt_axis_arg():
+    x = [[3, 7, 1, 1],
+         [-2, 5, 4, 6]]
+
+    cA, cD = pywt.dwt(x, 'db2', axis=1)
+
+    x_ = pywt.idwt(cA, cD, 'db2', axis=-1)
+    x = pywt.idwt(cA, cD, 'db2', axis=1)
+
+    assert_allclose(x_, x)
+
+
 def test_dwt_idwt_axis_excess():
     x = [[3, 7, 1, 1],
          [-2, 5, 4, 6]]

--- a/pywt/tests/test_dwt_idwt.py
+++ b/pywt/tests/test_dwt_idwt.py
@@ -97,7 +97,7 @@ def test_idwt_invalid_input():
     assert_raises(ValueError, pywt.idwt, [1, 2, 4], [4, 1, 3], 'db4', 'symmetric')
 
 
-def test_dwt_idwt_axis():
+def test_dwt_single_axis():
     x = [[3, 7, 1, 1],
          [-2, 5, 4, 6]]
 


### PR DESCRIPTION
Allow computing one-dimensional dwt over multi-dimensional arrays. Proof of concept for #115.

TODO:
- [x] add axis argument to dwt (use `dwt_axis`)
- [x] add axis argument to idwt (use `idwt_axis`)