### PR TITLE
Drop GIL in c_wt calls

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,5 +1,9 @@
 Changelog
 
+unreleased:
+    changes:
+        - most operations now drop the Python GIL to allow efficient threading
+
 0.4.0
     changes:
       - idwt no longer takes a 'correct_size' parameter.

--- a/pywt/_extensions/_dwt.pyx
+++ b/pywt/_extensions/_dwt.pyx
@@ -1,3 +1,4 @@
+#cython: boundscheck=False, wraparound=False
 cimport common, c_wt, cython
 from common cimport pywt_index_t, MODE
 from ._pywt cimport _check_dtype
@@ -18,7 +19,6 @@ cpdef dwt_coeff_len(size_t data_len, size_t filter_len, MODE mode):
 
     return common.dwt_buffer_length(data_len, filter_len, mode)
 
-@cython.boundscheck(False)
 cpdef dwt_single(data_t[::1] data, Wavelet wavelet, MODE mode):
     cdef size_t output_len = dwt_coeff_len(data.size, wavelet.dec_len, mode)
     cdef np.ndarray cA, cD
@@ -229,7 +229,6 @@ cpdef idwt_axis(np.ndarray coefs_a, np.ndarray coefs_d,
 
     return output
 
-@cython.boundscheck(False)
 cpdef upcoef(bint do_rec_a, data_t[::1] coeffs, Wavelet wavelet, int level, int take):
     cdef data_t[::1] rec
     cdef int i, ret
@@ -294,7 +293,6 @@ cpdef upcoef(bint do_rec_a, data_t[::1] coeffs, Wavelet wavelet, int level, int 
     return rec
 
 
-@cython.boundscheck(False)
 cpdef downcoef(bint do_dec_a, data_t[::1] data, Wavelet wavelet, MODE mode, int level):
     cdef data_t[::1] coeffs
     cdef int i, ret

--- a/pywt/_extensions/c_wt.pxd
+++ b/pywt/_extensions/c_wt.pxd
@@ -10,70 +10,70 @@ cdef extern from "c/wt.h":
     cdef int double_downcoef_axis(const double * const input, const ArrayInfo input_info,
                                   double * const output, const ArrayInfo output_info,
                                   const Wavelet * const wavelet, const size_t axis,
-                                  const Coefficient detail, const MODE mode)
+                                  const Coefficient detail, const MODE mode) nogil
     cdef int double_idwt_axis(const double * const coefs_a, const ArrayInfo * const a_info,
                               const double * const coefs_d, const ArrayInfo * const d_info,
                               double * const output, const ArrayInfo output_info,
                               const Wavelet * const wavelet, const size_t axis,
-                              const MODE mode)
+                              const MODE mode) nogil
     cdef int double_dec_a(const double * const input, const size_t input_len,
                           const Wavelet * const wavelet,
                           double * const output, const size_t output_len,
-                          const MODE mode)
+                          const MODE mode) nogil
     cdef int double_dec_d(const double * const input, const size_t input_len,
                           const Wavelet * const wavelet,
                           double * const output, const size_t output_len,
-                          const MODE mode)
+                          const MODE mode) nogil
 
     cdef int double_rec_a(const double * const coeffs_a, const size_t coeffs_len,
                           const Wavelet * const wavelet,
-                          double * const output, const size_t output_len)
+                          double * const output, const size_t output_len) nogil
     cdef int double_rec_d(const double * const coeffs_d, const size_t coeffs_len,
                           const Wavelet * const wavelet,
-                          double * const output, const size_t output_len)
+                          double * const output, const size_t output_len) nogil
 
     cdef int double_idwt(double * const coeffs_a, const size_t coeffs_a_len,
                          double * const coeffs_d, const size_t coeffs_d_len,
                          double * const output, const size_t output_len,
-                         const Wavelet * const wavelet, const MODE mode)
+                         const Wavelet * const wavelet, const MODE mode) nogil
 
     cdef int double_swt_a(double input[], pywt_index_t input_len, Wavelet* wavelet,
-                          double output[], pywt_index_t output_len, int level)
+                          double output[], pywt_index_t output_len, int level) nogil
     cdef int double_swt_d(double input[], pywt_index_t input_len, Wavelet* wavelet,
-                          double output[], pywt_index_t output_len, int level)
+                          double output[], pywt_index_t output_len, int level) nogil
 
 
     cdef int float_downcoef_axis(const float * const input, const ArrayInfo input_info,
                                  float * const output, const ArrayInfo output_info,
                                  const Wavelet * const wavelet, const size_t axis,
-                                 const Coefficient detail, const MODE mode)
+                                 const Coefficient detail, const MODE mode) nogil
     cdef int float_idwt_axis(const float * const coefs_a, const ArrayInfo * const a_info,
                              const float * const coefs_d, const ArrayInfo * const d_info,
                              float * const output, const ArrayInfo output_info,
                              const Wavelet * const wavelet, const size_t axis,
-                             const MODE mode)
+                             const MODE mode) nogil
     cdef int float_dec_a(const float * const input, const size_t input_len,
                          const Wavelet * const wavelet,
                          float * const output, const size_t output_len,
-                         const MODE mode)
+                         const MODE mode) nogil
     cdef int float_dec_d(const float * const input, const size_t input_len,
                          const Wavelet * const wavelet,
                          float * const output, const size_t output_len,
-                         const MODE mode)
+                         const MODE mode) nogil
 
     cdef int float_rec_a(const float * const coeffs_a, const size_t coeffs_len,
                          const Wavelet * const wavelet,
-                         float * const output, const size_t output_len)
+                         float * const output, const size_t output_len) nogil
     cdef int float_rec_d(const float * const coeffs_d, const size_t coeffs_len,
                          const Wavelet * const wavelet,
-                         float * const output, const size_t output_len)
+                         float * const output, const size_t output_len) nogil
 
     cdef int float_idwt(const float * const coeffs_a, const size_t coeffs_a_len,
                         const float * const coeffs_d, const size_t coeffs_d_len,
                         float * const output, const size_t output_len,
-                        const Wavelet * const wavelet, const MODE mode)
+                        const Wavelet * const wavelet, const MODE mode) nogil
 
     cdef int float_swt_a(float input[], pywt_index_t input_len, Wavelet* wavelet,
-                         float output[], pywt_index_t output_len, int level)
+                         float output[], pywt_index_t output_len, int level) nogil
     cdef int float_swt_d(float input[], pywt_index_t input_len, Wavelet* wavelet,
-                         float output[], pywt_index_t output_len, int level)
+                         float output[], pywt_index_t output_len, int level) nogil


### PR DESCRIPTION
This PR drops the Python GIL for the computationally expensive `c_wt` calls in `_dwt.pyx`. This allows for efficient multithreading of PyWavelets code. Since the `c_wt` code does not modify any Python objects, dropping the GIL does not pose any risks (at least as far as I can tell).

The code passes all tests, and on my machine, computing four 2560x2560 `wavedec2` calls in parallel (using `concurrent.futures`) takes about 1 second with this PR, and about 3 seconds using the current master. I think the approach will scale nicely up to larger numbers of cores, since the GIL will be dropped during most of the computation time.

If there is a different reason to hold on to the GIL in `c_wt` calls, or if you want me to add/remove/change things, please let me know.