### PR TITLE
fix corner case in coeffs_to_array

### DIFF
--- a/pywt/_multilevel.py
+++ b/pywt/_multilevel.py
@@ -727,7 +727,7 @@ def coeffs_to_array(coeffs, padding=0):
     ndim = a_coeffs.ndim
     if len(coeffs) == 1:
         # only a single approximation coefficient array was found
-        return a_coeffs
+        return a_coeffs, [[slice(None)] * ndim]
 
     # determine size of output and if tight packing is possible
     arr_shape, is_tight_packing = _determine_coeff_array_shape(coeffs)

--- a/pywt/tests/test_multilevel.py
+++ b/pywt/tests/test_multilevel.py
@@ -386,10 +386,11 @@ def test_waverecn_all_wavelets_modes():
 
 
 def test_coeffs_to_array():
-    # single element list returns just the first element
+    # single element list returns the first element
     a_coeffs = [np.arange(8).reshape(2, 4), ]
-    arr = pywt.coeffs_to_array(a_coeffs)
+    arr, arr_slices = pywt.coeffs_to_array(a_coeffs)
     assert_allclose(arr, a_coeffs[0])
+    assert_allclose(arr, arr[arr_slices[0]])
 
     assert_raises(ValueError, pywt.coeffs_to_array, [])
     # invalid second element:  array as in wavedec, but not 1D


### PR DESCRIPTION
This PR fixes an inconsistency in the recently introduced `coeffs_to_array` for the corner case where the input does not contain any detail coefficients (e.g. coefficients as produced by `wavedec` for a transform of 0 levels).

 previously, no `coeff_slices` variable was returned which was a mismatch to the documentation