### PR TITLE
Autogenerate function API docs

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -24,7 +24,8 @@ import jinja2.filters
 
 # Add any Sphinx extension module names here, as strings. They can be extensions
 # coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
-extensions = ['sphinx.ext.doctest', 'sphinx.ext.autodoc', 'sphinx.ext.todo', 'sphinx.ext.extlinks']
+extensions = ['sphinx.ext.doctest', 'sphinx.ext.autodoc', 'sphinx.ext.todo',
+              'sphinx.ext.extlinks', 'numpydoc']
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']

--- a/doc/source/dev/installing_build_dependencies.rst
+++ b/doc/source/dev/installing_build_dependencies.rst
@@ -54,8 +54,14 @@ nicely looking html documentation. Install it with::
 
     pip install Sphinx
 
+numpydoc_ is used to format the API docmentation appropriately.  Install it
+via::
+
+    pip install numpydoc
+
 
 .. _virtualenv: http://pypi.python.org/pypi/virtualenv
 .. _numpy: http://numpy.scipy.org/
 .. _Cython: http://cython.org/
 .. _Sphinx: http://sphinx.pocoo.org
+.. _numpydoc: https://github.com/numpy/numpydoc

--- a/doc/source/ref/2d-dwt-and-idwt.rst
+++ b/doc/source/ref/2d-dwt-and-idwt.rst
@@ -11,28 +11,7 @@
 Single level ``dwt2``
 ~~~~~~~~~~~~~~~~~~~~~
 
-.. function:: dwt2(data, wavelet[, mode='symmetric'])
-
-  The :func:`dwt2` function performs single level 2D Discrete Wavelet Transform.
-
-  :param data: 2D input data.
-
-  :param wavelet: |wavelet|
-
-  :param mode: |mode| This is only important when DWT was performed
-               in :ref:`periodization <Modes.periodization>` mode.
-
-  .. compound::
-
-    Returns one average and three details 2D coefficients arrays. The
-    coefficients arrays are organized in tuples in the following form:
-
-      ::
-
-      (cA, (cH, cV, cD))
-
-    where *cA*, *cH*, *cV*, *cD* denote approximation, horizontal
-    detail, vertical detail and diagonal detail coefficients respectively.
+.. autofunction:: dwt2
 
 The relation to the other common data layout where all the approximation and
 details coefficients are stored in one big 2D array is as follows:
@@ -52,116 +31,18 @@ details coefficients are stored in one big 2D array is as follows:
 PyWavelets does not follow this pattern because of pure practical reasons of simple
 access to particular type of the output coefficients.
 
-  **Example:**
-
-  .. sourcecode:: python
-
-    >>> import pywt, numpy
-    >>> data = numpy.ones((4,4), dtype=numpy.float64)
-    >>> coeffs = pywt.dwt2(data, 'haar')
-    >>> cA, (cH, cV, cD) = coeffs
-    >>> print cA
-    [[ 2.  2.]
-     [ 2.  2.]]
-    >>> print cV
-    [[ 0.  0.]
-     [ 0.  0.]]
-
 
 Single level ``idwt2``
 ~~~~~~~~~~~~~~~~~~~~~~
 
-.. function:: idwt2(coeffs, wavelet[, mode='symmetric'])
-
-  The :func:`idwt2` function reconstructs data from the given coefficients
-  set by performing single level 2D Inverse Discrete Wavelet Transform.
-
-  :param coeffs: A tuple with approximation coefficients and three details
-                 coefficients 2D arrays like from :func:`dwt2`::
-
-                    (cA, (cH, cV, cD))
-
-  :param wavelet: |wavelet|
-
-  :param mode: |mode| This is only important when the :func:`dwt` was performed
-               in the :ref:`periodization <Modes.periodization>` mode.
-
-  **Example:**
-
-  .. sourcecode:: python
-
-    >>> import pywt, numpy
-    >>> data = numpy.array([[1,2], [3,4]], dtype=numpy.float64)
-    >>> coeffs = pywt.dwt2(data, 'haar')
-    >>> print pywt.idwt2(coeffs, 'haar')
-    [[ 1.  2.]
-     [ 3.  4.]]
-
+.. autofunction:: idwt2
 
 2D multilevel decomposition using ``wavedec2``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. function:: wavedec2(data, wavelet[, mode='symmetric'[, level=None]])
