### PR TITLE
DOC: clarification to swt and iswt docstrings

### DIFF
--- a/pywt/_multidim.py
+++ b/pywt/_multidim.py
@@ -287,7 +287,7 @@ def swt2(data, wavelet, level, start_level=0):
     wavelet : Wavelet object or name string
         Wavelet to use
     level : int
-        How many decomposition steps to perform
+        The number of decomposition steps to perform.
     start_level : int, optional
         The level at which the decomposition will start (default: 0)
 
@@ -297,20 +297,20 @@ def swt2(data, wavelet, level, start_level=0):
         Approximation and details coefficients::
 
             [
-                (cA_n,
-                    (cH_n, cV_n, cD_n)
+                (cA_m,
+                    (cH_m, cV_m, cD_m)
                 ),
-                (cA_n+1,
-                    (cH_n+1, cV_n+1, cD_n+1)
+                (cA_m+1,
+                    (cH_m+1, cV_m+1, cD_m+1)
                 ),
                 ...,
-                (cA_n+level,
-                    (cH_n+level, cV_n+level, cD_n+level)
+                (cA_m+level,
+                    (cH_m+level, cV_m+level, cD_m+level)
                 )
             ]
 
         where cA is approximation, cH is horizontal details, cV is
-        vertical details, cD is diagonal details and n is start_level.
+        vertical details, cD is diagonal details and m is ``start_level``.
 
     """
     data = np.asarray(data)

--- a/pywt/_multilevel.py
+++ b/pywt/_multilevel.py
@@ -266,9 +266,10 @@ def iswt(coeffs, wavelet):
     coeffs : array_like
         Coefficients list of tuples::
 
-            [(cA1, cD1), (cA2, cD2), ..., (cAn, cDn)]
+            [(cAn, cDn), (cA2, cD2), ..., (cA1, cD1)]
 
-        where cA is approximation, cD is details, and n is start_level.
+        where cA is approximation, cD is details.  Index 1 corresponds to
+        ``start_level`` from ``pywt.swt``.
     wavelet : Wavelet object or name string
         Wavelet to use
 
@@ -343,8 +344,8 @@ def iswt2(coeffs, wavelet):
             ]
 
         where cA is approximation, cH is horizontal details, cV is
-        vertical details, cD is diagonal details and n is number of
-        levels.
+        vertical details, cD is diagonal details and n is the number of
+        levels.  Index 1 corresponds to ``start_level`` from ``pywt.swt2``.
     wavelet : Wavelet object or name string
         Wavelet to use
 

--- a/pywt/_swt.py
+++ b/pywt/_swt.py
@@ -19,7 +19,7 @@ def swt(data, wavelet, level=None, start_level=0):
     wavelet :
         Wavelet to use (Wavelet object or name)
     level : int, optional
-        Transform level.
+        The number of decomposition steps to perform.
     start_level : int, optional
         The level at which the decomposition will begin (it allows one to
         skip a given number of transform steps and compute
@@ -33,9 +33,10 @@ def swt(data, wavelet, level=None, start_level=0):
 
             [(cAn, cDn), ..., (cA2, cD2), (cA1, cD1)]
 
-        where ``n`` equals input parameter `level`.
+        where n equals input parameter ``level``.
 
-        If *m* = *start_level* is given, then the beginning *m* steps are skipped::
+        If ``start_level = m`` is given, then the beginning m steps are
+        skipped::
 
             [(cAm+n, cDm+n), ..., (cAm+1, cDm+1), (cAm, cDm)]
 


### PR DESCRIPTION
This is an attempt to make the ``swt``-related docstrings more clearerly describe the coefficients produced.

Two primary things were changed:
1.) consistent coefficient naming across forward and inverse transforms.  As an example, previously, what was called `cA1` in `swt` corresponded to `cAn` in the `iswt` docstring.

~~2.) There was an inconsistency in the docstrings for `swt` and `swt2` when `start_level > 0`.
The original docstring coefficient names suggest that the range used would be ``range(start_level, start_level+level)``, but the actual implementation is ``range(start_level, level)``.~~