### PR TITLE
doctest fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -56,4 +56,4 @@ before_install:
   - set -o pipefail
 
 script:
-  - python -u $OPTIMIZE runtests.py -g -m full --coverage
+  - python -u $OPTIMIZE runtests.py -g -m full --coverage --doctests

--- a/doc/source/dev/testing.rst
+++ b/doc/source/dev/testing.rst
@@ -28,7 +28,7 @@ Tests are implemented with `nose`_, so use one of:
 
     $ nosetests pywt
 
-    >>> pywt.test()
+    >>> pywt.test()  # doctest: +SKIP
 
 
 Running tests with Tox

--- a/doc/source/ref/idwt-inverse-discrete-wavelet-transform.rst
+++ b/doc/source/ref/idwt-inverse-discrete-wavelet-transform.rst
@@ -20,7 +20,7 @@ Single level ``idwt``
     >>> import pywt
     >>> (cA, cD) = pywt.dwt([1,2,3,4,5,6], 'db2', 'smooth')
     >>> print pywt.idwt(cA, cD, 'db2', 'smooth')
-    [ 1.  2.  3.  4.  5.  6.]
+    array([ 1.,  2.,  3.,  4.,  5.,  6.])
 
   One of the neat features of :func:`idwt` is that one of the *cA* and *cD*
   arguments can be set to ``None``. In that situation the reconstruction will be
@@ -36,7 +36,7 @@ Single level ``idwt``
     >>> A = pywt.idwt(cA, None, 'db2', 'smooth')
     >>> D = pywt.idwt(None, cD, 'db2', 'smooth')
     >>> print A + D
-    [ 1.  2.  3.  4.  5.  6.]
+    array([ 1.,  2.,  3.,  4.,  5.,  6.])
 
 
 Multilevel reconstruction using ``waverec``

--- a/doc/source/ref/wavelets.rst
+++ b/doc/source/ref/wavelets.rst
@@ -134,7 +134,7 @@ Built-in wavelets - ``wavelist()``
 
     >>> import pywt
     >>> wavelet = pywt.Wavelet('db1')
-    >>> print wavelet
+    >>> print(wavelet)
     Wavelet db1
       Family name:    Daubechies
       Short name:     db
@@ -142,9 +142,9 @@ Built-in wavelets - ``wavelist()``
       Orthogonal:     True
       Biorthogonal:   True
       Symmetry:       asymmetric
-    >>> print format_array(wavelet.dec_lo), format_array(wavelet.dec_hi)
+    >>> print(format_array(wavelet.dec_lo), format_array(wavelet.dec_hi))
     [0.70710678118655, 0.70710678118655] [-0.70710678118655, 0.70710678118655]
-    >>> print format_array(wavelet.rec_lo), format_array(wavelet.rec_hi)
+    >>> print(format_array(wavelet.rec_lo), format_array(wavelet.rec_hi))
     [0.70710678118655, 0.70710678118655] [0.70710678118655, -0.70710678118655]
 
 

--- a/doc/source/regression/dwt-idwt.rst
+++ b/doc/source/regression/dwt-idwt.rst
@@ -18,9 +18,9 @@ the ``db2`` wavelet. It's simple..
 And the approximation and details coefficients are in ``cA`` and ``cD``
 respectively:
 
-    >>> print cA
+    >>> print(cA)
     [ 5.65685425  7.39923721  0.22414387  3.33677403  7.77817459]
-    >>> print cD
+    >>> print(cD)
     [-2.44948974 -1.60368225 -4.44140056 -0.41361256  1.22474487]
 
 Inverse Discrete Wavelet Transform
@@ -29,7 +29,7 @@ Inverse Discrete Wavelet Transform
 Now let's do an opposite operation
 - :func:`Inverse Discrete Wavelet Transform <idwt>`:
 
-    >>> print pywt.idwt(cA, cD, 'db2')
+    >>> print(pywt.idwt(cA, cD, 'db2'))
     [ 3.  7.  1.  1. -2.  5.  4.  6.]
 
 Voilà! That's it!
@@ -44,9 +44,9 @@ border effect handling:
 
     >>> w = pywt.Wavelet('sym3')
     >>> cA, cD = pywt.dwt(x, wavelet=w, mode='constant')
-    >>> print cA
+    >>> print(cA)
     [ 4.38354585  3.80302657  7.31813271 -0.58565539  4.09727044  7.81994027]
-    >>> print cD
+    >>> print(cD)
     [-1.33068221 -2.78795192 -3.16825651 -0.67715519 -0.09722957 -0.07045258]
 
 Note that the output coefficients arrays length depends not only on the input
@@ -91,9 +91,9 @@ doing :func:`DWT <dwt>` and :func:`IDWT <idwt>`. Otherwise, it will produce
     >>> x
     [3, 7, 1, 1, -2, 5, 4, 6]
     >>> cA, cD = pywt.dwt(x, wavelet=w, mode='periodization')
-    >>> print pywt.idwt(cA, cD, 'sym3', 'symmetric') # invalid mode
+    >>> print(pywt.idwt(cA, cD, 'sym3', 'symmetric')) # invalid mode
     [ 1.  1. -2.  5.]
-    >>> print pywt.idwt(cA, cD, 'sym3', 'periodization')
+    >>> print(pywt.idwt(cA, cD, 'sym3', 'periodization'))
     [ 3.  7.  1.  1. -2.  5.  4.  6.]
 
 
@@ -107,21 +107,21 @@ Now some tips & tricks. Passing ``None`` as one of the coefficient arrays
 parameters is similar to passing a *zero-filled* array. The results are simply
 the same:
 
-    >>> print pywt.idwt([1,2,0,1], None, 'db2', 'symmetric')
+    >>> print(pywt.idwt([1,2,0,1], None, 'db2', 'symmetric'))
     [ 1.19006969  1.54362308  0.44828774 -0.25881905  0.48296291  0.8365163 ]
 
-    >>> print pywt.idwt([1, 2, 0, 1], [0, 0, 0, 0], 'db2', 'symmetric')
+    >>> print(pywt.idwt([1, 2, 0, 1], [0, 0, 0, 0], 'db2', 'symmetric'))
     [ 1.19006969  1.54362308  0.44828774 -0.25881905  0.48296291  0.8365163 ]
 
-    >>> print pywt.idwt(None, [1, 2, 0, 1], 'db2', 'symmetric')
+    >>> print(pywt.idwt(None, [1, 2, 0, 1], 'db2', 'symmetric'))
     [ 0.57769726 -0.93125065  1.67303261 -0.96592583 -0.12940952 -0.22414387]
 
-    >>> print pywt.idwt([0, 0, 0, 0], [1, 2, 0, 1], 'db2', 'symmetric')
+    >>> print(pywt.idwt([0, 0, 0, 0], [1, 2, 0, 1], 'db2', 'symmetric'))
     [ 0.57769726 -0.93125065  1.67303261 -0.96592583 -0.12940952 -0.22414387]
 
 Remember that only one argument at a time can be ``None``:
 