-
-  .. compound::
-
-      Performs multilevel 2D Discrete Wavelet Transform decomposition and
-      returns coefficients list::
-
-        [cAn, (cHn, cVn, cDn), ..., (cH1, cV1, cD1)]
-
-      where *n* denotes the level of decomposition and *cA*, *cH*, *cV* and *cD*
-      are approximation, horizontal detail, vertical detail and diagonal detail
-      coefficients arrays respectively.
-
-  :param data: |data|
-
-  :param wavelet: |wavelet|
-
-  :param mode: |mode|
-
-  :param level: Decomposition level. This should not be greater than the
-                reasonable maximum value computed with the :func:`dwt_max_level`
-                function for the smaller dimension of the input data.
-
-  **Example:**
-
-  .. sourcecode:: python
-
-    >>> import pywt, numpy
-    >>> coeffs = pywt.wavedec2(numpy.ones((8,8)), 'db1', level=2)
-    >>> cA2, (cH2, cV2, cD2), (cH1, cV1, cD1) = coeffs
-    >>> print cA2
-    [[ 4.  4.]
-     [ 4.  4.]]
-
+.. autofunction:: wavedec2
 
 2D multilevel reconstruction using ``waverec2``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. function:: waverec2(coeffs, wavelet[, mode='symmetric'])
-
-  Performs multilevel reconstruction from the given coefficients set.
-
-  :param coeffs: Coefficients set must be in the form like that
-                 from :func:`wavedec2` decomposition::
-
-                    [cAn, (cHn, cVn, cDn), ..., (cH1, cV1, cD1)]
-
-  :param wavelet: |wavelet|
-
-  :param mode: |mode|
-
-  **Example:**
-
-  .. sourcecode:: python
-
-    >>> import pywt, numpy
-    >>> coeffs = pywt.wavedec2(numpy.ones((4,4)), 'db1')
-    >>> print "levels:", len(coeffs)-1
-    levels: 2
-    >>> print pywt.waverec2(coeffs, 'db1')
-    [[ 1.  1.  1.  1.]
-     [ 1.  1.  1.  1.]
-     [ 1.  1.  1.  1.]
-     [ 1.  1.  1.  1.]]
+.. autofunction:: waverec2

--- a/doc/source/ref/dwt-discrete-wavelet-transform.rst
+++ b/doc/source/ref/dwt-discrete-wavelet-transform.rst
@@ -15,172 +15,45 @@ functions used to perform single- and multilevel Discrete Wavelet Transforms.
 Single level ``dwt``
 --------------------
 
-.. function:: dwt(data, wavelet[, mode='symmetric', axis=-1])
+.. autofunction:: dwt
 
-  The :func:`dwt` function is used to perform single level, one dimensional
-  Discrete Wavelet Transform.
-
-  ::
-
-    (cA, cD) = dwt(data, wavelet, mode='symmetric')
-
-  :param data: |data|
-
-  :param wavelet: |wavelet|
-
-  :param mode: |mode|
-
-  :param axis: |axis|
-
-  The transform coefficients are returned as two arrays containing
-  approximation (*cA*) and detail (*cD*) coefficients respectively. Length
-  of returned arrays depends on the selected signal extension *mode* - see
-  the :ref:`signal extension modes <ref-modes>` section for the list of
+  See the :ref:`signal extension modes <ref-modes>` section for the list of
   available options and the :func:`dwt_coeff_len` function for information on
   getting the expected result length:
-
-  * for all :ref:`modes <ref-modes>` except :ref:`periodization <Modes.periodization>`::
-
-      len(cA) == len(cD) == floor((len(data) + wavelet.dec_len - 1) / 2)
-
-  * for :ref:`periodization <Modes.periodization>` mode (``"periodization"``)::
-
-      len(cA) == len(cD) == ceil(len(data) / 2)
 
   The transform can be performed over one axis of multi-dimensional
   data. By default this is the last axis. For multi-dimensional transforms
   see the :ref:`2D transforms <ref-dwt2>` section.
 
