### PR TITLE
add axis/axes support to multilevel discrete wavelet transforms

### DIFF
--- a/pywt/_multidim.py
+++ b/pywt/_multidim.py
@@ -270,7 +270,7 @@ def idwtn(coeffs, wavelet, mode='symmetric', axes=None):
             raise ValueError("Axis greater than data dimensions")
 
         new_coeffs = {}
-        new_keys = [''.join(coeff) for coeff in product('ad', repeat=key_length)]
+        new_keys = [''.join(coef) for coef in product('ad', repeat=key_length)]
 
         for key in new_keys:
             L = coeffs.get(key + 'a', None)

--- a/pywt/_multidim.py
+++ b/pywt/_multidim.py
@@ -245,11 +245,12 @@ def idwtn(coeffs, wavelet, mode='symmetric', axes=None):
         return (idwtn(real_coeffs, wavelet, mode, axes) +
                 1j * idwtn(imag_coeffs, wavelet, mode, axes))
 
-    ndim = max(len(key) for key in coeffs.keys())
+    # key length matches the number of axes transformed
+    ndim_transform = max(len(key) for key in coeffs.keys())
 
     try:
         coeff_shapes = (v.shape for k, v in coeffs.items()
-                        if v is not None and len(k) == ndim)
+                        if v is not None and len(k) == ndim_transform)
         coeff_shape = next(coeff_shapes)
     except StopIteration:
         raise ValueError("`coeffs` must contain at least one non-null wavelet "
@@ -258,10 +259,16 @@ def idwtn(coeffs, wavelet, mode='symmetric', axes=None):
         raise ValueError("`coeffs` must all be of equal size (or None)")
 
     if axes is None:
-        axes = range(ndim)
+        axes = range(ndim_transform)
+        ndim = ndim_transform
+    else:
+        ndim = len(coeff_shape)
     axes = (a + ndim if a < 0 else a for a in axes)
 
     for key_length, axis in reversed(list(enumerate(axes))):
+        if axis < 0 or axis >= ndim:
+            raise ValueError("Axis greater than data dimensions")
+
         new_coeffs = {}
         new_keys = [''.join(coeff) for coeff in product('ad', repeat=key_length)]
 

--- a/pywt/_multidim.py
+++ b/pywt/_multidim.py
@@ -40,7 +40,7 @@ def dwt2(data, wavelet, mode='symmetric', axes=(-2, -1)):
     (cA, (cH, cV, cD)) : tuple
         Approximation, horizontal detail, vertical detail and diagonal
         detail coefficients respectively.  Horizontal refers to array axis 0
-        (or axes[0] for user-specified ``axes``).
+        (or ``axes[0]`` for user-specified ``axes``).
 
     Examples
     --------

--- a/pywt/_multidim.py
+++ b/pywt/_multidim.py
@@ -39,7 +39,8 @@ def dwt2(data, wavelet, mode='symmetric', axes=(-2, -1)):
     -------
     (cA, (cH, cV, cD)) : tuple
         Approximation, horizontal detail, vertical detail and diagonal
-        detail coefficients respectively.  Horizontal refers to array axis 0.
+        detail coefficients respectively.  Horizontal refers to array axis 0
+        (or axes[0] for user-specified ``axes``).
 
     Examples
     --------
@@ -149,6 +150,9 @@ def dwtn(data, wavelet, mode='symmetric', axes=None):
              'da': <coeffs>  # H(HL) - det. on 1st dim, approx. on 2nd dim
              'dd': <coeffs>  # D(HH) - det. on 1st dim, det. on 2nd dim
             }
