### PR TITLE
speedup multi-level swt

### DIFF
--- a/pywt/_extensions/c/convolution.template.c
+++ b/pywt/_extensions/c/convolution.template.c
@@ -73,7 +73,7 @@ int CAT(TYPE, _downsampling_convolution_periodization)(const TYPE * const restri
         size_t k_start = 0;
         while (i-j >= N){
             size_t k;
-            // TODO: fstep for reverse indices
+            // for simplicity, not using fstep here
             for (k = 0; k < padding && i-j >= N; ++k, ++j)
                 sum += filter[i-N-j] * input[N-1];
             for (k = 0; k < N && i-j >= N; ++k, ++j)
@@ -99,6 +99,7 @@ int CAT(TYPE, _downsampling_convolution_periodization)(const TYPE * const restri
         TYPE sum = 0;
         size_t j = 0;
         while (i-j >= N){
+            // for simplicity, not using fstep here
             size_t k;
             for (k = 0; k < padding && i-j >= N; ++k, ++j)
                 sum += filter[i-N-j] * input[N-1];

--- a/pywt/_extensions/c/convolution.template.h
+++ b/pywt/_extensions/c/convolution.template.h
@@ -34,6 +34,24 @@ int CAT(TYPE, _downsampling_convolution)(const TYPE * const restrict input, cons
                                          TYPE * const restrict output, const size_t step,
                                          MODE mode);
 
+
+/* downsampling convolution routine specific to periodization mode.
+ *
+ * input    - input data
+ * N        - input data length
+ * filter   - filter data
+ * F        - filter data length
+ * output   - output data
+ * step     - decimation step
+ * fstep    - step size between non-zero entries in filter
+ *            (used to improve performance for the multilevel swt)
+ */
+int CAT(TYPE, _downsampling_convolution_periodization)(
+    const TYPE * const restrict input, const size_t N,
+    const TYPE * const restrict filter, const size_t F,
+    TYPE * const restrict output, const size_t step,
+    const size_t fstep);
+
 /*
  * Performs normal (full) convolution of "upsampled" input coeffs array with
  * filter Requires zero-filled output buffer (adds values instead of

--- a/pywt/_extensions/c/wt.template.c
+++ b/pywt/_extensions/c/wt.template.c
@@ -405,7 +405,7 @@ int CAT(TYPE, _swt_)(TYPE input[], pywt_index_t input_len,
                      TYPE output[], pywt_index_t output_len, int level){
 
     TYPE * e_filter;
-    pywt_index_t i, e_filter_len, jstep;
+    pywt_index_t i, e_filter_len, fstep;
     int ret;
 
     if(level < 1)
@@ -424,7 +424,7 @@ int CAT(TYPE, _swt_)(TYPE input[], pywt_index_t input_len,
         e_filter = wtcalloc(e_filter_len, sizeof(TYPE));
         if(e_filter == NULL)
             return -1;
-        jstep = 1 << (level - 1)
+        fstep = 1 << (level - 1);  // spacing between non-zero filter entries
 
         /* compute upsampled filter values */
         for(i = 0; i < filter_len; ++i){
@@ -432,7 +432,7 @@ int CAT(TYPE, _swt_)(TYPE input[], pywt_index_t input_len,
         }
         ret = CAT(TYPE, _downsampling_convolution_periodization)(input, input_len, e_filter,
                                                    e_filter_len, output, 1,
-                                                   jstep);
+                                                   fstep);
         wtfree(e_filter);
         return ret;
 

--- a/pywt/_extensions/c/wt.template.c
+++ b/pywt/_extensions/c/wt.template.c
@@ -405,7 +405,7 @@ int CAT(TYPE, _swt_)(TYPE input[], pywt_index_t input_len,
                      TYPE output[], pywt_index_t output_len, int level){
 
     TYPE * e_filter;
-    pywt_index_t i, e_filter_len;
+    pywt_index_t i, e_filter_len, jstep;
     int ret;
 
     if(level < 1)
@@ -424,21 +424,22 @@ int CAT(TYPE, _swt_)(TYPE input[], pywt_index_t input_len,
         e_filter = wtcalloc(e_filter_len, sizeof(TYPE));
         if(e_filter == NULL)
             return -1;
+        jstep = 1 << (level - 1)
 
         /* compute upsampled filter values */
         for(i = 0; i < filter_len; ++i){
             e_filter[i << (level-1)] = filter[i];
         }
-        ret = CAT(TYPE, _downsampling_convolution)(input, input_len, e_filter,
+        ret = CAT(TYPE, _downsampling_convolution_periodization)(input, input_len, e_filter,
                                                    e_filter_len, output, 1,
-                                                   MODE_PERIODIZATION);
+                                                   jstep);
         wtfree(e_filter);
         return ret;
 
     } else {
-        return CAT(TYPE, _downsampling_convolution)(input, input_len, filter,
+        return CAT(TYPE, _downsampling_convolution_periodization)(input, input_len, filter,
                                                     filter_len, output, 1,
-                                                    MODE_PERIODIZATION);
+                                                    1);
     }
 }
 

--- a/pywt/tests/test_multilevel.py
+++ b/pywt/tests/test_multilevel.py
@@ -127,7 +127,7 @@ def test_waverec_all_wavelets_modes():
 def test_swt_decomposition():
     x = [3, 7, 1, 3, -2, 6, 4, 6]
     db1 = pywt.Wavelet('db1')
-    (cA2, cD2), (cA1, cD1) = pywt.swt(x, db1, level=2)
+    (cA3, cD3), (cA2, cD2), (cA1, cD1) = pywt.swt(x, db1, level=3)
     expected_cA1 = [7.07106781, 5.65685425, 2.82842712, 0.70710678,
                     2.82842712, 7.07106781, 7.07106781, 6.36396103]
     assert_allclose(cA1, expected_cA1)
@@ -138,6 +138,11 @@ def test_swt_decomposition():
     assert_allclose(cA2, expected_cA2, rtol=tol_double)
     expected_cD2 = [3, 3.5, 0, -4.5, -3, 0.5, 0, 0.5]
     assert_allclose(cD2, expected_cD2, rtol=tol_double, atol=1e-14)
+    expected_cA3 = [9.89949494, ] * 8
+    assert_allclose(cA3, expected_cA3)
+    expected_cD3 = [0.00000000, -3.53553391, -4.24264069, -2.12132034,
+                    0.00000000, 3.53553391, 4.24264069, 2.12132034]
+    assert_allclose(cD3, expected_cD3)
 
     # level=1, start_level=1 decomposition should match level=2
     res = pywt.swt(cA1, db1, level=1, start_level=1)


### PR DESCRIPTION
This PR skips the zero entries in the upsampled wavelet filters for `swt` with `level` > 1.  

The idea is simple: 
implement a stepsize, `fstep`, for use when iterating over the filter to skip the known 0 entries.  That said, getting all of the indexing offsets correct took  a few tries to get right.  

Reusing the example from issue #200

```python
x = np.random.rand(524288,)
wvlt = pywt.swt(x, 'sym4', level=11)
```

**On my system the runtime for the above example with this PR is improved from approximately 18.1 seconds to 115 ms!**.  The speedup is more modest for transforms with a smaller number of levels.

At level 11, the filter in the example above is upsampled from length 6 to length 6144 with only 6 non-zero entries!  This PR just skips the unnecessary multiplications and additions by zero.

**edit**:
Matlab R2012b takes ~0.5 seconds for the example above