### PR TITLE
bug fix: allow swt input lengths which are not powers of 2

### DIFF
--- a/pywt/src/common.c
+++ b/pywt/src/common.c
@@ -76,8 +76,6 @@ unsigned char swt_max_level(size_t input_len){
     /* check how many times input_len is divisible by 2 */
     unsigned char j = 0;
     while (input_len > 0){
-        if (input_len % 2)
-            return j;
         input_len /= 2;
         j++;
     }


### PR DESCRIPTION
Bug: When we want to run swt or swt2 and the input size is not a power of 2 it calculates a wrong swt_max_level, which leads to the following error message when we want to run swt or swt2: "start_level must be less than 1."

swt and swt2 are implemented as convolution with stride 2, so there is no need for the input length to be a power of 2. The function swt_max_level() was directly returning the current number of divisions as soon as it finds out that the length is not a power of 2.