-    >>> print pywt.idwt(None, None, 'db2', 'symmetric')
+    >>> print(pywt.idwt(None, None, 'db2', 'symmetric'))
     Traceback (most recent call last):
     ...
     ValueError: At least one coefficient parameter must be specified.
@@ -133,7 +133,7 @@ Coefficients data size in :attr:`idwt`
 When doing the :func:`IDWT <idwt>` transform, usually the coefficient arrays
 must have the same size.
 
-    >>> print pywt.idwt([1, 2, 3, 4, 5], [1, 2, 3, 4], 'db2', 'symmetric')
+    >>> print(pywt.idwt([1, 2, 3, 4, 5], [1, 2, 3, 4], 'db2', 'symmetric'))
     Traceback (most recent call last):
     ...
     ValueError: Coefficients arrays must have the same size.

--- a/doc/source/regression/modes.rst
+++ b/doc/source/regression/modes.rst
@@ -18,7 +18,7 @@ Import :mod:`pywt` first
 
 List of available signal extension :ref:`modes <Modes>`:
 
-    >>> print pywt.Modes.modes
+    >>> print(pywt.Modes.modes)
     ['zero', 'constant', 'symmetric', 'periodic', 'smooth', 'periodization']
 
 
@@ -27,10 +27,10 @@ Test that :func:`dwt` and :func:`idwt` can be performed using every mode:
     >>> x = [1,2,1,5,-1,8,4,6]
     >>> for mode in pywt.Modes.modes:
     ...     cA, cD = pywt.dwt(x, 'db2', mode)
-    ...     print "Mode:", mode
-    ...     print "cA:", format_array(cA)
-    ...     print "cD:", format_array(cD)
-    ...     print "Reconstruction:", pywt.idwt(cA, cD, 'db2', mode)
+    ...     print("Mode:", mode)
+    ...     print("cA:", format_array(cA))
+    ...     print("cD:", format_array(cD))
+    ...     print("Reconstruction:", pywt.idwt(cA, cD, 'db2', mode))
     Mode: zero
     cA: [-0.03468  1.73309  3.40612  6.32929  6.95095]
     cD: [-0.12941 -2.156   -5.95035 -1.21545 -1.8625 ]
@@ -70,10 +70,10 @@ You can also refer to modes via :ref:`Modes <Modes>` class attributes:
     >>> for mode_name in ['zero', 'constant', 'symmetric', 'periodic', 'smooth', 'periodization']:
     ...     mode = getattr(pywt.Modes, mode_name)
     ...     cA, cD = pywt.dwt([1,2,1,5,-1,8,4,6], 'db2', mode)
-    ...     print "Mode:", mode, "(%s)" % mode_name
-    ...     print "cA:", format_array(cA)
-    ...     print "cD:", format_array(cD)
-    ...     print "Reconstruction:", pywt.idwt(cA, cD, 'db2', mode)
+    ...     print("Mode:", mode, "(%s)" % mode_name)
+    ...     print("cA:", format_array(cA))
+    ...     print("cD:", format_array(cD))
+    ...     print("Reconstruction:", pywt.idwt(cA, cD, 'db2', mode))
     Mode: 0 (zero)
     cA: [-0.03468  1.73309  3.40612  6.32929  6.95095]
     cD: [-0.12941 -2.156   -5.95035 -1.21545 -1.8625 ]
@@ -103,20 +103,20 @@ You can also refer to modes via :ref:`Modes <Modes>` class attributes:
 The default mode is :ref:`symmetric <Modes.symmetric>`:
 
     >>> cA, cD = pywt.dwt(x, 'db2')
-    >>> print cA
+    >>> print(cA)
     [ 1.76776695  1.73309178  3.40612438  6.32928585  7.77817459]
-    >>> print cD
+    >>> print(cD)
     [-0.61237244 -2.15599552 -5.95034847 -1.21545369  1.22474487]
-    >>> print pywt.idwt(cA, cD, 'db2')
+    >>> print(pywt.idwt(cA, cD, 'db2'))
     [ 1.  2.  1.  5. -1.  8.  4.  6.]
 
 
 And using a keyword argument:
 
     >>> cA, cD = pywt.dwt(x, 'db2', mode='symmetric')
-    >>> print cA
+    >>> print(cA)
     [ 1.76776695  1.73309178  3.40612438  6.32928585  7.77817459]
-    >>> print cD
+    >>> print(cD)
     [-0.61237244 -2.15599552 -5.95034847 -1.21545369  1.22474487]
-    >>> print pywt.idwt(cA, cD, 'db2')
+    >>> print(pywt.idwt(cA, cD, 'db2'))
     [ 1.  2.  1.  5. -1.  8.  4.  6.]

--- a/doc/source/regression/modes.rst
+++ b/doc/source/regression/modes.rst
@@ -27,10 +27,11 @@ Test that :func:`dwt` and :func:`idwt` can be performed using every mode:
     >>> x = [1,2,1,5,-1,8,4,6]
     >>> for mode in pywt.Modes.modes:
     ...     cA, cD = pywt.dwt(x, 'db2', mode)
-    ...     print("Mode:", mode)
-    ...     print("cA:", format_array(cA))
-    ...     print("cD:", format_array(cD))
-    ...     print("Reconstruction:", pywt.idwt(cA, cD, 'db2', mode))
+    ...     print("Mode: %s" % mode)
+    ...     print("cA: " + format_array(cA))
+    ...     print("cD: " + format_array(cD))
+    ...     print("Reconstruction: " + format_array(
+    ...         pywt.idwt(cA, cD, 'db2', mode)))
     Mode: zero
     cA: [-0.03468  1.73309  3.40612  6.32929  6.95095]
     cD: [-0.12941 -2.156   -5.95035 -1.21545 -1.8625 ]
@@ -70,10 +71,11 @@ You can also refer to modes via :ref:`Modes <Modes>` class attributes:
     >>> for mode_name in ['zero', 'constant', 'symmetric', 'periodic', 'smooth', 'periodization']:
     ...     mode = getattr(pywt.Modes, mode_name)
     ...     cA, cD = pywt.dwt([1,2,1,5,-1,8,4,6], 'db2', mode)
-    ...     print("Mode:", mode, "(%s)" % mode_name)
-    ...     print("cA:", format_array(cA))
-    ...     print("cD:", format_array(cD))
-    ...     print("Reconstruction:", pywt.idwt(cA, cD, 'db2', mode))
+    ...     print("Mode: %d (%s)" % (mode, mode_name))
+    ...     print("cA: " + format_array(cA))
+    ...     print("cD: " + format_array(cD))
+    ...     print("Reconstruction: " + format_array(
+    ...         pywt.idwt(cA, cD, 'db2', mode)))
     Mode: 0 (zero)
     cA: [-0.03468  1.73309  3.40612  6.32929  6.95095]
     cD: [-0.12941 -2.156   -5.95035 -1.21545 -1.8625 ]

--- a/doc/source/regression/multilevel.rst
+++ b/doc/source/regression/multilevel.rst
@@ -12,13 +12,13 @@ Multilevel DWT decomposition
 >>> x = [3, 7, 1, 1, -2, 5, 4, 6]
 >>> db1 = pywt.Wavelet('db1')
 >>> cA3, cD3, cD2, cD1 = pywt.wavedec(x, db1)