-  **Example:**
-
-  .. sourcecode:: python
-
-    >>> import pywt
-    >>> (cA, cD) = pywt.dwt([1,2,3,4,5,6], 'db1')
-    >>> print cA
-    [ 2.12132034  4.94974747  7.77817459]
-    >>> print cD
-    [-0.70710678 -0.70710678 -0.70710678]
-
 
 Multilevel decomposition using ``wavedec``
 ------------------------------------------
 
-.. function:: wavedec(data, wavelet, mode='symmetric', level=None)
-
-  .. compound::
-
-    The :func:`wavedec` function performs 1D multilevel Discrete Wavelet
-    Transform decomposition of given signal and returns ordered list of
-    coefficients arrays in the form:
-
-      ::
-
-      [cA_n, cD_n, cD_n-1, ..., cD2, cD1],
-
-    where *n* denotes the level of decomposition. The first element (*cA_n*) of
-    the result is approximation coefficients array and the following elements
-    (*cD_n* - *cD_1*) are details coefficients arrays.
-
-  :param data: |data|
-
-  :param wavelet: |wavelet|
-
-  :param mode: |mode|
-
-  :param level: Number of decomposition steps to perform. If the level is
-                ``None``, then the full decomposition up to the level computed
-                with :func:`dwt_max_level` function for the given data and
-                wavelet lengths is performed.
-
-  **Example:**
-
-  .. sourcecode:: python
-
-    >>> import pywt
-    >>> coeffs = pywt.wavedec([1,2,3,4,5,6,7,8], 'db1', level=2)
-    >>> cA2, cD2, cD1 = coeffs
-    >>> print cD1
-    [-0.70710678 -0.70710678 -0.70710678 -0.70710678]
-    >>> print cD2
-    [-2. -2.]
-    >>> print cA2
-    [  5.  13.]
+.. autofunction:: wavedec
 
 
 Partial Discrete Wavelet Transform data decomposition ``downcoef``
 ------------------------------------------------------------------
 
-.. function:: downcoef(part, data, wavelet[, mode='symmetric'[, level=1]])
-
-   Similar to :func:`~pywt.dwt`, but computes only one set of coefficients.
-   Useful when you need only approximation or only details at the given level.
-
-   :param part: decomposition type. For ``a`` computes approximation
-                coefficients, for ``d`` - details coefficients.
-
-   :param data: |data|
-
-   :param wavelet: |wavelet|
-
-   :param mode: |mode|
-
-   :param level: Number of decomposition steps to perform.
-
+.. autofunction:: downcoef
 
 
 Maximum decomposition level - ``dwt_max_level``
 -----------------------------------------------
 
-.. function:: dwt_max_level(data_len, filter_len)
+.. autofunction:: dwt_max_level
 
-  The :func:`~pywt.dwt_max_level` function can be used to compute the maximum
-  *useful* level of decomposition for the given *input data length* and *wavelet
-  filter length*.
-
-  The returned value equals to::
-
-    floor( log(data_len/(filter_len-1)) / log(2) )
-
-  Although the maximum decomposition level can be quite high for long signals,
-  usually smaller values are chosen depending on the application.
-
-  The *filter_len* can be either an ``int`` or :class:`Wavelet` object for
-  convenience.
-
-  **Example:**
-
-  .. sourcecode:: python
-
-    >>> import pywt
-    >>> w = pywt.Wavelet('sym5')
-    >>> print pywt.dwt_max_level(data_len=1000, filter_len=w.dec_len)
-    6
-    >>> print pywt.dwt_max_level(1000, w)
-    6
 
 .. _`dwt_coeff_len`:
-
-
 Result coefficients length - ``dwt_coeff_len``
 ----------------------------------------------
 
-.. function:: dwt_coeff_len(data_len, filter_len, mode)
+.. autofunction:: dwt_coeff_len
 
 Based on the given *input data length*, Wavelet *decomposition filter length*
 and :ref:`signal extension mode <Modes>`, the :func:`dwt_coeff_len` function
