### PR TITLE
convert transform coefficients to and from a single n-dimensional array

### DIFF
--- a/pywt/_multilevel.py
+++ b/pywt/_multilevel.py
@@ -675,7 +675,7 @@ def coeffs_to_array(coeffs):
         # a_shape and d_shape may differ along odd-sized axes
 
         # TODO: allocate the full coeff_arr outside this loop for efficiency?
-        temp = np.empty(np.asarray(a_shape) + np.asarray(d_shape),
+        temp = np.zeros(np.asarray(a_shape) + np.asarray(d_shape),
                         dtype=coeff_arr.dtype)
         slice_array = [slice(a_shape[i]) for i in range(ndim)]
         temp[slice_array] = coeff_arr

--- a/pywt/_multilevel.py
+++ b/pywt/_multilevel.py
@@ -620,7 +620,7 @@ def _coeffs_wavedec2_to_wavedecn(coeffs):
     for n in range(1, len(coeffs)):
         if not isinstance(coeffs[n], tuple) or len(coeffs[n]) != 3:
             raise ValueError("expected a 3-tuple of detail coefficients")
-        (ad, da, dd) = coeffs[n]
+        (da, ad, dd) = coeffs[n]
         coeffs[n] = dict(ad=ad, da=da, dd=dd)
     return coeffs
 

--- a/pywt/_multilevel.py
+++ b/pywt/_multilevel.py
@@ -624,8 +624,8 @@ def coeffs_to_array(coeffs):
     Then all 2D coefficients will be stacked into a single larger 2D array
     as follows:
 
-                                    <-------- d_shapes[1][0] ------->
-    <--a0_shape[0]-><-d_shapes[0][0]>
+                                    <-------- d_shapes[1][1] ------->
+    <--a0_shape[1]-><-d_shapes[0][1]>
     +---------------+---------------+-------------------------------+
     |               |               |                               |
     |     c[0]      |  c[1]['da']   |                               |
@@ -648,6 +648,11 @@ def coeffs_to_array(coeffs):
     --------
     array_to_coeffs : the inverse of coeffs_to_array
 
+    Examples
+    --------
+    cam = pywt.data.camera()
+    coeffs = pywt.wavedecn(cam, wavelet='db2', level=3)
+    arr, a0_shape, d_shapes = pywt.coeffs_to_array(coeffs)
     """
     if not isinstance(coeffs, list) or len(coeffs) == 0:
         raise ValueError("input must be a list of coefficients from wavedecn")
@@ -725,8 +730,8 @@ def array_to_coeffs(arr, a0_shape, d_shapes):
     A single large array containing all coefficients will have subsets stored,
     into a `waverecn` list, c, as indicated below:
 
-                                    <-------- d_shapes[1][0] ------->
-    <--a0_shape[0]-><-d_shapes[0][0]>
+                                    <-------- d_shapes[1][1] ------->
+    <--a0_shape[1]-><-d_shapes[0][1]>
     +---------------+---------------+-------------------------------+
     |               |               |                               |
     |     c[0]      |  c[1]['da']   |                               |
@@ -744,6 +749,15 @@ def array_to_coeffs(arr, a0_shape, d_shapes):
     |                               |                               |
     |                               |                               |
     --------------------------------+-------------------------------+
+
+    Examples
+    --------
+    cam = pywt.data.camera()
+    coeffs = pywt.wavedecn(cam, wavelet='db2', level=3)
+    arr, a0_shape, d_shapes = pywt.coeffs_to_array(coeffs)
+    coeffs_from_arr = pywt.array_to_coeffs(arr, a0_shape, d_shapes)
+    cam_recon = pywt.waverecn(coeffs_from_arr, wavelet='db2')
+    assert_array_almost_equal(cam, cam_recon)
 
     """
     arr = np.asarray(arr)

--- a/pywt/_multilevel.py
+++ b/pywt/_multilevel.py
@@ -694,6 +694,9 @@ def coeffs_to_array(coeffs):
         else:
             raise ValueError("invalid coefficient list")
     # initialize with the approximation coefficients.
+    if coeffs[0] is None:
+        raise ValueError("coeffs_to_array does not support missing "
+                         "coefficients.")
     coeff_arr = coeffs[0]
     coeff_slices = []
     coeff_slices.append([slice(s) for s in coeff_arr.shape])
@@ -721,6 +724,9 @@ def coeffs_to_array(coeffs):
         temp[slice_array] = coeff_arr
         for key in coeff_dict.keys():
             d = coeff_dict[key]
+            if d is None:
+                raise ValueError("coeffs_to_array does not support missing "
+                                 "coefficients.")
             slice_array = [slice(None), ] * ndim
             for i, let in enumerate(key):
                 if let == 'a':

--- a/pywt/_multilevel.py
+++ b/pywt/_multilevel.py
@@ -11,7 +11,6 @@ and Inverse Discrete Wavelet Transform.
 from __future__ import division, print_function, absolute_import
 
 from copy import copy
-from itertools import product
 import numpy as np
 
 from ._extensions._pywt import Wavelet

--- a/pywt/_multilevel.py
+++ b/pywt/_multilevel.py
@@ -22,7 +22,7 @@ try:
     # full was added in numpy 1.8
     from numpy import full
 except ImportError:
-    def full(value, shape, dtype):
+    def full(shape, value, dtype):
         return value * np.ones(shape, dtype)
 
 __all__ = ['wavedec', 'waverec', 'wavedec2', 'waverec2', 'wavedecn',

--- a/pywt/_multilevel.py
+++ b/pywt/_multilevel.py
@@ -18,6 +18,13 @@ from ._extensions._dwt import dwt_max_level
 from ._dwt import dwt, idwt
 from ._multidim import dwt2, idwt2, dwtn, idwtn, _fix_coeffs
 
+try:
+    # full was added in numpy 1.8
+    from numpy import full
+except ImportError:
+    def full(value, shape, dtype):
+        return value * np.ones(shape, dtype)
+
 __all__ = ['wavedec', 'waverec', 'wavedec2', 'waverec2', 'wavedecn',
            'waverecn', 'iswt', 'iswt2', 'coeffs_to_array', 'array_to_coeffs']
 
@@ -731,7 +738,8 @@ def coeffs_to_array(coeffs, padding=0):
             raise ValueError("array coefficients cannot be tightly packed")
         coeff_arr = np.empty(arr_shape, dtype=a_coeffs.dtype)
     else:
-        coeff_arr = np.full(arr_shape, padding, dtype=a_coeffs.dtype)
+        coeff_arr = full(arr_shape, padding, dtype=a_coeffs.dtype)
+
     a_slices = [slice(s) for s in a_shape]
     coeff_arr[a_slices] = a_coeffs
 
@@ -761,7 +769,7 @@ def coeffs_to_array(coeffs, padding=0):
                     raise ValueError("unexpected letter: {}".format(let))
             coeff_arr[slice_array] = d
             coeff_slices[-1][key] = slice_array
-        a_shape = [a_shape[d] + d_shape[d] for d in range(ndim)]
+        a_shape = [a_shape[n] + d_shape[n] for n in range(ndim)]
     return coeff_arr, coeff_slices
 
 

--- a/pywt/tests/test_multilevel.py
+++ b/pywt/tests/test_multilevel.py
@@ -396,7 +396,6 @@ def test_coeffs_to_array():
     assert_raises(ValueError, pywt.coeffs_to_array, [a_coeffs[0], ] * 2)
 
 
-@dec.slow
 def test_wavedecn_coeff_reshape_even():
     # verify round trip is correct:
     #   wavedecn - >coeffs_to_array-> array_to_coeffs -> waverecn
@@ -409,13 +408,12 @@ def test_wavedecn_coeff_reshape_even():
             if maxlevel == 0:
                 continue
             coeffs = pywt.wavedecn(x1, w, mode=mode)
-            coeff_arr, a_shape, d_shapes = pywt.coeffs_to_array(coeffs)
-            coeffs2 = pywt.array_to_coeffs(coeff_arr, a_shape, d_shapes)
+            coeff_arr, coeff_slices = pywt.coeffs_to_array(coeffs)
+            coeffs2 = pywt.array_to_coeffs(coeff_arr, coeff_slices)
             x1r = pywt.waverecn(coeffs2, w, mode=mode)
             assert_allclose(x1, x1r, rtol=1e-4, atol=1e-4)
 
 
-@dec.slow
 def test_waverecn_coeff_reshape_odd():
     # verify round trip is correct:
     #   wavedecn - >coeffs_to_array-> array_to_coeffs -> waverecn
@@ -428,8 +426,8 @@ def test_waverecn_coeff_reshape_odd():
             if maxlevel == 0:
                 continue
             coeffs = pywt.wavedecn(x1, w, mode=mode)
-            coeff_arr, a_shape, d_shapes = pywt.coeffs_to_array(coeffs)
-            coeffs2 = pywt.array_to_coeffs(coeff_arr, a_shape, d_shapes)
+            coeff_arr, coeff_slices = pywt.coeffs_to_array(coeffs)
+            coeffs2 = pywt.array_to_coeffs(coeff_arr, coeff_slices)
             x1r = pywt.waverecn(coeffs2, w, mode=mode)
             # truncate reconstructed values to original shape
             x1r = x1r[[slice(s) for s in x1.shape]]

--- a/pywt/tests/test_multilevel.py
+++ b/pywt/tests/test_multilevel.py
@@ -397,6 +397,10 @@ def test_coeffs_to_array():
     # invalid second element:  tuple as in wavedec2, but not a 3-tuple
     assert_raises(ValueError, pywt.coeffs_to_array, [a_coeffs[0],
                                                      (a_coeffs[0], )])
+    # coefficients as None is not supported
+    assert_raises(ValueError, pywt.coeffs_to_array, [None, ])
+    assert_raises(ValueError, pywt.coeffs_to_array, [a_coeffs,
+                                                     (None, None, None)])
 
 
 def test_wavedecn_coeff_reshape_even():

--- a/pywt/tests/test_multilevel.py
+++ b/pywt/tests/test_multilevel.py
@@ -406,19 +406,27 @@ def test_coeffs_to_array():
 def test_wavedecn_coeff_reshape_even():
     # verify round trip is correct:
     #   wavedecn - >coeffs_to_array-> array_to_coeffs -> waverecn
+    # This is done for wavedec{1, 2, n}
     rng = np.random.RandomState(1234)
-    x1 = rng.randn(48, 32, 16)
-    for mode in pywt.Modes.modes:
-        for wave in wavelist:
-            w = pywt.Wavelet(wave)
-            maxlevel = pywt.dwt_max_level(np.min(x1.shape), w.dec_len)
-            if maxlevel == 0:
-                continue
-            coeffs = pywt.wavedecn(x1, w, mode=mode)
-            coeff_arr, coeff_slices = pywt.coeffs_to_array(coeffs)
-            coeffs2 = pywt.array_to_coeffs(coeff_arr, coeff_slices)
-            x1r = pywt.waverecn(coeffs2, w, mode=mode)
-            assert_allclose(x1, x1r, rtol=1e-4, atol=1e-4)
+    params = {'wavedec': {'d': 1, 'dec': pywt.wavedecn, 'rec': pywt.waverecn},
+              'wavedec2': {'d': 2, 'dec':pywt.wavedec2, 'rec': pywt.waverec2},
+              'wavedecn': {'d': 3, 'dec': pywt.wavedecn, 'rec': pywt.waverecn}}
+    N = 28
+    for f in params:
+        x1 = rng.randn(*([N] * params[f]['d']))
+        for mode in pywt.Modes.modes:
+            for wave in wavelist:
+                w = pywt.Wavelet(wave)
+                maxlevel = pywt.dwt_max_level(np.min(x1.shape), w.dec_len)
+                if maxlevel == 0:
+                    continue
+
+                coeffs = params[f]['dec'](x1, w, mode=mode)
+                coeff_arr, coeff_slices = pywt.coeffs_to_array(coeffs)
+                coeffs2 = pywt.array_to_coeffs(coeff_arr, coeff_slices)
+                x1r = params[f]['rec'](coeffs2, w, mode=mode)
+
+                assert_allclose(x1, x1r, rtol=1e-4, atol=1e-4)
 
 
 def test_wavedec_wavedec2_coeff_reshape():

--- a/pywt/tests/test_multilevel.py
+++ b/pywt/tests/test_multilevel.py
@@ -422,8 +422,9 @@ def test_wavedecn_coeff_reshape_even():
 
 
 def test_wavedec_wavedec2_coeff_reshape():
-    x1d = np.ones(16)
-    x2d = np.ones((16, 16))
+    rng = np.random.RandomState(1234)
+    x1d = rng.randn(16)
+    x2d = rng.randn(16, 16)
     mode = 'symmetric'
     w = pywt.Wavelet('db1')
     test_cases = [('wavedec', pywt.wavedec, pywt.waverec, x1d),

--- a/pywt/tests/test_multilevel.py
+++ b/pywt/tests/test_multilevel.py
@@ -408,8 +408,8 @@ def test_wavedecn_coeff_reshape_even():
     #   wavedecn - >coeffs_to_array-> array_to_coeffs -> waverecn
     # This is done for wavedec{1, 2, n}
     rng = np.random.RandomState(1234)
-    params = {'wavedec': {'d': 1, 'dec': pywt.wavedecn, 'rec': pywt.waverecn},
-              'wavedec2': {'d': 2, 'dec':pywt.wavedec2, 'rec': pywt.waverec2},
+    params = {'wavedec': {'d': 1, 'dec': pywt.wavedec, 'rec': pywt.waverec},
+              'wavedec2': {'d': 2, 'dec': pywt.wavedec2, 'rec': pywt.waverec2},
               'wavedecn': {'d': 3, 'dec': pywt.wavedecn, 'rec': pywt.waverecn}}
     N = 28
     for f in params:
@@ -423,35 +423,11 @@ def test_wavedecn_coeff_reshape_even():
 
                 coeffs = params[f]['dec'](x1, w, mode=mode)
                 coeff_arr, coeff_slices = pywt.coeffs_to_array(coeffs)
-                coeffs2 = pywt.array_to_coeffs(coeff_arr, coeff_slices)
+                coeffs2 = pywt.array_to_coeffs(coeff_arr, coeff_slices,
+                                               output_format=f)
                 x1r = params[f]['rec'](coeffs2, w, mode=mode)
 
                 assert_allclose(x1, x1r, rtol=1e-4, atol=1e-4)
-
-
-def test_wavedec_wavedec2_coeff_reshape():
-    rng = np.random.RandomState(1234)
-    x1d = rng.randn(16)
-    x2d = rng.randn(16, 16)
-    mode = 'symmetric'
-    w = pywt.Wavelet('db1')
-    test_cases = [('wavedec', pywt.wavedec, pywt.waverec, x1d),
-                  ('wavedec2', pywt.wavedec2, pywt.waverec2, x2d)]
-    for (output_format, dec_fun, rec_fun, data) in test_cases:
-        coeffs = dec_fun(data, w, mode=mode)
-        coeff_arr, coeff_slices = pywt.coeffs_to_array(coeffs)
-
-        # make sure coeffs weren't modified in-place during conversion
-        if output_format == 'wavedec':
-            assert_(isinstance(coeffs[1], np.ndarray))
-        elif output_format == 'wavedec2':
-            assert_(isinstance(coeffs[1], tuple))
-
-        # test reconstruction
-        coeffs2 = pywt.array_to_coeffs(coeff_arr, coeff_slices,
-                                       output_format=output_format)
-        data_r = rec_fun(coeffs2, w, mode=mode)
-        assert_allclose(data, data_r, rtol=1e-4, atol=1e-4)
 
 
 def test_waverecn_coeff_reshape_odd():


### PR DESCRIPTION
This is an attempt to provide a feature requested in #166 where it was desired to have a utility to concatenate a set of multilevel wavelet coefficients into a single array as is commonly used for signal and image processing algorithms.

The proposed functions are compatible with `wavedecn` and `waverecn`.  Unfortunately `wavedec` and `wavedec2` don't have quite the same output format, but the function could potentially be modified to work for those as well (although I am not sure how you would know which coefficient format to transform back to when going in the reverse direction).

2D example:
```python
import pywt
from matplotlib import pyplot as plt

cam = pywt.data.camera()
coeffs = pywt.wavedecn(cam, wavelet='db2', level=2)
arr, a0_shape, d_shapes = pywt.coeffs_to_array(coeffs)

plt.figure();
plt.imshow(arr, interpolation='nearest', cmap=plt.cm.gray)

# can reform to a format compatible with waverecn
coeffs_reformed = pywt.array_to_coeffs(arr, a0_shape, d_shapes)
cam_recon = pywt.waverecn(coeffs_reformed, wavelet='db2')
```
![coeffs](https://cloud.githubusercontent.com/assets/6528957/13513791/81e1d2bc-e171-11e5-8d11-64221eff7b2b.png)

As far as I can tell, this seems to be working for all wavelets and modes and for odd or even sized inputs (verified via round-trip tests).  I don't particularly like needing to pass around the arrays of coefficient shapes (`a0_shape`, `d_shapes`), but I couldn't see how else to get the sizes right in the general case.