->>> print cA3
+>>> print(cA3)
 [ 8.83883476]
->>> print cD3
+>>> print(cD3)
 [-0.35355339]
->>> print cD2
+>>> print(cD2)
 [ 4.  -3.5]
->>> print cD1
+>>> print(cD1)
 [-2.82842712  0.         -4.94974747 -1.41421356]
 
 >>> pywt.dwt_max_level(len(x), db1)
@@ -31,7 +31,7 @@ Multilevel IDWT reconstruction
 ------------------------------
 
 >>> coeffs = pywt.wavedec(x, db1)
->>> print pywt.waverec(coeffs, db1)
+>>> print(pywt.waverec(coeffs, db1))
 [ 3.  7.  1.  1. -2.  5.  4.  6.]
 
 
@@ -40,21 +40,21 @@ Multilevel SWT decomposition
 
 >>> x = [3, 7, 1, 3, -2, 6, 4, 6]
 >>> (cA2, cD2), (cA1, cD1) = pywt.swt(x, db1, level=2)
->>> print cA1
+>>> print(cA1)
 [ 7.07106781  5.65685425  2.82842712  0.70710678  2.82842712  7.07106781
   7.07106781  6.36396103]
->>> print cD1
+>>> print(cD1)
 [-2.82842712  4.24264069 -1.41421356  3.53553391 -5.65685425  1.41421356
  -1.41421356  2.12132034]
->>> print cA2
+>>> print(cA2)
 [  7.    4.5   4.    5.5   7.    9.5  10.    8.5]
->>> print cD2
+>>> print(cD2)
 [ 3.   3.5  0.  -4.5 -3.   0.5  0.   0.5]
 
 >>> [(cA2, cD2)] = pywt.swt(cA1, db1, level=1, start_level=1)
->>> print cA2
+>>> print(cA2)
 [  7.    4.5   4.    5.5   7.    9.5  10.    8.5]
->>> print cD2
+>>> print(cD2)
 [ 3.   3.5  0.  -4.5 -3.   0.5  0.   0.5]
 
 >>> coeffs = pywt.swt(x, db1)

--- a/doc/source/regression/wavelet.rst
+++ b/doc/source/regression/wavelet.rst
@@ -26,7 +26,7 @@ The :func:`wavelist` function with family name passed as an argument is used to
 obtain the list of wavelet names in each family.
 
     >>> for family in pywt.families():
-    ...     print("%s family:" % family, ', '.join(pywt.wavelist(family)))
+    ...     print("%s family: " % family + ', '.join(pywt.wavelist(family)))
     haar family: haar
     db family: db1, db2, db3, db4, db5, db6, db7, db8, db9, db10, db11, db12, db13, db14, db15, db16, db17, db18, db19, db20
     sym family: sym2, sym3, sym4, sym5, sym6, sym7, sym8, sym9, sym10, sym11, sym12, sym13, sym14, sym15, sym16, sym17, sym18, sym19, sym20

--- a/doc/source/regression/wavelet.rst
+++ b/doc/source/regression/wavelet.rst
@@ -26,7 +26,7 @@ The :func:`wavelist` function with family name passed as an argument is used to
 obtain the list of wavelet names in each family.
 
     >>> for family in pywt.families():
-    ...     print "%s family:" % family, ', '.join(pywt.wavelist(family))
+    ...     print("%s family:" % family, ', '.join(pywt.wavelist(family)))
     haar family: haar
     db family: db1, db2, db3, db4, db5, db6, db7, db8, db9, db10, db11, db12, db13, db14, db15, db16, db17, db18, db19, db20
     sym family: sym2, sym3, sym4, sym5, sym6, sym7, sym8, sym9, sym10, sym11, sym12, sym13, sym14, sym15, sym16, sym17, sym18, sym19, sym20
@@ -62,7 +62,7 @@ First, let's try printing a :class:`Wavelet` object. This shows a brief
 information about its name, its family name and some properties like
 orthogonality and symmetry.
 
-    >>> print w
+    >>> print(w)
     Wavelet db3
       Family name:    Daubechies
       Short name:     db
@@ -79,7 +79,7 @@ corresponds to lowpass and highpass decomposition filters and lowpass and
 highpass reconstruction filters respectively:
 
     >>> def print_array(arr):
-    ...     print "[%s]" % ", ".join(["%.14f" % x for x in arr])
+    ...     print("[%s]" % ", ".join(["%.14f" % x for x in arr]))
 
     >>> print_array(w.dec_lo)
     [0.03522629188210, -0.08544127388224, -0.13501102001039, 0.45987750211933, 0.80689150931334, 0.33267055295096]
@@ -101,11 +101,11 @@ Other Wavelet's properties are:
 
     Wavelet :attr:`~Wavelet.name`, :attr:`~Wavelet.short_family_name` and :attr:`~Wavelet.family_name`:
 
-        >>> print w.name
+        >>> print(w.name)
         db3
-        >>> print w.short_family_name
+        >>> print(w.short_family_name)
         db
-        >>> print w.family_name
+        >>> print(w.family_name)
         Daubechies
 
     - Decomposition (:attr:`~Wavelet.dec_len`) and reconstruction
@@ -125,7 +125,7 @@ Other Wavelet's properties are:
 
     - Symmetry (:attr:`~Wavelet.symmetry`):
 
-        >>> print w.symmetry
+        >>> print(w.symmetry)
         asymmetric
 
     - Number of vanishing moments for the scaling function *phi*
@@ -166,7 +166,7 @@ Now when we know a bit about the builtin Wavelets, let's see how to create
 Note that such custom wavelets **will not** have all the properties set
 to correct values:
 
-    >>> print my_wavelet
+    >>> print(my_wavelet)
     Wavelet My Haar Wavelet
       Family name:
       Short name:
@@ -180,7 +180,7 @@ to correct values:
     >>> my_wavelet.orthogonal = True
     >>> my_wavelet.biorthogonal = True
 
-    >>> print my_wavelet
+    >>> print(my_wavelet)
     Wavelet My Haar Wavelet
       Family name:
       Short name:

--- a/doc/source/regression/wp.rst
+++ b/doc/source/regression/wp.rst
@@ -28,21 +28,21 @@ Ok, let's create a sample :class:`WaveletPacket`:
 The input *data* and decomposition coefficients are stored in the
 :attr:`WaveletPacket.data` attribute:
 
-    >>> print wp.data
+    >>> print(wp.data)
     [1, 2, 3, 4, 5, 6, 7, 8]
 
 :class:`Nodes <Node>` are identified by :attr:`paths <~Node.path>`. For the root
 node the path is ``''`` and the decomposition level is ``0``.
 
-    >>> print repr(wp.path)
+    >>> print(repr(wp.path))
     ''
-    >>> print wp.level
+    >>> print(wp.level)
     0
 
 The *maxlevel*, if not given as param in the constructor, is automatically
 computed:
 
-    >>> print wp['ad'].maxlevel
+    >>> print(wp['ad'].maxlevel)
     3
 
 
