### PR TITLE
handle None properly in waverec

### DIFF
--- a/pywt/_multilevel.py
+++ b/pywt/_multilevel.py
@@ -110,7 +110,7 @@ def waverec(coeffs, wavelet, mode='symmetric'):
     a, ds = coeffs[0], coeffs[1:]
 
     for d in ds:
-        if len(a) == len(d) + 1:
+        if (a is not None) and (d is not None) and (len(a) == len(d) + 1):
             a = a[:-1]
         a = idwt(a, d, wavelet, mode)
 

--- a/pywt/tests/test_multilevel.py
+++ b/pywt/tests/test_multilevel.py
@@ -31,6 +31,16 @@ def test_waverec():
     assert_allclose(pywt.waverec(coeffs, 'db1'), x, rtol=1e-12)
 
 
+def test_waverec_none():
+    x = [3, 7, 1, 1, -2, 5, 4, 6]
+    coeffs = pywt.wavedec(x, 'db1')
+
+    # set some coefficients to None
+    coeffs[2] = None
+    coeffs[0] = None
+    assert_(pywt.waverec(coeffs, 'db1').size, len(x))
+
+
 def test_waverec_odd_length():
     x = [3, 7, 1, 1, -2, 5]
     coeffs = pywt.wavedec(x, 'db1')


### PR DESCRIPTION
This is a fix to #140.  It restores handling of coefficients as None in `waverecn`