### PR TITLE
bump minimum numpy to 1.9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,10 +31,10 @@ matrix:
         - NUMPYSPEC=numpy
     - python: 2.6
       env:
-        - NUMPYSPEC="numpy==1.7.2"
+        - NUMPYSPEC="numpy==1.9.3"
     - python: 2.7
       env:
-        - NUMPYSPEC="numpy==1.9.1"
+        - NUMPYSPEC=numpy
 
 cache: pip
 

--- a/README.rst
+++ b/README.rst
@@ -38,7 +38,7 @@ Installation
 ------------
 
 PyWavelets supports `Python`_ 2.6, 2.7 or >=3.3, and is only dependent on `Numpy`_
-(supported versions are currently ``>= 1.6.2``). To pass all of the tests,
+(supported versions are currently ``>= 1.9``). To pass all of the tests,
 `Matplotlib`_ is also required.
 
 Binaries for Windows and OS X (wheels) on PyPi are in the works, however

--- a/doc/source/dev/installing_build_dependencies.rst
+++ b/doc/source/dev/installing_build_dependencies.rst
@@ -30,16 +30,11 @@ Use ``pip`` to install numpy_::
 
     pip install numpy
 
-It takes some time to compile numpy, so it might be more convenient to install
-it from a binary release.
+Numpy can also be obtained via scientific python distributions such as:
 
-.. note::
-
-  Installing numpy in a virtual environment on Windows is not straightforward.
-
-  It is recommended to download a suitable binary ``.exe`` release from
-  http://www.scipy.org/Download/ and install it using ``easy_install``
-  (i.e. ``easy_install numpy-1.6.2-win32-superpack-python2.7.exe``).
+- Anaconda_
+- `Enthought Canopy`_
+- `Python(x,y) <http://python-xy.github.io/>`_
 
 .. note::
 
@@ -65,3 +60,5 @@ via::
 .. _Cython: http://cython.org/
 .. _Sphinx: http://sphinx.pocoo.org
 .. _numpydoc: https://github.com/numpy/numpydoc
+.. _Anaconda: https://www.continuum.io/downloads
+.. _Enthought Canopy: https://www.enthought.com/products/canopy/

--- a/pywt/_multilevel.py
+++ b/pywt/_multilevel.py
@@ -18,13 +18,6 @@ from ._extensions._dwt import dwt_max_level
 from ._dwt import dwt, idwt
 from ._multidim import dwt2, idwt2, dwtn, idwtn, _fix_coeffs
 
-try:
-    # full was added in numpy 1.8
-    from numpy import full
-except ImportError:
-    def full(shape, value, dtype):
-        return value * np.ones(shape, dtype)
-
 __all__ = ['wavedec', 'waverec', 'wavedec2', 'waverec2', 'wavedecn',
            'waverecn', 'iswt', 'iswt2', 'coeffs_to_array', 'array_to_coeffs']
 
@@ -737,7 +730,7 @@ def coeffs_to_array(coeffs, padding=0):
             raise ValueError("array coefficients cannot be tightly packed")
         coeff_arr = np.empty(arr_shape, dtype=a_coeffs.dtype)
     else:
-        coeff_arr = full(arr_shape, padding, dtype=a_coeffs.dtype)
+        coeff_arr = np.full(arr_shape, padding, dtype=a_coeffs.dtype)
 
     a_slices = [slice(s) for s in a_shape]
     coeff_arr[a_slices] = a_coeffs


### PR DESCRIPTION
This PR would bump the minimum `numpy` version to 1.9 (see #189)

I also removed some text related to `easy_install` on windows as I think `pip` will now find numpy wheels for Windows.