### PR TITLE
fix:  iswt/idwt performance regression

### DIFF
--- a/pywt/_dwt.py
+++ b/pywt/_dwt.py
@@ -230,7 +230,6 @@ def idwt(cA, cD, wavelet, mode='symmetric', axis=-1):
 
     if ndim == 1:
         rec = idwt_single(cA, cD, wavelet, mode)
-        rec = np.asarray(rec, dt)
     else:
         rec = idwt_axis(cA, cD, wavelet, mode, axis=axis)
 

--- a/pywt/_extensions/_dwt.pyx
+++ b/pywt/_extensions/_dwt.pyx
@@ -32,10 +32,10 @@ cpdef dwt_single(data_t[::1] data, Wavelet wavelet, MODE mode):
         cD = np.zeros(output_len, np.float64)
 
         if (c_wt.double_dec_a(&data[0], data.size, wavelet.w,
-                              <double *>cA.data, cA.size, mode) < 0
+                              <double *>cA.data, output_len, mode) < 0
             or
             c_wt.double_dec_d(&data[0], data.size, wavelet.w,
-                              <double *>cD.data, cD.size,
+                              <double *>cD.data, output_len,
                               mode) < 0):
             raise RuntimeError("C dwt failed.")
     elif data_t is np.float32_t:
@@ -43,10 +43,10 @@ cpdef dwt_single(data_t[::1] data, Wavelet wavelet, MODE mode):
         cD = np.zeros(output_len, np.float32)
 
         if (c_wt.float_dec_a(&data[0], data.size, wavelet.w,
-                             <float *>cA.data, cA.size, mode) < 0
+                             <float *>cA.data, output_len, mode) < 0
             or
             c_wt.float_dec_d(&data[0], data.size, wavelet.w,
-                             <float *>cD.data, cD.size, mode) < 0):
+                             <float *>cD.data, output_len, mode) < 0):
             raise RuntimeError("C dwt failed.")
 
     return (cA, cD)
@@ -122,16 +122,16 @@ cpdef idwt_single(np.ndarray cA, np.ndarray cD, Wavelet wavelet, MODE mode):
     # reconstruction of non-null part will be performed
     if cA.dtype == np.float64:
         rec = np.zeros(rec_len, dtype=np.float64)
-        if c_wt.double_idwt(<double *>cA.data, cA.size,
-                            <double *>cD.data, cD.size,
-                            <double *>rec.data, rec.size,
+        if c_wt.double_idwt(<double *>cA.data, input_len,
+                            <double *>cD.data, input_len,
+                            <double *>rec.data, rec_len,
                             wavelet.w, mode) < 0:
             raise RuntimeError("C idwt failed.")
     elif cA.dtype == np.float32:
         rec = np.zeros(rec_len, dtype=np.float32)
-        if c_wt.float_idwt(<float *>cA.data, cA.size,
-                           <float *>cD.data, cD.size,
-                           <float *>rec.data, rec.size,
+        if c_wt.float_idwt(<float *>cA.data, input_len,
+                           <float *>cD.data, input_len,
+                           <float *>rec.data, rec_len,
                            wavelet.w, mode) < 0:
             raise RuntimeError("C idwt failed.")
 

--- a/pywt/_multilevel.py
+++ b/pywt/_multilevel.py
@@ -287,6 +287,8 @@ def iswt(coeffs, wavelet):
 
     # num_levels, equivalent to the decomposition level, n
     num_levels = len(coeffs)
+    if not isinstance(wavelet, Wavelet):
+        wavelet = Wavelet(wavelet)
     for j in range(num_levels, 0, -1):
         step_size = int(pow(2, j-1))
         last_index = step_size
@@ -367,6 +369,8 @@ def iswt2(coeffs, wavelet):
 
     # num_levels, equivalent to the decomposition level, n
     num_levels = len(coeffs)
+    if not isinstance(wavelet, Wavelet):
+        wavelet = Wavelet(wavelet)
     for j in range(num_levels, 0, -1):
         step_size = int(pow(2, j-1))
         last_index = step_size


### PR DESCRIPTION
This is an attempt to address the performance regression in #157

Altogether this gives me an approximately 3-fold speedup relative to current master for the test script provided by @zstomp in #157.  Roughly half the improvement is from the first commit and most of the rest is from the third.

I am not a big fan of the third commit here, so would appreciate if anyone else has a cleaner solution.

apologies to @kwohlfahrt  if you had already started working on this, but perhaps you will have found other areas for improvement that I missed!

probably the most obvious next step to improve perfomance for `iswt` would be moving the loops over to the C/Cython side as was done for `dwtn` and `idwtn` in v0.4.0, but I don't currently have time to work on that.