### PR TITLE
Always install new pip on Appveyor

### DIFF
--- a/util/appveyor/install.ps1
+++ b/util/appveyor/install.ps1
@@ -157,15 +157,11 @@ function RunCommand ($command, $command_args) {
 function InstallPip ($python_home) {
     $pip_path = $python_home + "\Scripts\pip.exe"
     $python_path = $python_home + "\python.exe"
-    if (-not(Test-Path $pip_path)) {
-        Write-Host "Installing pip..."
-        $webclient = New-Object System.Net.WebClient
-        $webclient.DownloadFile($GET_PIP_URL, $GET_PIP_PATH)
-        Write-Host "Executing:" $python_path $GET_PIP_PATH
-        & $python_path $GET_PIP_PATH
-    } else {
-        Write-Host "pip already installed."
-    }
+    Write-Host "Installing pip..."
+    $webclient = New-Object System.Net.WebClient
+    $webclient.DownloadFile($GET_PIP_URL, $GET_PIP_PATH)
+    Write-Host "Executing:" $python_path $GET_PIP_PATH
+    & $python_path $GET_PIP_PATH
 }
 
 


### PR DESCRIPTION
Builds currently failing, rgommers suggested this might be the issue.

This simply doesn't check for existing pip and always installs a new one.

Merging immediately to get tests working. Passes on [my branch](https://ci.appveyor.com/project/kwohlfahrt/pywt/build/1.0.107)