-calculates length of resulting coefficients arrays that would be created while
-performing :func:`dwt` transform.
+calculates the length of the resulting coefficients arrays that would be
+created while performing :func:`dwt` transform.
 
-For :ref:`periodization <Modes.periodization>` mode this equals::
-
-  ceil(data_len / 2)
-
-which is the lowest possible length guaranteeing perfect reconstruction.
-
-For other :ref:`modes <ref-modes>`::
-
-  floor((data_len + filter_len - 1) / 2)
-
-The *filter_len* can be either an *int* or :class:`Wavelet` object for
+*filter_len* can be either an *int* or :class:`Wavelet` object for
 convenience.

--- a/doc/source/ref/dwt-discrete-wavelet-transform.rst
+++ b/doc/source/ref/dwt-discrete-wavelet-transform.rst
@@ -17,13 +17,13 @@ Single level ``dwt``
 
 .. autofunction:: dwt
 
-  See the :ref:`signal extension modes <ref-modes>` section for the list of
-  available options and the :func:`dwt_coeff_len` function for information on
-  getting the expected result length:
+See the :ref:`signal extension modes <ref-modes>` section for the list of
+available options and the :func:`dwt_coeff_len` function for information on
+getting the expected result length.
 
-  The transform can be performed over one axis of multi-dimensional
-  data. By default this is the last axis. For multi-dimensional transforms
-  see the :ref:`2D transforms <ref-dwt2>` section.
+The transform can be performed over one axis of multi-dimensional
+data. By default this is the last axis. For multi-dimensional transforms
+see the :ref:`2D transforms <ref-dwt2>` section.
 
 
 Multilevel decomposition using ``wavedec``
@@ -45,6 +45,7 @@ Maximum decomposition level - ``dwt_max_level``
 
 
 .. _`dwt_coeff_len`:
+
 Result coefficients length - ``dwt_coeff_len``
 ----------------------------------------------
 

--- a/doc/source/ref/idwt-inverse-discrete-wavelet-transform.rst
+++ b/doc/source/ref/idwt-inverse-discrete-wavelet-transform.rst
@@ -11,22 +11,7 @@ Inverse Discrete Wavelet Transform (IDWT)
 Single level ``idwt``
 ---------------------
 
-.. function:: idwt(cA, cD, wavelet[, mode='symmetric', axis=-1])
-
-  The :func:`idwt` function reconstructs data from the given coefficients by
-  performing single level Inverse Discrete Wavelet Transform.
-
-  :param cA: Approximation coefficients.
-
-  :param cD: Detail coefficients.
-
-  :param wavelet: |wavelet|
-
-  :param mode: |mode| This is only important when DWT was performed in
-               :ref:`periodization <Modes.periodization>` mode.
-
-  :param axis: |axis| This should be the same as the axis used in the
-               DWT that produced the coefficients.
+.. autofunction:: idwt
 
   **Example:**
 
@@ -54,66 +39,13 @@ Single level ``idwt``
     [ 1.  2.  3.  4.  5.  6.]
 
 
-
 Multilevel reconstruction using ``waverec``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. function:: waverec(coeffs, wavelet[, mode='symmetric'])
-
-  Performs multilevel reconstruction of signal from the given list of
-  coefficients.
-
-  :param coeffs: Coefficients list must be in the form like returned by :func:`wavedec` decomposition function, which is::
-
-      [cAn, cDn, cDn-1, ..., cD2, cD1]
-
-  :param wavelet: |wavelet|
-
-  :param mode: |mode|
-
-  **Example:**
-
-  .. sourcecode:: python
-
-    >>> import pywt
-    >>> coeffs = pywt.wavedec([1,2,3,4,5,6,7,8], 'db2', level=2)
-    >>> print pywt.waverec(coeffs, 'db2')
-    [ 1.  2.  3.  4.  5.  6.  7.  8.]
+.. autofunction:: waverec
 
 
 Direct reconstruction with ``upcoef``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. function:: upcoef(part, coeffs, wavelet[, level=1[, take=0]])
