### PR TITLE
use Index_t instead of index_t

### DIFF
--- a/demo/_dwt_decompose.c
+++ b/demo/_dwt_decompose.c
@@ -19,7 +19,7 @@ int main(){
     int i;
     float input[] = {1,2,3,4,5,6,7,8,9};
     float *cA, *cD;
-    Index_t input_len, output_len;
+    pywt_index_t input_len, output_len;
 
     input_len = sizeof input / sizeof input[0];
     output_len = dwt_buffer_length(input_len, w->dec_len, mode);

--- a/demo/_dwt_decompose.c
+++ b/demo/_dwt_decompose.c
@@ -19,7 +19,7 @@ int main(){
     int i;
     float input[] = {1,2,3,4,5,6,7,8,9};
     float *cA, *cD;
-    index_t input_len, output_len;
+    Index_t input_len, output_len;
 
     input_len = sizeof input / sizeof input[0];
     output_len = dwt_buffer_length(input_len, w->dec_len, mode);

--- a/pywt/_extensions/_dwt.pyx
+++ b/pywt/_extensions/_dwt.pyx
@@ -1,5 +1,5 @@
 cimport common, c_wt
-from common cimport Index_t, MODE
+from common cimport pywt_index_t, MODE
 from ._pywt cimport _check_dtype
 
 cimport numpy as np
@@ -67,11 +67,11 @@ cpdef dwt_axis(np.ndarray data, Wavelet wavelet, MODE mode, unsigned int axis=0)
     cD = np.empty(output_shape, data.dtype)
 
     data_info.ndim = data.ndim
-    data_info.strides = <Index_t *> data.strides
+    data_info.strides = <pywt_index_t *> data.strides
     data_info.shape = <size_t *> data.shape
 
     output_info.ndim = cA.ndim
-    output_info.strides = <Index_t *> cA.strides
+    output_info.strides = <pywt_index_t *> cA.strides
     output_info.shape = <size_t *> cA.shape
 
     if data.dtype == np.float64:
@@ -151,7 +151,7 @@ cpdef idwt_axis(np.ndarray coefs_a, np.ndarray coefs_d,
         else:
             coefs_a = coefs_a.astype(_check_dtype(coefs_a), copy=False)
         a_info.ndim = coefs_a.ndim
-        a_info.strides = <Index_t *> coefs_a.strides
+        a_info.strides = <pywt_index_t *> coefs_a.strides
         a_info.shape = <size_t *> coefs_a.shape
     if coefs_d is not None:
         if coefs_a is not None and coefs_a.dtype.itemsize > coefs_d.dtype.itemsize:
@@ -159,7 +159,7 @@ cpdef idwt_axis(np.ndarray coefs_a, np.ndarray coefs_d,
         else:
             coefs_d = coefs_d.astype(_check_dtype(coefs_d), copy=False)
         d_info.ndim = coefs_d.ndim
-        d_info.strides = <Index_t *> coefs_d.strides
+        d_info.strides = <pywt_index_t *> coefs_d.strides
         d_info.shape = <size_t *> coefs_d.shape
 
     if coefs_a is not None:
@@ -178,7 +178,7 @@ cpdef idwt_axis(np.ndarray coefs_a, np.ndarray coefs_d,
     output = np.empty(output_shape, output_dtype)
 
     output_info.ndim = output.ndim
-    output_info.strides = <Index_t *> output.strides
+    output_info.strides = <pywt_index_t *> output.strides
     output_info.shape = <size_t *> output.shape
 
     if output.dtype == np.float64:

--- a/pywt/_extensions/_dwt.pyx
+++ b/pywt/_extensions/_dwt.pyx
@@ -1,5 +1,5 @@
 cimport common, c_wt
-from common cimport index_t, MODE
+from common cimport Index_t, MODE
 from ._pywt cimport _check_dtype
 
 cimport numpy as np
@@ -67,11 +67,11 @@ cpdef dwt_axis(np.ndarray data, Wavelet wavelet, MODE mode, unsigned int axis=0)
     cD = np.empty(output_shape, data.dtype)
 
     data_info.ndim = data.ndim
-    data_info.strides = <index_t *> data.strides
+    data_info.strides = <Index_t *> data.strides
     data_info.shape = <size_t *> data.shape
 
     output_info.ndim = cA.ndim
-    output_info.strides = <index_t *> cA.strides
+    output_info.strides = <Index_t *> cA.strides
     output_info.shape = <size_t *> cA.shape
 
     if data.dtype == np.float64:
@@ -151,7 +151,7 @@ cpdef idwt_axis(np.ndarray coefs_a, np.ndarray coefs_d,
         else:
             coefs_a = coefs_a.astype(_check_dtype(coefs_a), copy=False)
         a_info.ndim = coefs_a.ndim
-        a_info.strides = <index_t *> coefs_a.strides
+        a_info.strides = <Index_t *> coefs_a.strides
         a_info.shape = <size_t *> coefs_a.shape
     if coefs_d is not None:
         if coefs_a is not None and coefs_a.dtype.itemsize > coefs_d.dtype.itemsize:
@@ -159,7 +159,7 @@ cpdef idwt_axis(np.ndarray coefs_a, np.ndarray coefs_d,
         else:
             coefs_d = coefs_d.astype(_check_dtype(coefs_d), copy=False)
         d_info.ndim = coefs_d.ndim
-        d_info.strides = <index_t *> coefs_d.strides
+        d_info.strides = <Index_t *> coefs_d.strides
         d_info.shape = <size_t *> coefs_d.shape
 
     if coefs_a is not None:
@@ -178,7 +178,7 @@ cpdef idwt_axis(np.ndarray coefs_a, np.ndarray coefs_d,
     output = np.empty(output_shape, output_dtype)
 
     output_info.ndim = output.ndim
-    output_info.strides = <index_t *> output.strides
+    output_info.strides = <Index_t *> output.strides
     output_info.shape = <size_t *> output.shape
 
     if output.dtype == np.float64:

--- a/pywt/_extensions/_pywt.pxd
+++ b/pywt/_extensions/_pywt.pxd
@@ -1,7 +1,7 @@
 cimport wavelet
 cimport numpy as np
 
-ctypedef Py_ssize_t index_t
+ctypedef Py_ssize_t Index_t
 
 ctypedef fused data_t:
     np.float32_t

--- a/pywt/_extensions/_pywt.pxd
+++ b/pywt/_extensions/_pywt.pxd
@@ -1,7 +1,7 @@
 cimport wavelet
 cimport numpy as np
 
-ctypedef Py_ssize_t Index_t
+ctypedef Py_ssize_t pywt_index_t
 
 ctypedef fused data_t:
     np.float32_t

--- a/pywt/_extensions/_pywt.pyx
+++ b/pywt/_extensions/_pywt.pyx
@@ -260,7 +260,7 @@ cdef public class Wavelet [type WaveletType, object WaveletObject]:
     def __cinit__(self, name=u"", object filter_bank=None):
         cdef object family_code, family_number
         cdef object filters
-        cdef index_t filter_length
+        cdef Index_t filter_length
         cdef object dec_lo, dec_hi, rec_lo, rec_hi
 
         if not name and filter_bank is None:
@@ -480,10 +480,10 @@ cdef public class Wavelet [type WaveletType, object WaveletObject]:
         >>> phi_d, psi_d, phi_r, psi_r, x = wavelet.wavefun(level=5)
 
         """
-        cdef index_t filter_length "filter_length"
-        cdef index_t right_extent_length "right_extent_length"
-        cdef index_t output_length "output_length"
-        cdef index_t keep_length "keep_length"
+        cdef Index_t filter_length "filter_length"
+        cdef Index_t right_extent_length "right_extent_length"
+        cdef Index_t output_length "output_length"
+        cdef Index_t keep_length "keep_length"
         cdef np.float64_t n, n_mul
         cdef np.float64_t[::1] n_arr = <np.float64_t[:1]> &n,
         cdef np.float64_t[::1] n_mul_arr = <np.float64_t[:1]> &n_mul
@@ -497,7 +497,7 @@ cdef public class Wavelet [type WaveletType, object WaveletObject]:
 
         if self.w.orthogonal:
             filter_length = self.w.dec_len
-            output_length = <index_t> ((filter_length-1) * p + 1)
+            output_length = <Index_t> ((filter_length-1) * p + 1)
             keep_length = get_keep_length(output_length, level, filter_length)
             output_length = fix_output_length(output_length, keep_length)
 
@@ -522,7 +522,7 @@ cdef public class Wavelet [type WaveletType, object WaveletObject]:
             other = Wavelet(filter_bank=self.inverse_filter_bank)
 
             filter_length  = other.w.dec_len
-            output_length = <index_t> ((filter_length-1) * p)
+            output_length = <Index_t> ((filter_length-1) * p)
             keep_length = get_keep_length(output_length, level, filter_length)
             output_length = fix_output_length(output_length, keep_length)
             right_extent_length = get_right_extent_length(output_length, keep_length)
@@ -536,7 +536,7 @@ cdef public class Wavelet [type WaveletType, object WaveletObject]:
                                      np.zeros(right_extent_length)))
 
             filter_length = self.w.dec_len
-            output_length = <index_t> ((filter_length-1) * p)
+            output_length = <Index_t> ((filter_length-1) * p)
             keep_length = get_keep_length(output_length, level, filter_length)
             output_length = fix_output_length(output_length, keep_length)
             right_extent_length = get_right_extent_length(output_length, keep_length)
@@ -574,10 +574,10 @@ cdef public class Wavelet [type WaveletType, object WaveletObject]:
                            filter_bank=self.filter_bank)
 
 
-cdef index_t get_keep_length(index_t output_length,
-                             int level, index_t filter_length):
-    cdef index_t lplus "lplus"
-    cdef index_t keep_length "keep_length"
+cdef Index_t get_keep_length(Index_t output_length,
+                             int level, Index_t filter_length):
+    cdef Index_t lplus "lplus"
+    cdef Index_t keep_length "keep_length"
     cdef int i "i"
     lplus = filter_length - 2
     keep_length = 1
@@ -585,12 +585,12 @@ cdef index_t get_keep_length(index_t output_length,
         keep_length = 2*keep_length+lplus
     return keep_length
 
-cdef index_t fix_output_length(index_t output_length, index_t keep_length):
+cdef Index_t fix_output_length(Index_t output_length, Index_t keep_length):
     if output_length-keep_length-2 < 0:
         output_length = keep_length+2
     return output_length
 
-cdef index_t get_right_extent_length(index_t output_length, index_t keep_length):
+cdef Index_t get_right_extent_length(Index_t output_length, Index_t keep_length):
     return output_length - keep_length - 1
 
 
@@ -629,8 +629,8 @@ def keep(arr, keep_length):
 
 # Some utility functions
 
-cdef object float64_array_to_list(double* data, index_t n):
-    cdef index_t i
+cdef object float64_array_to_list(double* data, Index_t n):
+    cdef Index_t i
     cdef object app
     cdef object ret
     ret = []
@@ -641,7 +641,7 @@ cdef object float64_array_to_list(double* data, index_t n):
 
 
 cdef void copy_object_to_float64_array(source, double* dest) except *:
-    cdef index_t i
+    cdef Index_t i
     cdef double x
     i = 0
     for x in source:
@@ -650,7 +650,7 @@ cdef void copy_object_to_float64_array(source, double* dest) except *:
 
 
 cdef void copy_object_to_float32_array(source, float* dest) except *:
-    cdef index_t i
+    cdef Index_t i
     cdef float x
     i = 0
     for x in source:

--- a/pywt/_extensions/_pywt.pyx
+++ b/pywt/_extensions/_pywt.pyx
@@ -260,7 +260,7 @@ cdef public class Wavelet [type WaveletType, object WaveletObject]:
     def __cinit__(self, name=u"", object filter_bank=None):
         cdef object family_code, family_number
         cdef object filters
-        cdef Index_t filter_length
+        cdef pywt_index_t filter_length
         cdef object dec_lo, dec_hi, rec_lo, rec_hi
 
         if not name and filter_bank is None:
@@ -480,10 +480,10 @@ cdef public class Wavelet [type WaveletType, object WaveletObject]:
         >>> phi_d, psi_d, phi_r, psi_r, x = wavelet.wavefun(level=5)
 
         """
-        cdef Index_t filter_length "filter_length"
-        cdef Index_t right_extent_length "right_extent_length"
-        cdef Index_t output_length "output_length"
-        cdef Index_t keep_length "keep_length"
+        cdef pywt_index_t filter_length "filter_length"
+        cdef pywt_index_t right_extent_length "right_extent_length"
+        cdef pywt_index_t output_length "output_length"
+        cdef pywt_index_t keep_length "keep_length"
         cdef np.float64_t n, n_mul
         cdef np.float64_t[::1] n_arr = <np.float64_t[:1]> &n,
         cdef np.float64_t[::1] n_mul_arr = <np.float64_t[:1]> &n_mul
@@ -497,7 +497,7 @@ cdef public class Wavelet [type WaveletType, object WaveletObject]:
 
         if self.w.orthogonal:
             filter_length = self.w.dec_len
-            output_length = <Index_t> ((filter_length-1) * p + 1)
+            output_length = <pywt_index_t> ((filter_length-1) * p + 1)
             keep_length = get_keep_length(output_length, level, filter_length)
             output_length = fix_output_length(output_length, keep_length)
 
@@ -522,7 +522,7 @@ cdef public class Wavelet [type WaveletType, object WaveletObject]:
             other = Wavelet(filter_bank=self.inverse_filter_bank)
 
             filter_length  = other.w.dec_len
-            output_length = <Index_t> ((filter_length-1) * p)
+            output_length = <pywt_index_t> ((filter_length-1) * p)
             keep_length = get_keep_length(output_length, level, filter_length)
             output_length = fix_output_length(output_length, keep_length)
             right_extent_length = get_right_extent_length(output_length, keep_length)
@@ -536,7 +536,7 @@ cdef public class Wavelet [type WaveletType, object WaveletObject]:
                                      np.zeros(right_extent_length)))
 
             filter_length = self.w.dec_len
-            output_length = <Index_t> ((filter_length-1) * p)
+            output_length = <pywt_index_t> ((filter_length-1) * p)
             keep_length = get_keep_length(output_length, level, filter_length)
             output_length = fix_output_length(output_length, keep_length)
             right_extent_length = get_right_extent_length(output_length, keep_length)
@@ -574,10 +574,10 @@ cdef public class Wavelet [type WaveletType, object WaveletObject]:
                            filter_bank=self.filter_bank)
 
 
-cdef Index_t get_keep_length(Index_t output_length,
-                             int level, Index_t filter_length):
-    cdef Index_t lplus "lplus"
-    cdef Index_t keep_length "keep_length"
+cdef pywt_index_t get_keep_length(pywt_index_t output_length,
+                             int level, pywt_index_t filter_length):
+    cdef pywt_index_t lplus "lplus"
+    cdef pywt_index_t keep_length "keep_length"
     cdef int i "i"
     lplus = filter_length - 2
     keep_length = 1
@@ -585,12 +585,12 @@ cdef Index_t get_keep_length(Index_t output_length,
         keep_length = 2*keep_length+lplus
     return keep_length
 
-cdef Index_t fix_output_length(Index_t output_length, Index_t keep_length):
+cdef pywt_index_t fix_output_length(pywt_index_t output_length, pywt_index_t keep_length):
     if output_length-keep_length-2 < 0:
         output_length = keep_length+2
     return output_length
 
-cdef Index_t get_right_extent_length(Index_t output_length, Index_t keep_length):
+cdef pywt_index_t get_right_extent_length(pywt_index_t output_length, pywt_index_t keep_length):
     return output_length - keep_length - 1
 
 
@@ -629,8 +629,8 @@ def keep(arr, keep_length):
 
 # Some utility functions
 
-cdef object float64_array_to_list(double* data, Index_t n):
-    cdef Index_t i
+cdef object float64_array_to_list(double* data, pywt_index_t n):
+    cdef pywt_index_t i
     cdef object app
     cdef object ret
     ret = []
@@ -641,7 +641,7 @@ cdef object float64_array_to_list(double* data, Index_t n):
 
 
 cdef void copy_object_to_float64_array(source, double* dest) except *:
-    cdef Index_t i
+    cdef pywt_index_t i
     cdef double x
     i = 0
     for x in source:
@@ -650,7 +650,7 @@ cdef void copy_object_to_float64_array(source, double* dest) except *:
 
 
 cdef void copy_object_to_float32_array(source, float* dest) except *:
-    cdef Index_t i
+    cdef pywt_index_t i
     cdef float x
     i = 0
     for x in source:

--- a/pywt/_extensions/c/common.h
+++ b/pywt/_extensions/c/common.h
@@ -23,6 +23,7 @@
         #include "Python.h"
     #endif
 
+    /* on Solaris/SmartOS system, index_t is used in sys/types.h, so use pytw_index_t */
     typedef Py_ssize_t pywt_index_t;
 
     /* using Python's memory manager */

--- a/pywt/_extensions/c/common.h
+++ b/pywt/_extensions/c/common.h
@@ -23,14 +23,14 @@
         #include "Python.h"
     #endif
 
-    typedef Py_ssize_t index_t;
+    typedef Py_ssize_t Index_t;
 
     /* using Python's memory manager */
     #define wtmalloc(size)      PyMem_Malloc(size)
     #define wtfree(ptr)         PyMem_Free(ptr)
     void *wtcalloc(size_t, size_t);
 #else
-    typedef int index_t;
+    typedef int Index_t;
     /* standard c memory management */
     #define wtmalloc(size)      malloc(size)
     #define wtfree(ptr)         free(ptr)
@@ -43,7 +43,7 @@
 
 typedef struct {
     size_t * shape;
-    index_t * strides;
+    Index_t * strides;
     size_t ndim;
 } ArrayInfo;
 

--- a/pywt/_extensions/c/common.h
+++ b/pywt/_extensions/c/common.h
@@ -23,14 +23,14 @@
         #include "Python.h"
     #endif
 
-    typedef Py_ssize_t Index_t;
+    typedef Py_ssize_t pywt_index_t;
 
     /* using Python's memory manager */
     #define wtmalloc(size)      PyMem_Malloc(size)
     #define wtfree(ptr)         PyMem_Free(ptr)
     void *wtcalloc(size_t, size_t);
 #else
-    typedef int Index_t;
+    typedef int pywt_index_t;
     /* standard c memory management */
     #define wtmalloc(size)      malloc(size)
     #define wtfree(ptr)         free(ptr)
@@ -43,7 +43,7 @@
 
 typedef struct {
     size_t * shape;
-    Index_t * strides;
+    pywt_index_t * strides;
     size_t ndim;
 } ArrayInfo;
 

--- a/pywt/_extensions/c/wavelets.h
+++ b/pywt/_extensions/c/wavelets.h
@@ -31,7 +31,7 @@ typedef struct {
     /* Wavelet properties */
     int vanishing_moments_psi;
     int vanishing_moments_phi;
-    index_t support_width;
+    Index_t support_width;
 
     SYMMETRY symmetry;
 

--- a/pywt/_extensions/c/wavelets.h
+++ b/pywt/_extensions/c/wavelets.h
@@ -31,7 +31,7 @@ typedef struct {
     /* Wavelet properties */
     int vanishing_moments_psi;
     int vanishing_moments_phi;
-    Index_t support_width;
+    pywt_index_t support_width;
 
     SYMMETRY symmetry;
 

--- a/pywt/_extensions/c/wt.template.c
+++ b/pywt/_extensions/c/wt.template.c
@@ -400,12 +400,12 @@ int CAT(TYPE, _idwt)(const TYPE * const restrict coeffs_a, const size_t coeffs_a
 }
 
 /* basic SWT step (TODO: optimize) */
-int CAT(TYPE, _swt_)(TYPE input[], Index_t input_len,
-                     const TYPE filter[], Index_t filter_len,
-                     TYPE output[], Index_t output_len, int level){
+int CAT(TYPE, _swt_)(TYPE input[], pywt_index_t input_len,
+                     const TYPE filter[], pywt_index_t filter_len,
+                     TYPE output[], pywt_index_t output_len, int level){
 
     TYPE * e_filter;
-    Index_t i, e_filter_len;
+    pywt_index_t i, e_filter_len;
     int ret;
 
     if(level < 1)
@@ -446,8 +446,8 @@ int CAT(TYPE, _swt_)(TYPE input[], Index_t input_len,
  * Approximation at specified level
  * input - approximation coeffs from upper level or signal if level == 1
  */
-int CAT(TYPE, _swt_a)(TYPE input[], Index_t input_len, Wavelet* wavelet,
-                      TYPE output[], Index_t output_len, int level){
+int CAT(TYPE, _swt_a)(TYPE input[], pywt_index_t input_len, Wavelet* wavelet,
+                      TYPE output[], pywt_index_t output_len, int level){
     return CAT(TYPE, _swt_)(input, input_len, wavelet->CAT(dec_lo_, TYPE),
                             wavelet->dec_len, output, output_len, level);
 }
@@ -455,8 +455,8 @@ int CAT(TYPE, _swt_a)(TYPE input[], Index_t input_len, Wavelet* wavelet,
 /* Details at specified level
  * input - approximation coeffs from upper level or signal if level == 1
  */
-int CAT(TYPE, _swt_d)(TYPE input[], Index_t input_len, Wavelet* wavelet,
-                      TYPE output[], Index_t output_len, int level){
+int CAT(TYPE, _swt_d)(TYPE input[], pywt_index_t input_len, Wavelet* wavelet,
+                      TYPE output[], pywt_index_t output_len, int level){
     return CAT(TYPE, _swt_)(input, input_len, wavelet->CAT(dec_hi_, TYPE),
                             wavelet->dec_len, output, output_len, level);
 }

--- a/pywt/_extensions/c/wt.template.c
+++ b/pywt/_extensions/c/wt.template.c
@@ -400,12 +400,12 @@ int CAT(TYPE, _idwt)(const TYPE * const restrict coeffs_a, const size_t coeffs_a
 }
 
 /* basic SWT step (TODO: optimize) */
-int CAT(TYPE, _swt_)(TYPE input[], index_t input_len,
-                     const TYPE filter[], index_t filter_len,
-                     TYPE output[], index_t output_len, int level){
+int CAT(TYPE, _swt_)(TYPE input[], Index_t input_len,
+                     const TYPE filter[], Index_t filter_len,
+                     TYPE output[], Index_t output_len, int level){
 
     TYPE * e_filter;
-    index_t i, e_filter_len;
+    Index_t i, e_filter_len;
     int ret;
 
     if(level < 1)
@@ -446,8 +446,8 @@ int CAT(TYPE, _swt_)(TYPE input[], index_t input_len,
  * Approximation at specified level
  * input - approximation coeffs from upper level or signal if level == 1
  */
-int CAT(TYPE, _swt_a)(TYPE input[], index_t input_len, Wavelet* wavelet,
-                      TYPE output[], index_t output_len, int level){
+int CAT(TYPE, _swt_a)(TYPE input[], Index_t input_len, Wavelet* wavelet,
+                      TYPE output[], Index_t output_len, int level){
     return CAT(TYPE, _swt_)(input, input_len, wavelet->CAT(dec_lo_, TYPE),
                             wavelet->dec_len, output, output_len, level);
 }
@@ -455,8 +455,8 @@ int CAT(TYPE, _swt_a)(TYPE input[], index_t input_len, Wavelet* wavelet,
 /* Details at specified level
  * input - approximation coeffs from upper level or signal if level == 1
  */
-int CAT(TYPE, _swt_d)(TYPE input[], index_t input_len, Wavelet* wavelet,
-                      TYPE output[], index_t output_len, int level){
+int CAT(TYPE, _swt_d)(TYPE input[], Index_t input_len, Wavelet* wavelet,
+                      TYPE output[], Index_t output_len, int level){
     return CAT(TYPE, _swt_)(input, input_len, wavelet->CAT(dec_hi_, TYPE),
                             wavelet->dec_len, output, output_len, level);
 }

--- a/pywt/_extensions/c/wt.template.h
+++ b/pywt/_extensions/c/wt.template.h
@@ -59,14 +59,14 @@ int CAT(TYPE, _idwt)(const TYPE * const restrict coeffs_a, const size_t coeffs_a
                      const Wavelet * const wavelet, const MODE mode);
 
 /* SWT decomposition at given level */
-int CAT(TYPE, _swt_a)(TYPE input[], Index_t input_len,
+int CAT(TYPE, _swt_a)(TYPE input[], pywt_index_t input_len,
                       Wavelet* wavelet,
-                      TYPE output[], Index_t output_len,
+                      TYPE output[], pywt_index_t output_len,
                       int level);
 
-int CAT(TYPE, _swt_d)(TYPE input[], Index_t input_len,
+int CAT(TYPE, _swt_d)(TYPE input[], pywt_index_t input_len,
                       Wavelet* wavelet,
-                      TYPE output[], Index_t output_len,
+                      TYPE output[], pywt_index_t output_len,
                       int level);
 
 #endif /* TYPE */

--- a/pywt/_extensions/c/wt.template.h
+++ b/pywt/_extensions/c/wt.template.h
@@ -59,14 +59,14 @@ int CAT(TYPE, _idwt)(const TYPE * const restrict coeffs_a, const size_t coeffs_a
                      const Wavelet * const wavelet, const MODE mode);
 
 /* SWT decomposition at given level */
-int CAT(TYPE, _swt_a)(TYPE input[], index_t input_len,
+int CAT(TYPE, _swt_a)(TYPE input[], Index_t input_len,
                       Wavelet* wavelet,
-                      TYPE output[], index_t output_len,
+                      TYPE output[], Index_t output_len,
                       int level);
 
-int CAT(TYPE, _swt_d)(TYPE input[], index_t input_len,
+int CAT(TYPE, _swt_d)(TYPE input[], Index_t input_len,
                       Wavelet* wavelet,
-                      TYPE output[], index_t output_len,
+                      TYPE output[], Index_t output_len,
                       int level);
 
 #endif /* TYPE */

--- a/pywt/_extensions/c_wt.pxd
+++ b/pywt/_extensions/c_wt.pxd
@@ -1,7 +1,7 @@
 # Copyright (c) 2006-2012 Filip Wasilewski <http://en.ig.ma/>
 # See COPYING for license details.
 
-from common cimport MODE, Index_t, ArrayInfo, Coefficient
+from common cimport MODE, pywt_index_t, ArrayInfo, Coefficient
 from wavelet cimport Wavelet
 
 
@@ -37,10 +37,10 @@ cdef extern from "c/wt.h":
                          double * const output, const size_t output_len,
                          const Wavelet * const wavelet, const MODE mode)
 
-    cdef int double_swt_a(double input[], Index_t input_len, Wavelet* wavelet,
-                          double output[], Index_t output_len, int level)
-    cdef int double_swt_d(double input[], Index_t input_len, Wavelet* wavelet,
-                          double output[], Index_t output_len, int level)
+    cdef int double_swt_a(double input[], pywt_index_t input_len, Wavelet* wavelet,
+                          double output[], pywt_index_t output_len, int level)
+    cdef int double_swt_d(double input[], pywt_index_t input_len, Wavelet* wavelet,
+                          double output[], pywt_index_t output_len, int level)
 
 
     cdef int float_downcoef_axis(const float * const input, const ArrayInfo input_info,
@@ -73,7 +73,7 @@ cdef extern from "c/wt.h":
                         float * const output, const size_t output_len,
                         const Wavelet * const wavelet, const MODE mode)
 
-    cdef int float_swt_a(float input[], Index_t input_len, Wavelet* wavelet,
-                         float output[], Index_t output_len, int level)
-    cdef int float_swt_d(float input[], Index_t input_len, Wavelet* wavelet,
-                         float output[], Index_t output_len, int level)
+    cdef int float_swt_a(float input[], pywt_index_t input_len, Wavelet* wavelet,
+                         float output[], pywt_index_t output_len, int level)
+    cdef int float_swt_d(float input[], pywt_index_t input_len, Wavelet* wavelet,
+                         float output[], pywt_index_t output_len, int level)

--- a/pywt/_extensions/c_wt.pxd
+++ b/pywt/_extensions/c_wt.pxd
@@ -1,7 +1,7 @@
 # Copyright (c) 2006-2012 Filip Wasilewski <http://en.ig.ma/>
 # See COPYING for license details.
 
-from common cimport MODE, index_t, ArrayInfo, Coefficient
+from common cimport MODE, Index_t, ArrayInfo, Coefficient
 from wavelet cimport Wavelet
 
 
@@ -37,10 +37,10 @@ cdef extern from "c/wt.h":
                          double * const output, const size_t output_len,
                          const Wavelet * const wavelet, const MODE mode)
 
-    cdef int double_swt_a(double input[], index_t input_len, Wavelet* wavelet,
-                          double output[], index_t output_len, int level)
-    cdef int double_swt_d(double input[], index_t input_len, Wavelet* wavelet,
-                          double output[], index_t output_len, int level)
+    cdef int double_swt_a(double input[], Index_t input_len, Wavelet* wavelet,
+                          double output[], Index_t output_len, int level)
+    cdef int double_swt_d(double input[], Index_t input_len, Wavelet* wavelet,
+                          double output[], Index_t output_len, int level)
 
 
     cdef int float_downcoef_axis(const float * const input, const ArrayInfo input_info,
@@ -73,7 +73,7 @@ cdef extern from "c/wt.h":
                         float * const output, const size_t output_len,
                         const Wavelet * const wavelet, const MODE mode)
 
-    cdef int float_swt_a(float input[], index_t input_len, Wavelet* wavelet,
-                         float output[], index_t output_len, int level)
-    cdef int float_swt_d(float input[], index_t input_len, Wavelet* wavelet,
-                         float output[], index_t output_len, int level)
+    cdef int float_swt_a(float input[], Index_t input_len, Wavelet* wavelet,
+                         float output[], Index_t output_len, int level)
+    cdef int float_swt_d(float input[], Index_t input_len, Wavelet* wavelet,
+                         float output[], Index_t output_len, int level)

--- a/pywt/_extensions/common.pxd
+++ b/pywt/_extensions/common.pxd
@@ -1,5 +1,5 @@
 cdef extern from "c/common.h":
-    ctypedef int Index_t
+    ctypedef int pywt_index_t
 
     cdef void* wtmalloc(long size)
     cdef void* wtcalloc(long len, long size)
@@ -7,7 +7,7 @@ cdef extern from "c/common.h":
 
     ctypedef struct ArrayInfo:
         size_t * shape
-        Index_t * strides
+        pywt_index_t * strides
         size_t ndim
 
     ctypedef enum Coefficient:

--- a/pywt/_extensions/common.pxd
+++ b/pywt/_extensions/common.pxd
@@ -1,5 +1,5 @@
 cdef extern from "c/common.h":
-    ctypedef int index_t
+    ctypedef int Index_t
 
     cdef void* wtmalloc(long size)
     cdef void* wtcalloc(long len, long size)
@@ -7,7 +7,7 @@ cdef extern from "c/common.h":
 
     ctypedef struct ArrayInfo:
         size_t * shape
-        index_t * strides
+        Index_t * strides
         size_t ndim
 
     ctypedef enum Coefficient:

--- a/pywt/_extensions/wavelet.pxd
+++ b/pywt/_extensions/wavelet.pxd
@@ -1,4 +1,4 @@
-from common cimport index_t
+from common cimport Index_t
 
 cdef extern from "c/wavelets.h":
     ctypedef enum SYMMETRY:
@@ -22,7 +22,7 @@ cdef extern from "c/wavelets.h":
 
         int vanishing_moments_psi
         int vanishing_moments_phi
-        index_t support_width
+        Index_t support_width
 
         unsigned int orthogonal
         unsigned int biorthogonal

--- a/pywt/_extensions/wavelet.pxd
+++ b/pywt/_extensions/wavelet.pxd
@@ -1,4 +1,4 @@
-from common cimport Index_t
+from common cimport pywt_index_t
 
 cdef extern from "c/wavelets.h":
     ctypedef enum SYMMETRY:
@@ -22,7 +22,7 @@ cdef extern from "c/wavelets.h":
 
         int vanishing_moments_psi
         int vanishing_moments_phi
-        Index_t support_width
+        pywt_index_t support_width
 
         unsigned int orthogonal
         unsigned int biorthogonal


### PR DESCRIPTION
on smartos system(open solaris system like), index_t is used in file
sys/types.h, so modify index_t to Index_t to skip the conflict.

Signed-off-by: Frank Yu <flyxiaoyu@gmail.com>