### PR TITLE
ENH: update name_key in authors.py to handle apostrophes

### DIFF
--- a/util/authors.py
+++ b/util/authors.py
@@ -87,13 +87,14 @@ def main():
 
     # Sort
     def name_key(fullname):
-        m = re.search(u(' [a-z ]*[A-Za-z-]+$'), fullname)
+        m = re.search(u(' [a-z ]*[A-Za-z-\']+$'), fullname)
         if m:
             forename = fullname[:m.start()].strip()
             surname = fullname[m.start():].strip()
         else:
             forename = ""
             surname = fullname.strip()
+        surname = surname.replace('\'', '')
         if surname.startswith(u('van der ')):
             surname = surname[8:]
         if surname.startswith(u('de ')):

--- a/util/authors.py
+++ b/util/authors.py
@@ -26,6 +26,7 @@ else:
 
 NAME_MAP = {
     u('Helder'): u('Helder Oliveira'),
+    u('Kai'): u('Kai Wohlfahrt'),
 }
 
 


### PR DESCRIPTION
Prior to this PR names containing apostrophes (e.g. `Aaron O'Leary` ) appeared first in the autogenerated author list because the regular expression used did not split names containing apostrophes properly.

running `python util/authors.py v0.3.0...HEAD`

now gives the expected order

```
Authors
=======

* Thomas Arildsen +
* François Boulogne
* Ralf Gommers
* Kai +
* Gregory R. Lee
* Michael Marino +
* Aaron O'Leary +
* Daniele Tricoli +
* Kai Wohlfahrt
```