-
-  Direct reconstruction from coefficients.
-
-  :param part: Defines the input coefficients type:
-
-      - **'a'** - approximations reconstruction is performed
-      - **'d'** - details reconstruction is performed
-
-  :param coeffs: Coefficients array to reconstruct.
-
-  :param wavelet: |wavelet|
-
-  :param level: If *level* value is specified then a multilevel reconstruction is
-                performed (first reconstruction is of type specified by *part*
-                and all the following ones with *part* type ``a``)
-
-  :param take: If *take* is specified then only the central part of length equal
-               to the *take* parameter value is returned.
-
-  **Example:**
-
-  .. sourcecode:: python
-
-    >>> import pywt
-    >>> data = [1,2,3,4,5,6]
-    >>> (cA, cD) = pywt.dwt(data, 'db2', 'smooth')
-    >>> print pywt.upcoef('a', cA, 'db2') + pywt.upcoef('d', cD, 'db2')
-    [-0.25       -0.4330127   1.          2.          3.          4.          5.
-      6.          1.78589838 -1.03108891]
-    >>> n = len(data)
-    >>> print pywt.upcoef('a',cA,'db2',take=n) + pywt.upcoef('d',cD,'db2',take=n)
-    [ 1.  2.  3.  4.  5.  6.]
+.. autofunction:: upcoef

--- a/doc/source/ref/index.rst
+++ b/doc/source/ref/index.rst
@@ -11,6 +11,7 @@ API Reference
    dwt-discrete-wavelet-transform
    idwt-inverse-discrete-wavelet-transform
    2d-dwt-and-idwt
+   nd-dwt-and-idwt
    swt-stationary-wavelet-transform
    wavelet-packets
    thresholding-functions

--- a/doc/source/ref/nd-dwt-and-idwt.rst
+++ b/doc/source/ref/nd-dwt-and-idwt.rst
@@ -16,9 +16,9 @@ Single level - ``idwtn``
 .. autofunction:: idwtn
 
 Multilevel decomposition - ``wavedecn``
------------------------------------
+---------------------------------------
 .. autofunction:: wavedecn
 
 Multilevel reconstruction - ``waverecn``
--------------------------------------
+----------------------------------------
 .. autofunction:: waverecn

--- a/doc/source/ref/nd-dwt-and-idwt.rst
+++ b/doc/source/ref/nd-dwt-and-idwt.rst
@@ -1,0 +1,16 @@
+.. _ref-dwtn:
+.. include:: ../substitutions.rst
+
+=================================================
+nD Forward and Inverse Discrete Wavelet Transform
+=================================================
+
+.. currentmodule:: pywt
+
+Single level ``dwtn``
+----------------------
+.. autofunction:: dwtn
+
+Single level ``idwtn``
+----------------------
+.. autofunction:: idwtn

--- a/doc/source/ref/nd-dwt-and-idwt.rst
+++ b/doc/source/ref/nd-dwt-and-idwt.rst
@@ -7,10 +7,18 @@ nD Forward and Inverse Discrete Wavelet Transform
 
 .. currentmodule:: pywt
 
-Single level ``dwtn``
-----------------------
+Single level - ``dwtn``
+-----------------------
 .. autofunction:: dwtn
 
-Single level ``idwtn``
-----------------------
+Single level - ``idwtn``
+------------------------
 .. autofunction:: idwtn
+
+Multilevel decomposition - ``wavedecn``
+-----------------------------------
+.. autofunction:: wavedecn
+
+Multilevel reconstruction - ``waverecn``
+-------------------------------------
+.. autofunction:: waverecn

--- a/doc/source/ref/other-functions.rst
+++ b/doc/source/ref/other-functions.rst
@@ -11,68 +11,28 @@ Other functions
 Single-level n-dimensional Discrete Wavelet Transform.
 ------------------------------------------------------
 
