### PR TITLE
change version to v0.4.0 for building Python 3.5 wheels

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,9 +7,9 @@ import subprocess
 
 
 MAJOR = 0
-MINOR = 5
+MINOR = 4
 MICRO = 0
-ISRELEASED = False
+ISRELEASED = True
 VERSION = '%d.%d.%d' % (MAJOR, MINOR, MICRO)
 
 


### PR DESCRIPTION
DO NOT MERGE.  just using to build the wheels for pypi