@@ -57,45 +57,45 @@ Accessing subnodes:
 
 First check what is the maximum level of decomposition:
 
-    >>> print wp.maxlevel
+    >>> print(wp.maxlevel)
     3
 
 and try accessing subnodes of the WP tree:
 
     * 1st level:
 
-        >>> print wp['a'].data
+        >>> print(wp['a'].data)
         [  2.12132034   4.94974747   7.77817459  10.60660172]
-        >>> print wp['a'].path
+        >>> print(wp['a'].path)
         a
 
     * 2nd level:
 
-        >>> print wp['aa'].data
+        >>> print(wp['aa'].data)
         [  5.  13.]
-        >>> print wp['aa'].path
+        >>> print(wp['aa'].path)
         aa
 
 
     * 3rd level:
 
-        >>> print wp['aaa'].data
+        >>> print(wp['aaa'].data)
         [ 12.72792206]
-        >>> print wp['aaa'].path
+        >>> print(wp['aaa'].path)
         aaa
 
 
       Ups, we have reached the maximum level of decomposition and got an
       :exc:`IndexError`:
 
-        >>> print wp['aaaa'].data
+        >>> print(wp['aaaa'].data)
         Traceback (most recent call last):
         ...
         IndexError: Path length is out of range.
 
 Now try some invalid path:
 
-    >>> print wp['ac']
+    >>> print(wp['ac'])
     Traceback (most recent call last):
     ...
     ValueError: Subnode name must be in ['a', 'd'], not 'c'.
@@ -118,26 +118,26 @@ Each tree node has a set of attributes: :attr:`~Node.data`, :attr:`~Node.path`,
 >>> x = [1, 2, 3, 4, 5, 6, 7, 8]
 >>> wp = pywt.WaveletPacket(data=x, wavelet='db1', mode='symmetric')
 
->>> print wp['ad'].data
+>>> print(wp['ad'].data)
 [-2. -2.]
 
->>> print wp['ad'].path
+>>> print(wp['ad'].path)
 ad
 
->>> print wp['ad'].node_name
+>>> print(wp['ad'].node_name)
 d
 
->>> print wp['ad'].parent.path
+>>> print(wp['ad'].parent.path)
 a
 
->>> print wp['ad'].level
+>>> print(wp['ad'].level)
 2
 
->>> print wp['ad'].maxlevel
+>>> print(wp['ad'].maxlevel)
 3
 
->>> print wp['ad'].mode
-sym
+>>> print(wp['ad'].mode)
+symmetric
 
 
 Collecting nodes
@@ -149,12 +149,12 @@ Collecting nodes
 
 We can get all nodes on the particular level either in ``natural`` order:
 
-    >>> print [node.path for node in wp.get_level(3, 'natural')]
+    >>> print([node.path for node in wp.get_level(3, 'natural')])
     ['aaa', 'aad', 'ada', 'add', 'daa', 'dad', 'dda', 'ddd']
 
 or sorted based on the band frequency (``freq``):
 
-    >>> print [node.path for node in wp.get_level(3, 'freq')]
+    >>> print([node.path for node in wp.get_level(3, 'freq')])
     ['aaa', 'aad', 'add', 'ada', 'dda', 'ddd', 'dad', 'daa']
 
 Note that :meth:`WaveletPacket.get_level` also performs automatic decomposition
@@ -183,28 +183,28 @@ For convenience, :attr:`Node.data` gets automatically extracted from the
 
 And reconstruct the data from the ``aa``, ``ad`` and ``d`` packets.
 
-    >>> print new_wp.reconstruct(update=False)
+    >>> print(new_wp.reconstruct(update=False))
     [ 1.  2.  3.  4.  5.  6.  7.  8.]
 
 If the *update* param in the reconstruct method is set to ``False``, the node's
 :attr:`~Node.data` will not be updated.
 
-    >>> print new_wp.data
+    >>> print(new_wp.data)
     None
 
 Otherwise, the :attr:`~Node.data` attribute will be set to the reconstructed
 value.
 
-    >>> print new_wp.reconstruct(update=True)
+    >>> print(new_wp.reconstruct(update=True))
     [ 1.  2.  3.  4.  5.  6.  7.  8.]
-    >>> print new_wp.data
+    >>> print(new_wp.data)
     [ 1.  2.  3.  4.  5.  6.  7.  8.]
 
 
->>> print [n.path for n in new_wp.get_leaf_nodes(False)]
+>>> print([n.path for n in new_wp.get_leaf_nodes(False)])
 ['aa', 'ad', 'd']
 
->>> print [n.path for n in new_wp.get_leaf_nodes(True)]
+>>> print([n.path for n in new_wp.get_leaf_nodes(True)])
 ['aaa', 'aad', 'ada', 'add', 'daa', 'dad', 'dda', 'ddd']
 
 
@@ -220,14 +220,14 @@ First, start with a tree decomposition at level 2. Leaf nodes in the tree are:
 
     >>> dummy = wp.get_level(2)
     >>> for n in wp.get_leaf_nodes(False):
-    ...     print n.path, format_array(n.data)
+    ...     print(n.path, format_array(n.data))
     aa [  5.  13.]
     ad [-2. -2.]
     da [-1. -1.]
     dd [ 0.  0.]
 
     >>> node = wp['ad']
-    >>> print node
+    >>> print(node)
     ad: [-2. -2.]
 
 To remove a node from the WP tree, use Python's `del obj[x]`
@@ -238,14 +238,14 @@ To remove a node from the WP tree, use Python's `del obj[x]`
 The leaf nodes that left in the tree are:
 
     >>> for n in wp.get_leaf_nodes():
-    ...     print n.path, format_array(n.data)
+    ...     print(n.path, format_array(n.data))
     aa [  5.  13.]
     da [-1. -1.]
     dd [ 0.  0.]
 
 And the reconstruction is:
 
-    >>> print wp.reconstruct()
+    >>> print(wp.reconstruct())
     [ 2.  3.  2.  3.  6.  7.  6.  7.]
 
 Now restore the deleted node value.
@@ -256,13 +256,13 @@ Printing leaf nodes and tree reconstruction confirms the original state of the
 tree:
 
     >>> for n in wp.get_leaf_nodes(False):
-    ...     print n.path, format_array(n.data)
+    ...     print(n.path, format_array(n.data))
     aa [  5.  13.]
     ad [-2. -2.]
     da [-1. -1.]
     dd [ 0.  0.]
 
-    >>> print wp.reconstruct()
+    >>> print(wp.reconstruct())
     [ 1.  2.  3.  4.  5.  6.  7.  8.]
 
 
@@ -278,7 +278,7 @@ Lazy evaluation:
 
 1) At first the wp's attribute `a` is None
 
-   >>> print wp.a
+   >>> print(wp.a)
    None
 
    **Remember that you should not rely on the attribute access.**
@@ -286,15 +286,15 @@ Lazy evaluation:
 2) At first attempt to access the node it is computed via decomposition
    of its parent node (the wp object itself).
 
-   >>> print wp['a']
+   >>> print(wp['a'])
    a: [  2.12132034   4.94974747   7.77817459  10.60660172]
 
 3) Now the `wp.a` is set to the newly created node:
 