-.. function:: dwtn(data, wavelet[, mode='symmetric'])
-
-   Performs single-level n-dimensional Discrete Wavelet Transform.
-
-   :param data: n-dimensional array
-   :param wavelet: |wavelet|
-   :param mode: |mode|
-
-   Results are arranged in a dictionary, where key specifies
-   the transform type on each dimension and value is a n-dimensional
-   coefficients array.
-
-   For example, for a 2D case the result will look something like this::
-
-      {
-          'aa': <coeffs>  # A(LL) - approx. on 1st dim, approx. on 2nd dim
-          'ad': <coeffs>  # H(LH) - approx. on 1st dim, det. on 2nd dim
-          'da': <coeffs>  # V(HL) - det. on 1st dim, approx. on 2nd dim
-          'dd': <coeffs>  # D(HH) - det. on 1st dim, det. on 2nd dim
-      }
+.. autofunction:: dwtn
 
 
-Integrating wavelet functions - :func:`integrate_wavelet`
------------------------------------------------
+Integrating wavelet functions
+-----------------------------
 
-.. function:: integrate_wavelet(wavelet[, precision=8])
+.. autofunction:: integrate_wavelet
 
-  Integration of wavelet function approximations can be performed
-  using the :func:`pywt.integrate_wavelet` function.
+The result of the call depends on the *wavelet* argument:
 
-  The result of the call depends on the *wavelet* argument:
+* for orthogonal and continuous wavelets - an integral of the
+  wavelet function specified on an x-grid::
 
-  * for orthogonal and continuous wavelets - an integral of the
-    wavelet function specified on an x-grid::
+    [int_psi, x_grid] = integrate_wavelet(wavelet, precision)
 
-      [int_psi, x_grid] = integrate_wavelet(wavelet, precision)
+* for other wavelets - integrals of decomposition and
+  reconstruction wavelet functions and a corresponding x-grid::
 
-  * for other wavelets - integrals of decomposition and
-    reconstruction wavelet functions and a corresponding x-grid::
-
-      [int_psi_d, int_psi_r, x_grid] = integrate_wavelet(wavelet, precision)
-
-  **Example:**
-
-  .. sourcecode:: python
-
-    >>> import pywt
-    >>> wavelet1 = pywt.Wavelet('db2')
-    >>> [int_psi, x] = pywt.integrate_wavelet(wavelet1, precision=5)
-    >>> wavelet2 = pywt.Wavelet('bior1.3')
-    >>> [int_psi_d, int_psi_r, x] = pywt.integrate_wavelet(wavelet2, precision=5)
+    [int_psi_d, int_psi_r, x_grid] = integrate_wavelet(wavelet, precision)
 
 
 Central frequency of *psi* wavelet function
 -------------------------------------------
 
-.. function:: central_frequency(wavelet[, precision=8])
-              central_frequency((function_approx, x))
-
-   :param wavelet: :class:`Wavelet`, wavelet name string or
-                   `(wavelet function approx., x grid)` pair
-
-   :param precision:  Precision that will be used for wavelet function
-                      approximation computed with the :meth:`Wavelet.wavefun`
-                      method.
+.. autofunction:: central_frequency

--- a/doc/source/ref/other-functions.rst
+++ b/doc/source/ref/other-functions.rst
@@ -36,3 +36,16 @@ Central frequency of *psi* wavelet function
 -------------------------------------------
 
 .. autofunction:: central_frequency
+
+.. autofunction:: scale2frequency
+
+
+Quadrature Mirror Filter
+------------------------
+
+.. autofunction:: qmf
+
+Orthogonal Filter Banks
+-----------------------
+
+.. autofunction:: orthogonal_filter_bank

--- a/doc/source/ref/other-functions.rst
+++ b/doc/source/ref/other-functions.rst
@@ -8,12 +8,6 @@ Other functions
 ===============
 
 
-Single-level n-dimensional Discrete Wavelet Transform.
-------------------------------------------------------
-
-.. autofunction:: dwtn
-
-
 Integrating wavelet functions
 -----------------------------
 

--- a/doc/source/ref/swt-stationary-wavelet-transform.rst
+++ b/doc/source/ref/swt-stationary-wavelet-transform.rst
@@ -15,78 +15,15 @@ transformation level.
 Multilevel ``swt``
 ~~~~~~~~~~~~~~~~~~
 
