### PR TITLE
switch travis from python 3.5-dev to 3.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ matrix:
         - PYFLAKES_NODOCTEST=1 pyflakes pywt demo | grep -E -v 'unable to detect undefined names|assigned to but never used|imported but unused|redefinition of unused' > test.out; cat test.out; test \! -s test.out
         - pep8 pywt demo
 
-    - python: 3.5-dev
+    - python: 3.5
       env:
         - NUMPYSPEC=numpy
     - python: 3.4


### PR DESCRIPTION
@rgommers 
I changed 3.5-dev to 3.5.  Should 3.5-dev or 3.6-dev still be present as well?