-   >>> print wp.a
+   >>> print(wp.a)
    a: [  2.12132034   4.94974747   7.77817459  10.60660172]
 
    And so is `wp.d`:
 
-   >>> print wp.d
+   >>> print(wp.d)
    d: [-0.70710678 -0.70710678 -0.70710678 -0.70710678]

--- a/doc/source/regression/wp.rst
+++ b/doc/source/regression/wp.rst
@@ -2,6 +2,8 @@
 
 .. currentmodule:: pywt
 
+>>> from __future__ import print_function
+
 Wavelet Packets
 ===============
 

--- a/doc/source/regression/wp2d.rst
+++ b/doc/source/regression/wp2d.rst
@@ -19,7 +19,7 @@ Create 2D Wavelet Packet structure
 Start with preparing test data:
 
     >>> x = numpy.array([[1, 2, 3, 4, 5, 6, 7, 8]] * 8, 'd')
-    >>> print x
+    >>> print(x)
     [[ 1.  2.  3.  4.  5.  6.  7.  8.]
      [ 1.  2.  3.  4.  5.  6.  7.  8.]
      [ 1.  2.  3.  4.  5.  6.  7.  8.]
@@ -36,7 +36,7 @@ Now create a :class:`2D Wavelet Packet <WaveletPacket2D>` object:
 The input *data* and decomposition coefficients are stored in the
 :attr:`WaveletPacket2D.data` attribute:
 
-    >>> print wp.data
+    >>> print(wp.data)
     [[ 1.  2.  3.  4.  5.  6.  7.  8.]
      [ 1.  2.  3.  4.  5.  6.  7.  8.]
      [ 1.  2.  3.  4.  5.  6.  7.  8.]
@@ -49,15 +49,15 @@ The input *data* and decomposition coefficients are stored in the
 :class:`Nodes <Node2D>` are identified by paths. For the root node the path is
 ``''`` and the decomposition level is ``0``.
 
-    >>> print repr(wp.path)
+    >>> print(repr(wp.path))
     ''
-    >>> print wp.level
+    >>> print(wp.level)
     0
 
 The :attr:`WaveletPacket2D.maxlevel`, if not given in the constructor, is
 automatically computed based on the data size:
 
-    >>> print wp.maxlevel
+    >>> print(wp.maxlevel)
     3
 
 
@@ -99,22 +99,22 @@ naming convention (as wavelet packet transform is based on the dwt2 transform)::
 Knowing what the nodes names are, we can now access them using the indexing
 operator `obj[x]` (:meth:`WaveletPacket2D.__getitem__`):
 
-    >>> print wp['a'].data
+    >>> print(wp['a'].data)
     [[  3.   7.  11.  15.]
      [  3.   7.  11.  15.]
      [  3.   7.  11.  15.]
      [  3.   7.  11.  15.]]
-    >>> print wp['h'].data
+    >>> print(wp['h'].data)
     [[ 0.  0.  0.  0.]
      [ 0.  0.  0.  0.]
      [ 0.  0.  0.  0.]
      [ 0.  0.  0.  0.]]
-    >>> print wp['v'].data
+    >>> print(wp['v'].data)
     [[-1. -1. -1. -1.]
      [-1. -1. -1. -1.]
      [-1. -1. -1. -1.]
      [-1. -1. -1. -1.]]
-    >>> print wp['d'].data
+    >>> print(wp['d'].data)
     [[ 0.  0.  0.  0.]
      [ 0.  0.  0.  0.]
      [ 0.  0.  0.  0.]
@@ -122,7 +122,7 @@ operator `obj[x]` (:meth:`WaveletPacket2D.__getitem__`):
 
 Similarly, a subnode of a subnode can be accessed by:
 
-    >>> print wp['aa'].data
+    >>> print(wp['aa'].data)
     [[ 10.  26.]
      [ 10.  26.]]
 
@@ -130,17 +130,17 @@ Indexing base :class:`WaveletPacket2D` (as well as 1D :class:`WaveletPacket`)
 using compound path is just the same as indexing WP subnode:
 
     >>> node = wp['a']
-    >>> print node['a'].data
+    >>> print(node['a'].data)
     [[ 10.  26.]
      [ 10.  26.]]
-    >>> print wp['a']['a'].data is wp['aa'].data
+    >>> print(wp['a']['a'].data is wp['aa'].data)
     True
 
 Following down the decomposition path:
 
-    >>> print wp['aaa'].data
+    >>> print(wp['aaa'].data)
     [[ 36.]]
-    >>> print wp['aaaa'].data
+    >>> print(wp['aaaa'].data)
     Traceback (most recent call last):
     ...
     IndexError: Path length is out of range.
@@ -148,13 +148,13 @@ Following down the decomposition path:
 Ups, we have reached the maximum level of decomposition for the ``'aaaa'`` path,
 which btw. was:
 
-    >>> print wp.maxlevel
+    >>> print(wp.maxlevel)
     3
 
 
 Now try some invalid path:
 
-    >>> print wp['f']
+    >>> print(wp['f'])
     Traceback (most recent call last):
     ...
     ValueError: Subnode name must be in ['a', 'h', 'v', 'd'], not 'f'.
@@ -168,33 +168,33 @@ of :class:`Node2D` objects. :class:`WaveletPacket2D` is just a special subclass
 of the :class:`Node2D` class (which in turn inherits from a :class:`BaseNode`,
 just like with :class:`Node` and :class:`WaveletPacket` for the 1D case.).
 
-    >>> print wp['av'].data
+    >>> print(wp['av'].data)
     [[-4. -4.]
      [-4. -4.]]
 
-    >>> print wp['av'].path
+    >>> print(wp['av'].path)
     av
 
-    >>> print wp['av'].node_name
+    >>> print(wp['av'].node_name)
     v
 
-    >>> print wp['av'].parent.path
+    >>> print(wp['av'].parent.path)
     a
 
-    >>> print wp['av'].parent.data
+    >>> print(wp['av'].parent.data)
     [[  3.   7.  11.  15.]
      [  3.   7.  11.  15.]
      [  3.   7.  11.  15.]
      [  3.   7.  11.  15.]]
 
-    >>> print wp['av'].level
+    >>> print(wp['av'].level)
     2
 
-    >>> print wp['av'].maxlevel
+    >>> print(wp['av'].maxlevel)
     3
 
-    >>> print wp['av'].mode
-    sym
+    >>> print(wp['av'].mode)
+    symmetric
 
 
 Collecting nodes
@@ -207,14 +207,14 @@ We can get all nodes on the particular level using the
 
         >>> len(wp.get_level(0))
         1
-        >>> print [node.path for node in wp.get_level(0)]
+        >>> print([node.path for node in wp.get_level(0)])
         ['']
 
     * 1st level of decomposition:
 
         >>> len(wp.get_level(1))
         4
-        >>> print [node.path for node in wp.get_level(1)]
+        >>> print([node.path for node in wp.get_level(1)])
         ['a', 'h', 'v', 'd']
 
     * 2nd level of decomposition:
@@ -223,8 +223,10 @@ We can get all nodes on the particular level using the
         16
         >>> paths = [node.path for node in wp.get_level(2)]
         >>> for i, path in enumerate(paths):
-        ...     print path,
-        ...     if (i+1) % 4 == 0: print
+        ...     if (i+1) % 4 == 0:
+        ...         print(path)
+        ...     else:
+        ...         print(path, end=' ')
         aa ah av ad
         ha hh hv hd
         va vh vv vd
@@ -232,12 +234,14 @@ We can get all nodes on the particular level using the
 
     * 3rd level of decomposition:
 
-        >>> print len(wp.get_level(3))
+        >>> print(len(wp.get_level(3)))
         64
         >>> paths = [node.path for node in wp.get_level(3)]
         >>> for i, path in enumerate(paths):
-        ...     print path,
-        ...     if (i+1) % 8 == 0: print
+        ...     if (i+1) % 8 == 0:
+        ...         print(path)
+        ...     else:
+        ...         print(path, end=' ')
         aaa aah aav aad aha ahh ahv ahd
         ava avh avv avd ada adh adv add
         haa hah hav had hha hhh hhv hhd
@@ -279,7 +283,7 @@ And reconstruct the data from the ``a``, ``d``, ``vh``, ``vv``, ``vd`` and ``h``
 packets (Note that ``va`` node was not set and the WP tree is "not complete"
 - the ``va`` branch will be treated as *zero-array*):
 
-    >>> print new_wp.reconstruct(update=False)
+    >>> print(new_wp.reconstruct(update=False))
     [[ 1.5  1.5  3.5  3.5  5.5  5.5  7.5  7.5]
      [ 1.5  1.5  3.5  3.5  5.5  5.5  7.5  7.5]
      [ 1.5  1.5  3.5  3.5  5.5  5.5  7.5  7.5]
@@ -292,7 +296,7 @@ packets (Note that ``va`` node was not set and the WP tree is "not complete"
 Now set the ``va`` node with the known values and do the reconstruction again:
 
     >>> new_wp['va'] = wp['va'].data # [[-2.0, -2.0], [-2.0, -2.0]]
-    >>> print new_wp.reconstruct(update=False)
+    >>> print(new_wp.reconstruct(update=False))
     [[ 1.  2.  3.  4.  5.  6.  7.  8.]
      [ 1.  2.  3.  4.  5.  6.  7.  8.]
      [ 1.  2.  3.  4.  5.  6.  7.  8.]
@@ -309,7 +313,7 @@ the ``va`` node, again, we get the "not complete" tree from one of the previous
 examples:
 
     >>> del new_wp['va']
-    >>> print new_wp.reconstruct(update=False)
+    >>> print(new_wp.reconstruct(update=False))
     [[ 1.5  1.5  3.5  3.5  5.5  5.5  7.5  7.5]
      [ 1.5  1.5  3.5  3.5  5.5  5.5  7.5  7.5]
      [ 1.5  1.5  3.5  3.5  5.5  5.5  7.5  7.5]
@@ -326,13 +330,13 @@ Just restore the node before next examples.
 If the *update* param in the :meth:`WaveletPacket2D.reconstruct` method is set
 to ``False``, the node's :attr:`Node2D.data` attribute will not be updated.
 
-    >>> print new_wp.data
+    >>> print(new_wp.data)
     None
 
 Otherwise, the :attr:`WaveletPacket2D.data` attribute will be set to the
 reconstructed value.
 
-    >>> print new_wp.reconstruct(update=True)
+    >>> print(new_wp.reconstruct(update=True))
     [[ 1.  2.  3.  4.  5.  6.  7.  8.]
      [ 1.  2.  3.  4.  5.  6.  7.  8.]
      [ 1.  2.  3.  4.  5.  6.  7.  8.]
@@ -341,7 +345,7 @@ reconstructed value.
      [ 1.  2.  3.  4.  5.  6.  7.  8.]
      [ 1.  2.  3.  4.  5.  6.  7.  8.]
      [ 1.  2.  3.  4.  5.  6.  7.  8.]]
-    >>> print new_wp.data
+    >>> print(new_wp.data)
     [[ 1.  2.  3.  4.  5.  6.  7.  8.]
      [ 1.  2.  3.  4.  5.  6.  7.  8.]
      [ 1.  2.  3.  4.  5.  6.  7.  8.]
@@ -355,7 +359,7 @@ Since we have an interesting WP structure built, it is a good occasion to
 present the :meth:`WaveletPacket2D.get_leaf_nodes` method, which collects
 non-zero leaf nodes from the WP tree:
 
-    >>> print [n.path for n in new_wp.get_leaf_nodes()]
+    >>> print([n.path for n in new_wp.get_leaf_nodes()])
     ['a', 'h', 'va', 'vh', 'vv', 'vd', 'd']
 
 Passing the *decompose=True* parameter to the method will force the WP object
@@ -365,8 +369,10 @@ to do a full decomposition up to the *maximum level* of decomposition:
     >>> len(paths)
     64
     >>> for i, path in enumerate(paths):
-    ...     print path,
-    ...     if (i+1) % 8 == 0: print
+    ...     if (i+1) % 8 == 0:
+    ...         print(path)
+    ...     else:
+    ...         print(path, end=' ')
     aaa aah aav aad aha ahh ahv ahd
     ava avh avv avd ada adh adv add
     haa hah hav had hha hhh hhv hhd
@@ -388,7 +394,7 @@ Lazy evaluation:
 
 1) At first the wp's attribute `a` is ``None``
 
-   >>> print wp.a
+   >>> print(wp.a)
    None
 
    **Remember that you should not rely on the attribute access.**
@@ -396,7 +402,7 @@ Lazy evaluation:
 2) During the first attempt to access the node it is computed
    via decomposition of its parent node (the wp object itself).
 
-   >>> print wp['a']
+   >>> print(wp['a'])
    a: [[  3.   7.  11.  15.]
     [  3.   7.  11.  15.]
     [  3.   7.  11.  15.]
@@ -404,7 +410,7 @@ Lazy evaluation:
 
 3) Now the `a` is set to the newly created node:
 
-    >>> print wp.a
+    >>> print(wp.a)
     a: [[  3.   7.  11.  15.]
      [  3.   7.  11.  15.]
      [  3.   7.  11.  15.]
@@ -412,7 +418,7 @@ Lazy evaluation:
 
    And so is `wp.d`:
 
-    >>> print wp.d
+    >>> print(wp.d)
     d: [[ 0.  0.  0.  0.]
      [ 0.  0.  0.  0.]
      [ 0.  0.  0.  0.]

--- a/doc/source/regression/wp2d.rst
+++ b/doc/source/regression/wp2d.rst
@@ -9,6 +9,7 @@
 Import pywt
 -----------
 
+>>> from __future__ import print_function
 >>> import pywt
 >>> import numpy
 
@@ -372,7 +373,10 @@ to do a full decomposition up to the *maximum level* of decomposition:
     ...     if (i+1) % 8 == 0:
     ...         print(path)
     ...     else:
-    ...         print(path, end=' ')
+    ...         try:
+    ...             print(path, end=' ')
+    ...         except:
+    ...             print(path, end=' ')
     aaa aah aav aad aha ahh ahv ahd
     ava avh avv avd ada adh adv add
     haa hah hav had hha hhh hhv hhd

--- a/pywt/_functions.py
+++ b/pywt/_functions.py
@@ -94,12 +94,11 @@ def integrate_wavelet(wavelet, precision=8):
 
     Examples
     --------
-    >>> import pywt
-    >>> wavelet1 = pywt.Wavelet('db2')
-    >>> [int_psi, x] = pywt.integrate_wavelet(wavelet1, precision=5)
-    >>> wavelet2 = pywt.Wavelet('bior1.3')
-    >>> [int_psi_d, int_psi_r, x] = pywt.integrate_wavelet(wavelet2,
-                                                           precision=5)
+    >>> from pywt import Wavelet, integrate_wavelet
+    >>> wavelet1 = Wavelet('db2')
+    >>> [int_psi, x] = integrate_wavelet(wavelet1, precision=5)
+    >>> wavelet2 = Wavelet('bior1.3')
+    >>> [int_psi_d, int_psi_r, x] = integrate_wavelet(wavelet2, precision=5)
 
     """
     # FIXME: this function should really use scipy.integrate.quad

--- a/pywt/_multidim.py
+++ b/pywt/_multidim.py
@@ -43,6 +43,7 @@ def dwt2(data, wavelet, mode='symmetric', axes=(-2, -1)):
 
     Examples
     --------
+    >>> import numpy as np
     >>> import pywt
     >>> data = np.ones((4,4), dtype=np.float64)
     >>> coeffs = pywt.dwt2(data, 'haar')
@@ -85,6 +86,7 @@ def idwt2(coeffs, wavelet, mode='symmetric', axes=(-2, -1)):
 
     Examples
     --------
+    >>> import numpy as np
     >>> import pywt
     >>> data = np.array([[1,2], [3,4]], dtype=np.float64)
     >>> coeffs = pywt.dwt2(data, 'haar')

--- a/pywt/_multilevel.py
+++ b/pywt/_multilevel.py
@@ -444,14 +444,27 @@ def wavedecn(data, wavelet, mode='symmetric', level=None):
     --------
     >>> import numpy as np
     >>> from pywt import wavedecn, waverecn
-    >>> data = np.ones((4, 4, 4))
-    >>> coeffs = wavedecn(data, 'db1')
+    >>> coeffs = wavedecn(np.ones((4, 4, 4)), 'db1')
     >>> # Levels:
     >>> len(coeffs)-1
     2
-    >>> rec = waverecn(coeffs, 'db1')
-    >>> np.max(data-rec) < 1e-14
-    True
+    >>> waverecn(coeffs, 'db1')  # doctest: +NORMALIZE_WHITESPACE
+    array([[[ 1.,  1.,  1.,  1.],
+            [ 1.,  1.,  1.,  1.],
+            [ 1.,  1.,  1.,  1.],
+            [ 1.,  1.,  1.,  1.]],
+           [[ 1.,  1.,  1.,  1.],
+            [ 1.,  1.,  1.,  1.],
+            [ 1.,  1.,  1.,  1.],
+            [ 1.,  1.,  1.,  1.]],
+           [[ 1.,  1.,  1.,  1.],
+            [ 1.,  1.,  1.,  1.],
+            [ 1.,  1.,  1.,  1.],
+            [ 1.,  1.,  1.,  1.]],
+           [[ 1.,  1.,  1.,  1.],
+            [ 1.,  1.,  1.,  1.],
+            [ 1.,  1.,  1.,  1.],
+            [ 1.,  1.,  1.,  1.]]])
 
     """
     data = np.asarray(data)
@@ -511,14 +524,28 @@ def waverecn(coeffs, wavelet, mode='symmetric'):
     --------
     >>> import numpy as np
     >>> from pywt import wavedecn, waverecn
-    >>> data = np.ones((4, 4, 4))
-    >>> coeffs = wavedecn(data, 'db1')
+    >>> coeffs = wavedecn(np.ones((4, 4, 4)), 'db1')
     >>> # Levels:
     >>> len(coeffs)-1
     2
-    >>> rec = waverecn(coeffs, 'db1')
-    >>> np.max(data-rec) < 1e-14
-    True
+    >>> waverecn(coeffs, 'db1')  # doctest: +NORMALIZE_WHITESPACE
+    array([[[ 1.,  1.,  1.,  1.],
+            [ 1.,  1.,  1.,  1.],
+            [ 1.,  1.,  1.,  1.],
+            [ 1.,  1.,  1.,  1.]],
+           [[ 1.,  1.,  1.,  1.],
+            [ 1.,  1.,  1.,  1.],
+            [ 1.,  1.,  1.,  1.],
+            [ 1.,  1.,  1.,  1.]],
+           [[ 1.,  1.,  1.,  1.],
+            [ 1.,  1.,  1.,  1.],
+            [ 1.,  1.,  1.,  1.],
+            [ 1.,  1.,  1.,  1.]],
+           [[ 1.,  1.,  1.,  1.],
+            [ 1.,  1.,  1.,  1.],
+            [ 1.,  1.,  1.,  1.],
+            [ 1.,  1.,  1.,  1.]]])
+
     """
     if len(coeffs) < 1:
         raise ValueError(

--- a/pywt/_multilevel.py
+++ b/pywt/_multilevel.py
@@ -111,8 +111,8 @@ def waverec(coeffs, wavelet, mode='symmetric'):
     Examples
     --------
     >>> import pywt
-    >>> coeffs = pywt.wavedec([1,2,3,4,5,6,7,8], 'db2', level=2)
-    >>> pywt.waverec(coeffs, 'db2')
+    >>> coeffs = pywt.wavedec([1,2,3,4,5,6,7,8], 'db1', level=2)
+    >>> pywt.waverec(coeffs, 'db1')
     array([ 1.,  2.,  3.,  4.,  5.,  6.,  7.,  8.])
     """
 
@@ -160,6 +160,7 @@ def wavedec2(data, wavelet, mode='symmetric', level=None):
     Examples
     --------
     >>> import pywt
+    >>> import numpy as np
     >>> coeffs = pywt.wavedec2(np.ones((4,4)), 'db1')
     >>> # Levels:
     >>> len(coeffs)-1
@@ -211,6 +212,7 @@ def waverec2(coeffs, wavelet, mode='symmetric'):
     Examples
     --------
     >>> import pywt
+    >>> import numpy as np
     >>> coeffs = pywt.wavedec2(np.ones((4,4)), 'db1')
     >>> # Levels:
     >>> len(coeffs)-1
@@ -440,31 +442,16 @@ def wavedecn(data, wavelet, mode='symmetric', level=None):
 
     Examples
     --------
-    >>> from pywt import multilevel
-    >>> coeffs = multilevel.wavedecn(np.ones((4, 4, 4)), 'db1')
+    >>> import numpy as np
+    >>> from pywt import wavedecn, waverecn
+    >>> data = np.ones((4, 4, 4))
+    >>> coeffs = wavedecn(data, 'db1')
     >>> # Levels:
     >>> len(coeffs)-1
-    3
-    >>> multilevel.waverecn(coeffs, 'db1')
-    array([[[ 1.,  1.,  1.,  1.],
-        [ 1.,  1.,  1.,  1.],
-        [ 1.,  1.,  1.,  1.],
-        [ 1.,  1.,  1.,  1.]],
-
-       [[ 1.,  1.,  1.,  1.],
-        [ 1.,  1.,  1.,  1.],
-        [ 1.,  1.,  1.,  1.],
-        [ 1.,  1.,  1.,  1.]],
-
-       [[ 1.,  1.,  1.,  1.],
-        [ 1.,  1.,  1.,  1.],
-        [ 1.,  1.,  1.,  1.],
-        [ 1.,  1.,  1.,  1.]],
-
-       [[ 1.,  1.,  1.,  1.],
-        [ 1.,  1.,  1.,  1.],
-        [ 1.,  1.,  1.,  1.],
-        [ 1.,  1.,  1.,  1.]]])
+    2
+    >>> rec = waverecn(coeffs, 'db1')
+    >>> np.max(data-rec) < 1e-14
+    True
 
     """
     data = np.asarray(data)
@@ -522,31 +509,16 @@ def waverecn(coeffs, wavelet, mode='symmetric'):
 
     Examples
     --------
-    >>> from pywt import multilevel
-    >>> coeffs = multilevel.wavedecn(np.ones((4, 4, 4)), 'db1')
+    >>> import numpy as np
+    >>> from pywt import wavedecn, waverecn
+    >>> data = np.ones((4, 4, 4))
+    >>> coeffs = wavedecn(data, 'db1')
     >>> # Levels:
     >>> len(coeffs)-1
     2
-    >>> multilevel.waverecn(coeffs, 'db1')
-    array([[[ 1.,  1.,  1.,  1.],
-        [ 1.,  1.,  1.,  1.],
-        [ 1.,  1.,  1.,  1.],
-        [ 1.,  1.,  1.,  1.]],
-
-       [[ 1.,  1.,  1.,  1.],
-        [ 1.,  1.,  1.,  1.],
-        [ 1.,  1.,  1.,  1.],
-        [ 1.,  1.,  1.,  1.]],
-
-       [[ 1.,  1.,  1.,  1.],
-        [ 1.,  1.,  1.,  1.],
-        [ 1.,  1.,  1.,  1.],
-        [ 1.,  1.,  1.,  1.]],
-
-       [[ 1.,  1.,  1.,  1.],
-        [ 1.,  1.,  1.,  1.],
-        [ 1.,  1.,  1.,  1.],
-        [ 1.,  1.,  1.,  1.]]])
+    >>> rec = waverecn(coeffs, 'db1')
+    >>> np.max(data-rec) < 1e-14
+    True
     """
     if len(coeffs) < 1:
         raise ValueError(

--- a/pywt/_thresholding.py
+++ b/pywt/_thresholding.py
@@ -86,6 +86,7 @@ def threshold(data, value, mode='soft', substitute=0):
 
     Examples
     --------
+    >>> import numpy as np
     >>> import pywt
     >>> data = np.linspace(1, 4, 7)
     >>> data

--- a/pywt/data/create_dat.py
+++ b/pywt/data/create_dat.py
@@ -20,13 +20,19 @@ import sys
 import numpy as np
 from scipy.misc import imread
 
-if len(sys.argv) != 3:
-    print(__doc__)
-    exit()
 
-image_fname = sys.argv[1]
-dat_fname = sys.argv[2]
+def main():
+    if len(sys.argv) != 3:
+        print(__doc__)
+        exit()
 
-data = imread(image_fname)
+    image_fname = sys.argv[1]
+    dat_fname = sys.argv[2]
 
-np.savez_compressed(dat_fname, data=data)
+    data = imread(image_fname)
+
+    np.savez_compressed(dat_fname, data=data)
+
+
+if __name__ == "__main__":
+    main()

--- a/pywt/data/create_dat.py
+++ b/pywt/data/create_dat.py
@@ -18,10 +18,11 @@ from __future__ import print_function
 import sys
 
 import numpy as np
-from scipy.misc import imread
 
 
 def main():
+    from scipy.misc import imread
+
     if len(sys.argv) != 3:
         print(__doc__)
         exit()

--- a/pywt/src/_pywt.pyx
+++ b/pywt/src/_pywt.pyx
@@ -245,8 +245,7 @@ def families(int short=True):
     >>> pywt.families()
     ['haar', 'db', 'sym', 'coif', 'bior', 'rbio', 'dmey']
     >>> pywt.families(short=False)
-    ['Haar', 'Daubechies', 'Symlets', 'Coiflets', 'Biorthogonal',
-     'Reverse biorthogonal', 'Discrete Meyer (FIR Approximation)']
+    ['Haar', 'Daubechies', 'Symlets', 'Coiflets', 'Biorthogonal', 'Reverse biorthogonal', 'Discrete Meyer (FIR Approximation)']
 
     """
     if short:
@@ -720,9 +719,9 @@ def dwt(object data, object wavelet, object mode='symmetric', int axis=-1):
     >>> import pywt
     >>> (cA, cD) = pywt.dwt([1, 2, 3, 4, 5, 6], 'db1')
     >>> cA
-    [ 2.12132034  4.94974747  7.77817459]
+    array([ 2.12132034,  4.94974747,  7.77817459])
     >>> cD
-    [-0.70710678 -0.70710678 -0.70710678]
+    array([-0.70710678, -0.70710678, -0.70710678])
 
     """
     if np.iscomplexobj(data):
@@ -1120,11 +1119,11 @@ def upcoef(part, coeffs, wavelet, level=1, take=0):
     >>> data = [1,2,3,4,5,6]
     >>> (cA, cD) = pywt.dwt(data, 'db2', 'smooth')
     >>> pywt.upcoef('a', cA, 'db2') + pywt.upcoef('d', cD, 'db2')
-    [-0.25       -0.4330127   1.          2.          3.          4.          5.
-      6.          1.78589838 -1.03108891]
+    array([-0.25      , -0.4330127 ,  1.        ,  2.        ,  3.        ,
+            4.        ,  5.        ,  6.        ,  1.78589838, -1.03108891])
     >>> n = len(data)
     >>> pywt.upcoef('a', cA, 'db2', take=n) + pywt.upcoef('d', cD, 'db2', take=n)
-    [ 1.  2.  3.  4.  5.  6.]
+    array([ 1.,  2.,  3.,  4.,  5.,  6.])
 
     """
     if np.iscomplexobj(coeffs):


### PR DESCRIPTION
`make doctest` was giving me a large number of doctest failures.  I got 37 on Python 2.7 and 160 on Python 3!

This PR fixes these so they should all pass in both Python 2.6+ or 3.2+.  I get no failures on my machine during testing on Python 2.7 and 3.4.  Many of the previous failures were due to the use of Python 2.x style print statements.  I think the only actual bug was in the number of levels listed in the docstring example for `wavedecn` and `waverecn`.