-.. function:: swt(data, wavelet, level[, start_level=0])
-
-  Performs multilevel Stationary Wavelet Transform.
-
-  :param data: |data|
-
-  :param wavelet: |wavelet|
-
-  :param int level: Required transform level. See the :func:`swt_max_level` function.
-
-  :param int start_level: The level at which the decomposition will begin (it
-      allows to skip a given number of transform steps and compute coefficients
-      starting directly from the *start_level*)
-
-  .. compound::
-
-      Returns list of coefficient pairs in the form::
-
-        [(cAn, cDn), ..., (cA2, cD2), (cA1, cD1)]
-
-      where *n* is the *level* value.
-
-      If *m* = *start_level* is given, then the beginning *m* steps are
-      skipped::
-
-        [(cAm+n, cDm+n), ..., (cAm+1, cDm+1), (cAm, cDm)]
-
+.. autofunction:: swt
 
 Multilevel ``swt2``
 ~~~~~~~~~~~~~~~~~~~~~
 
-.. function:: swt2(data, wavelet, level[, start_level=0])
-
-  Performs multilevel 2D Stationary Wavelet Transform.
-
-  :param data: 2D array with input data.
-
-  :param wavelet: |wavelet|
-
-  :param level: Number of decomposition steps to perform.
-
-  :param start_level: The level at which the decomposition will begin.
-
-  .. compound::
-
-      The result is a set of coefficients arrays over the range of decomposition
-      levels::
-
-        [
-            (cA_n,
-                (cH_n, cV_n, cD_n)
-            ),
-            (cA_n+1,
-                (cH_n+1, cV_n+1, cD_n+1)
-            ),
-            ...,
-            (cA_n+level,
-                (cH_n+level, cV_n+level, cD_n+level)
-            )
-        ]
-
-      where *cA* is approximation, *cH* is horizontal details, *cV* is vertical
-      details, *cD* is diagonal details, *n* is *start_level* and *m* equals
-      *n+level*.
+.. autofunction:: swt2
 
 
 Maximum decomposition level - ``swt_max_level``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. function:: swt_max_level(input_len)
-
-  Calculates the maximum level of Stationary Wavelet Transform for data of
-  given length.
-
-  :param input_len: Input data length.
+.. autofunction:: swt_max_level

--- a/doc/source/ref/thresholding-functions.rst
+++ b/doc/source/ref/thresholding-functions.rst
@@ -1,5 +1,5 @@
 .. _ref-thresholding:
-
+.. currentmodule:: pywt
 
 Thresholding functions
 ======================
@@ -8,60 +8,7 @@ The :mod:`~pywt.thresholding` helper module implements the most popular signal
 thresholding functions.
 
 
-Hard thresholding
------------------
+Thresholding
+------------
 
-.. function:: hard(data, value[, substitute=0])
-
-   Hard thresholding. Replace all *data* values with *substitute* where their
-   absolute value is less than the *value* param.
-
-   *Data* values with absolute value greater or equal to the thresholding
-   *value* stay untouched.
-
-   :param data: numeric data
-   :param value: thresholding value
-   :param substitute: substitute value
-   :returns: array
-
-
-Soft thresholding
------------------
-.. function:: soft(data, value[, substitute=0])
-
-   Soft thresholding.
-
-   :param data: numeric data
-   :param value: thresholding value
-   :param substitute: substitute value
-   :returns: array
-
-Greater
--------
-
-.. function:: greater(data, value[, substitute=0])
-
-   Replace *data* with *substitute* where *data* is below the thresholding
-   *value*.
-
-   `Greater` *data* values pass untouched.
-
-   :param data: numeric data
-   :param value: thresholding value
-   :param substitute: substitute value
-   :returns: array
-
-Less
-----
-
-.. function:: less(data, value[, substitute=0])
-
-   Replace *data* with *substitute* where *data* is above the thresholding
-   *value*.
-
-   `Less` *data* values pass untouched.
-
-   :param data: numeric data
-   :param value: thresholding value
-   :param substitute: substitute value
-   :returns: array
+.. autofunction:: threshold

--- a/doc/source/ref/wavelets.rst
+++ b/doc/source/ref/wavelets.rst
@@ -9,47 +9,13 @@ Wavelets
 Wavelet ``families()``
 ----------------------
 