+
+        For user-specified ``axes``, the order of the characters in the
+        dictionary keys map to the specified ``axes``.
 
     """
     data = np.asarray(data)

--- a/pywt/_multilevel.py
+++ b/pywt/_multilevel.py
@@ -171,7 +171,11 @@ def wavedec2(data, wavelet, mode='symmetric', level=None, axes=(-2, -1)):
     -------
     [cAn, (cHn, cVn, cDn), ... (cH1, cV1, cD1)] : list
         Coefficients list.  For user-specified ``axes``, ``cH*``
-        correspond to ``axes[0]`` while ``cV*`` correspond to ``axes[1]``.
+        corresponds to ``axes[0]`` while ``cV*`` corresponds to ``axes[1]``.
+        The first element returned is the approximation coefficients for the
+        nth level of decomposition.  Remaining elements are tuples of detail
+        coefficients in descending order of decomposition level.
+        (i.e. cH1 are the horizontal detail coefficients at the first level)
 
     Examples
     --------
@@ -200,10 +204,10 @@ def wavedec2(data, wavelet, mode='symmetric', level=None, axes=(-2, -1)):
     if len(axes) != len(set(axes)):
         raise ValueError("The axes passed to wavedec2 must be unique.")
     try:
-        axes_shapes = [data.shape[ax] for ax in axes]
+        axes_sizes = [data.shape[ax] for ax in axes]
     except IndexError:
         raise ValueError("Axis greater than data dimensions")
-    level = _check_level(min(axes_shapes), wavelet.dec_len, level)
+    level = _check_level(min(axes_sizes), wavelet.dec_len, level)
 
     coeffs_list = []
 
@@ -297,15 +301,27 @@ def wavedecn(data, wavelet, mode='symmetric', level=None, axes=None):
     mode : str, optional
         Signal extension mode, see Modes (default: 'symmetric')
     level : int, optional
-        Dxecomposition level (must be >= 0). If level is None (default) then it
+        Decomposition level (must be >= 0). If level is None (default) then it
         will be calculated using the ``dwt_max_level`` function.
     axes : sequence of ints, optional
-        Axes over which to compute the DWT. Axes may not be repeated.
+        Axes over which to compute the DWT. Axes may not be repeated. The
+        default is ``None``, which means transform all axes
+        (``axes = range(data.ndim)``).
 
     Returns
     -------
     [cAn, {details_level_n}, ... {details_level_1}] : list
-        Coefficients list
+        Coefficients list.  Coefficients are listed in descending order of
+        decomposition level.  ``cAn`` are the approximation coefficients at
+        level ``n``.  Each ``details_level_i`` element is a dictionary
+        containing detail coefficients at level `i` of the decomposition.  As
+        a concrete example, a 3D decomposition would have the following set of
+        keys in each ``details_level_i`` dictionary::
+
+            {'aad', 'ada', 'daa', 'add', 'dad', 'dda', 'ddd'}
+
+        where the order of the characters in each key map to the specified
+        ``axes``.
 
     Examples
     --------

--- a/pywt/_multilevel.py
+++ b/pywt/_multilevel.py
@@ -86,7 +86,11 @@ def wavedec(data, wavelet, mode='symmetric', level=None, axis=-1):
     if not isinstance(wavelet, Wavelet):
         wavelet = Wavelet(wavelet)
 
-    level = _check_level(data.shape[axis], wavelet.dec_len, level)
+    try:
+        axes_shape = data.shape[axis]
+    except IndexError:
+        raise ValueError("Axis greater than data dimensions")
+    level = _check_level(axes_shape, wavelet.dec_len, level)
 
     coeffs_list = []
 
@@ -193,10 +197,12 @@ def wavedec2(data, wavelet, mode='symmetric', level=None, axes=(-2, -1)):
     axes = tuple(axes)
     if len(axes) != 2:
         raise ValueError("Expected 2 axes")
+    if len(axes) != len(set(axes)):
+        raise ValueError("The axes passed to wavedec2 must be unique.")
     try:
         axes_shapes = [data.shape[ax] for ax in axes]
     except IndexError:
-        raise IndexError("Axis greater than data dimensions")
+        raise ValueError("Axis greater than data dimensions")
     level = _check_level(min(axes_shapes), wavelet.dec_len, level)
 
     coeffs_list = []
@@ -247,6 +253,9 @@ def waverec2(coeffs, wavelet, mode='symmetric', axes=(-2, -1)):
 
     if not isinstance(coeffs, (list, tuple)):
         raise ValueError("Expected sequence of coefficient arrays.")
+
+    if len(axes) != len(set(axes)):
+        raise ValueError("The axes passed to waverec2 must be unique.")
 
     if len(coeffs) < 1:
         raise ValueError(
@@ -334,6 +343,8 @@ def wavedecn(data, wavelet, mode='symmetric', level=None, axes=None):
     if not isinstance(wavelet, Wavelet):
         wavelet = Wavelet(wavelet)
 
+    if np.isscalar(axes):
+        axes = (axes, )
     if axes is None:
         axes = range(data.ndim)
     else:
@@ -344,7 +355,7 @@ def wavedecn(data, wavelet, mode='symmetric', level=None, axes=None):
     try:
         axes_shapes = [data.shape[ax] for ax in axes]
     except IndexError:
-        raise IndexError("Axis greater than data dimensions")
+        raise ValueError("Axis greater than data dimensions")
     level = _check_level(min(axes_shapes), wavelet.dec_len, level)
 
     coeffs_list = []
@@ -450,6 +461,8 @@ def waverecn(coeffs, wavelet, mode='symmetric', axes=None):
         raise ValueError(
             "All coefficients must have a matching number of dimensions")
 
+    if np.isscalar(axes):
+        axes = (axes, )
     if axes is None:
         axes = range(ndim)
     else:

--- a/pywt/_multilevel.py
+++ b/pywt/_multilevel.py
@@ -165,13 +165,13 @@ def wavedec2(data, wavelet, mode='symmetric', level=None, axes=(-2, -1)):
         Decomposition level (must be >= 0). If level is None (default) then it
         will be calculated using the ``dwt_max_level`` function.
     axes : 2-tuple of ints, optional
-        Axes over which to compute the DWT. Repeated elements mean the DWT will
-        be performed multiple times along these axes.
+        Axes over which to compute the DWT. Repeated elements are not allowed.
 
     Returns
     -------
     [cAn, (cHn, cVn, cDn), ... (cH1, cV1, cD1)] : list
-        Coefficients list
+        Coefficients list.  For user-specified ``axes``, ``cH*``
+        correspond to ``axes[0]`` while ``cV*`` correspond to ``axes[1]``.
 
     Examples
     --------
@@ -229,8 +229,7 @@ def waverec2(coeffs, wavelet, mode='symmetric', axes=(-2, -1)):
     mode : str, optional
         Signal extension mode, see Modes (default: 'symmetric')
     axes : 2-tuple of ints, optional
-        Axes over which to compute the IDWT. Repeated elements mean the IDWT
-        will be performed multiple times along these axes.
+        Axes over which to compute the IDWT. Repeated elements are not allowed.
 
     Returns
     -------

--- a/pywt/_multilevel.py
+++ b/pywt/_multilevel.py
@@ -426,14 +426,6 @@ def waverecn(coeffs, wavelet, mode='symmetric', axes=None):
 
     a, ds = coeffs[0], coeffs[1:]
 
-    if axes is None:
-        axes = range(a.ndim)
-    else:
-        axes = tuple(axes)
-    if len(axes) != len(set(axes)):
-        raise ValueError("The axes passed to waverecn must be unique.")
-    ndim_transform = len(axes)
-
     # Raise error for invalid key combinations
     ds = list(map(_fix_coeffs, ds))
 
@@ -452,9 +444,19 @@ def waverecn(coeffs, wavelet, mode='symmetric', axes=None):
 
     # test that all coefficients have a matching number of dimensions
     unique_coeff_ndims = np.unique(coeff_ndims)
-    if len(unique_coeff_ndims) != 1:
+    if len(unique_coeff_ndims) == 1:
+        ndim = unique_coeff_ndims[0]
+    else:
         raise ValueError(
             "All coefficients must have a matching number of dimensions")
+
+    if axes is None:
+        axes = range(ndim)
+    else:
+        axes = tuple(axes)
+    if len(axes) != len(set(axes)):
+        raise ValueError("The axes passed to waverecn must be unique.")
+    ndim_transform = len(axes)
 
     for idx, d in enumerate(ds):
         if a is None and not d:

--- a/pywt/tests/test_multilevel.py
+++ b/pywt/tests/test_multilevel.py
@@ -2,11 +2,11 @@
 
 from __future__ import division, print_function, absolute_import
 
+from itertools import combinations
 import numpy as np
 from numpy.testing import (run_module_suite, assert_almost_equal,
                            assert_allclose, assert_, assert_equal,
                            assert_raises, dec)
-
 import pywt
 
 # Check that float32 and complex64 are preserved.  Other real types get
@@ -445,6 +445,92 @@ def test_array_to_coeffs_invalid_inputs():
 
     # invalid format name
     assert_raises(ValueError, pywt.array_to_coeffs, arr, arr_slices, 'foo')
+
+
+def test_waverec_axes_subsets():
+    data = np.random.standard_normal((8, 8, 8))
+    # test all combinations of 1 out of 3 axes transformed
+    for axis in [0, 1, 2]:
+        coefs = pywt.wavedec(data, 'haar', axis=axis)
+        rec = pywt.waverec(coefs, 'haar', axis=axis)
+        assert_allclose(rec, data, atol=1e-14)
+
+
+def test_waverec2_axes_subsets():
+    data = np.random.standard_normal((8, 8, 8))
+    # test all combinations of 2 out of 3 axes transformed
+    for axes in combinations((0, 1, 2), 2):
+        coefs = pywt.wavedec2(data, 'haar', axes=axes)
+        rec = pywt.waverec2(coefs, 'haar', axes=axes)
+        assert_allclose(rec, data, atol=1e-14)
+
+
+def test_waverecn_axes_subsets():
+    data = np.random.standard_normal((8, 8, 8, 8))
+    # test all combinations of 3 out of 4 axes transformed
+    for axes in combinations((0, 1, 2, 3), 3):
+        coefs = pywt.wavedecn(data, 'haar', axes=axes)
+        rec = pywt.waverecn(coefs, 'haar', axes=axes)
+        assert_allclose(rec, data, atol=1e-14)
+
+
+def test_waverecn_int_axis():
+    # waverecn should also work for axes as an integer
+    data = np.random.standard_normal((8, 8))
+    for axis in [0, 1]:
+        coefs = pywt.wavedecn(data, 'haar', axes=axis)
+        rec = pywt.waverecn(coefs, 'haar', axes=axis)
+        assert_allclose(rec, data, atol=1e-14)
+
+
+def test_wavedec_axis_error():
+    data = np.ones(4)
+    # out of range axis not allowed
+    assert_raises(ValueError, pywt.wavedec, data, 'haar', axis=1)
+
+
+def test_waverec_axis_error():
+    c = pywt.wavedec(np.ones(4), 'haar')
+    # out of range axis not allowed
+    assert_raises(ValueError, pywt.waverec, c, 'haar', axis=1)
+
+
+def test_wavedec2_axes_errors():
+    data = np.ones((4, 4))
+    # integer axes not allowed
+    assert_raises(TypeError, pywt.wavedec2, data, 'haar', axes=1)
+    # non-unique axes not allowed
+    assert_raises(ValueError, pywt.wavedec2, data, 'haar', axes=(0, 0))
+    # out of range axis not allowed
+    assert_raises(ValueError, pywt.wavedec2, data, 'haar', axes=(0, 2))
+
+
+def test_waverec2_axes_errors():
+    data = np.ones((4, 4))
+    c = pywt.wavedec2(data, 'haar')
+    # integer axes not allowed
+    assert_raises(TypeError, pywt.waverec2, c, 'haar', axes=1)
+    # non-unique axes not allowed
+    assert_raises(ValueError, pywt.waverec2, c, 'haar', axes=(0, 0))
+    # out of range axis not allowed
+    assert_raises(ValueError, pywt.waverec2, c, 'haar', axes=(0, 2))
+
+
+def test_wavedecn_axes_errors():
+    data = np.ones((8, 8, 8))
+    # repeated axes not allowed
+    assert_raises(ValueError, pywt.wavedecn, data, 'haar', axes=(1, 1))
+    # out of range axis not allowed
+    assert_raises(ValueError, pywt.wavedecn, data, 'haar', axes=(0, 1, 3))
+
+
+def test_waverecn_axes_errors():
+    data = np.ones((8, 8, 8))
+    c = pywt.wavedecn(data, 'haar')
+    # repeated axes not allowed
+    assert_raises(ValueError, pywt.waverecn, c, 'haar', axes=(1, 1))
+    # out of range axis not allowed
+    assert_raises(ValueError, pywt.waverecn, c, 'haar', axes=(0, 1, 3))
 
 
 if __name__ == '__main__':

--- a/pywt/tests/test_multilevel.py
+++ b/pywt/tests/test_multilevel.py
@@ -448,7 +448,8 @@ def test_array_to_coeffs_invalid_inputs():
 
 
 def test_waverec_axes_subsets():
-    data = np.random.standard_normal((8, 8, 8))
+    rstate = np.random.RandomState(0)
+    data = rstate.standard_normal((8, 8, 8))
     # test all combinations of 1 out of 3 axes transformed
     for axis in [0, 1, 2]:
         coefs = pywt.wavedec(data, 'haar', axis=axis)
@@ -457,7 +458,8 @@ def test_waverec_axes_subsets():
 
 
 def test_waverec2_axes_subsets():
-    data = np.random.standard_normal((8, 8, 8))
+    rstate = np.random.RandomState(0)
+    data = rstate.standard_normal((8, 8, 8))
     # test all combinations of 2 out of 3 axes transformed
     for axes in combinations((0, 1, 2), 2):
         coefs = pywt.wavedec2(data, 'haar', axes=axes)
@@ -466,7 +468,8 @@ def test_waverec2_axes_subsets():
 
 
 def test_waverecn_axes_subsets():
-    data = np.random.standard_normal((8, 8, 8, 8))
+    rstate = np.random.RandomState(0)
+    data = rstate.standard_normal((8, 8, 8, 8))
     # test all combinations of 3 out of 4 axes transformed
     for axes in combinations((0, 1, 2, 3), 3):
         coefs = pywt.wavedecn(data, 'haar', axes=axes)
@@ -476,7 +479,8 @@ def test_waverecn_axes_subsets():
 
 def test_waverecn_int_axis():
     # waverecn should also work for axes as an integer
-    data = np.random.standard_normal((8, 8))
+    rstate = np.random.RandomState(0)
+    data = rstate.standard_normal((8, 8))
     for axis in [0, 1]:
         coefs = pywt.wavedecn(data, 'haar', axes=axis)
         rec = pywt.waverecn(coefs, 'haar', axes=axis)


### PR DESCRIPTION
This PR adds axis support to the multilevel discrete wavelet transforms.  This was enabled by the axis support that was added to _multidim.py in #130 and _dwt.py in #116 .

An example use case is a 3D array where it is desired to apply a multilevel DWT along only a subset of the axes.

I do not allow any non-unique axes to be specified for the 2D and nD transforms.  Also, for simplicity, the same number of transform levels are applied to each axis specified.