-.. function:: families()
-
-  Returns a list of available built-in wavelet families. Currently the built-in
-  families are:
-
-  * Haar (``haar``)
-  * Daubechies (``db``)
-  * Symlets (``sym``)
-  * Coiflets (``coif``)
-  * Biorthogonal (``bior``)
-  * Reverse biorthogonal (``rbio``)
-  * `"Discrete"` FIR approximation of Meyer wavelet (``dmey``)
-
-  **Example:**
-
-  .. sourcecode:: python
-
-    >>> import pywt
-    >>> print pywt.families()
-    ['haar', 'db', 'sym', 'coif', 'bior', 'rbio', 'dmey']
+.. autofunction:: families
 
 
 Built-in wavelets - ``wavelist()``
 ----------------------------------
 
-.. function:: wavelist([family])
-
-  The :func:`wavelist` function returns a list of names of the built-in
-  wavelets.
-
-  If the *family* name is ``None`` then names of all the built-in wavelets
-  are returned. Otherwise the function returns names of wavelets that belong
-  to the given family.
-
-  **Example:**
-
-  .. sourcecode:: python
-
-    >>> import pywt
-    >>> print pywt.wavelist('coif')
-    ['coif1', 'coif2', 'coif3', 'coif4', 'coif5']
+.. autofunction:: wavelist
 
   Custom user wavelets are also supported through the :class:`Wavelet` object
   constructor as described below.

--- a/pywt/src/_pywt.pyx
+++ b/pywt/src/_pywt.pyx
@@ -682,7 +682,7 @@ def dwt_max_level(data_len, filter_len):
 
 def dwt(object data, object wavelet, object mode='symmetric', int axis=-1):
     """
-    (cA, cD) = dwt(data, wavelet, mode='symmetric')
+    dwt(data, wavelet, mode='symmetric', axis=-1)
 
     Single level Discrete Wavelet Transform.
 
@@ -692,7 +692,7 @@ def dwt(object data, object wavelet, object mode='symmetric', int axis=-1):
         Input signal
     wavelet : Wavelet object or name
         Wavelet to use
-    mode : str, optional (default: 'symmetric')
+    mode : str, optional
         Signal extension mode, see Modes
     axis: int, optional
         Axis over which to compute the DWT. If not given, the
@@ -706,11 +706,14 @@ def dwt(object data, object wavelet, object mode='symmetric', int axis=-1):
 
     Notes
     -----
-    Length of coefficients arrays depends on the selected mode:
-    for all modes except periodization:
-        len(cA) == len(cD) == floor((len(data) + wavelet.dec_len - 1) / 2)
-    for periodization mode ("per"):
-        len(cA) == len(cD) == ceil(len(data) / 2)
+    Length of coefficients arrays depends on the selected mode.
+    For all modes except periodization:
+
+        ``len(cA) == len(cD) == floor((len(data) + wavelet.dec_len - 1) / 2)``
+
+    For periodization mode ("per"):
+
+        ``len(cA) == len(cD) == ceil(len(data) / 2)``
 
     Examples
     --------
@@ -880,9 +883,9 @@ def dwt_coeff_len(data_len, filter_len, mode='symmetric'):
 # idwt
 def idwt(cA, cD, object wavelet, object mode='symmetric', int axis=-1):
     """
-    idwt(cA, cD, wavelet, mode='symmetric')
+    idwt(cA, cD, wavelet, mode='symmetric', axis=-1)
 
-    Single level Inverse Discrete Wavelet Transform
+    Single level Inverse Discrete Wavelet Transform.
 
     Parameters
     ----------


### PR DESCRIPTION
As discussed in #138, this PR updates the various API documentation files in `/doc/source/ref`to use `sphinx.ext.autodoc` and `numpydoc` extensions to Sphinx.  This simplifies the API documentation and will enforce consistency between the documentation strings and the API documentation.

The intent here is just to reproduce nearly the identical documentation as before, but in an automated manner.  The only added content are a few functions that were previously missing (`idwtn`, `scale2frequency`, `qmf`. `orthogonal_filter_bank`).

I haven't updated the object oriented `Wavelet` code to use autodoc yet, but it should be possible to do the same there.
