### PR TITLE
fully separable wavelet transform

### DIFF
--- a/demo/fswt.py
+++ b/demo/fswt.py
@@ -26,3 +26,5 @@ ax2.imshow(np.abs(fswt_array)**0.25,
            interpolation='nearest')
 ax2.set_axis_off()
 ax2.set_title('Fully separable decomposition\n(fswt)')
+
+plt.show()

--- a/demo/fswt.py
+++ b/demo/fswt.py
@@ -1,0 +1,28 @@
+import numpy as np
+from matplotlib import pyplot as plt
+import pywt
+
+img = pywt.data.camera().astype(float)
+
+# Fully separable transform
+fswt_array, slices = pywt.fswt(img, 'db2', 'periodization', levels=4)
+
+# Standard DWT
+coefs = pywt.wavedec2(img, 'db2', 'periodization', level=4)
+# convert DWT coefficients to a 2D array
+mallat_array, mallat_slices = pywt.coeffs_to_array(coefs)
+
+
+fig, (ax1, ax2) = plt.subplots(1, 2)
+
+ax1.imshow(np.abs(mallat_array)**0.25,
+           cmap=plt.cm.gray,
+           interpolation='nearest')
+ax1.set_axis_off()
+ax1.set_title('Mallat decomposition\n(wavedec2)')
+
+ax2.imshow(np.abs(fswt_array)**0.25,
+           cmap=plt.cm.gray,
+           interpolation='nearest')
+ax2.set_axis_off()
+ax2.set_title('Fully separable decomposition\n(fswt)')

--- a/demo/fswt.py
+++ b/demo/fswt.py
@@ -5,7 +5,7 @@ import pywt
 img = pywt.data.camera().astype(float)
 
 # Fully separable transform
-fswt_array, slices = pywt.fswt(img, 'db2', 'periodization', levels=4)
+fswt_result = pywt.fswt(img, 'db2', 'periodization', levels=4)
 
 # Standard DWT
 coefs = pywt.wavedec2(img, 'db2', 'periodization', level=4)
@@ -21,7 +21,7 @@ ax1.imshow(np.abs(mallat_array)**0.25,
 ax1.set_axis_off()
 ax1.set_title('Mallat decomposition\n(wavedec2)')
 
-ax2.imshow(np.abs(fswt_array)**0.25,
+ax2.imshow(np.abs(fswt_result.coeffs)**0.25,
            cmap=plt.cm.gray,
            interpolation='nearest')
 ax2.set_axis_off()

--- a/demo/fswt.py
+++ b/demo/fswt.py
@@ -5,7 +5,7 @@ import pywt
 img = pywt.data.camera().astype(float)
 
 # Fully separable transform
-fswt_result = pywt.fswt(img, 'db2', 'periodization', levels=4)
+fswavedecn_result = pywt.fswavedecn(img, 'db2', 'periodization', levels=4)
 
 # Standard DWT
 coefs = pywt.wavedec2(img, 'db2', 'periodization', level=4)
@@ -21,7 +21,7 @@ ax1.imshow(np.abs(mallat_array)**0.25,
 ax1.set_axis_off()
 ax1.set_title('Mallat decomposition\n(wavedec2)')
 
-ax2.imshow(np.abs(fswt_result.coeffs)**0.25,
+ax2.imshow(np.abs(fswavedecn_result.coeffs)**0.25,
            cmap=plt.cm.gray,
            interpolation='nearest')
 ax2.set_axis_off()

--- a/demo/fswt_mondrian.py
+++ b/demo/fswt_mondrian.py
@@ -1,0 +1,81 @@
+"""Using the FSWT to process anistropic images.
+
+In this demo, an anisotropic piecewise-constant image is transformed by the
+standard DWT and the fully-separable DWT. The 'Haar' wavelet gives a sparse
+representation for such piecewise constant signals (detail coefficients are
+only non-zero near edges).
+
+For such anistropic signals, the number of non-zero coefficients will be lower
+for the fully separable DWT than for the isotropic one.
+
+This example is inspired by the following publication where it is proven that
+the FSWT gives a sparser representation than the DWT for this class of
+anistropic images:
+
+.. V Velisavljevic, B Beferull-Lozano, M Vetterli and PL Dragotti.
+   Directionlets: Anisotropic Multidirectional Representation With
+   Separable Filtering. IEEE Transactions on Image Processing, Vol. 15,
+   No. 7, July 2006.
+
+"""
+
+import numpy as np
+import pywt
+
+from matplotlib import pyplot as plt
+
+
+def mondrian(shape=(256, 256), nx=5, ny=8, seed=4):
+    """ Piecewise-constant image (reminiscent of Dutch painter Piet Mondrian's
+    geometrical period).
+    """
+    rstate = np.random.RandomState(seed)
+    min_dx = 0
+    while(min_dx < 3):
+        xp = np.sort(np.round(rstate.rand(nx-1)*shape[0]).astype(np.int))
+        xp = np.concatenate(((0, ), xp, (shape[0], )))
+        min_dx = np.min(np.diff(xp))
+    min_dy = 0
+    while(min_dy < 3):
+        yp = np.sort(np.round(rstate.rand(ny-1)*shape[1]).astype(np.int))
+        yp = np.concatenate(((0, ), yp, (shape[1], )))
+        min_dy = np.min(np.diff(yp))
+    img = np.zeros(shape)
+    for ix, x in enumerate(xp[:-1]):
+        for iy, y in enumerate(yp[:-1]):
+            slices = [slice(x, xp[ix+1]), slice(y, yp[iy+1])]
+            val = rstate.rand(1)[0]
+            img[slices] = val
+    return img
+
+
+# create an anisotropic piecewise constant image
+img = mondrian((128, 128))
+
+# perform DWT
+coeffs_dwt = pywt.wavedecn(img, wavelet='db1', level=None)
+
+# convert coefficient dictionary to a single array
+coeff_array_dwt, _ = pywt.coeffs_to_array(coeffs_dwt)
+
+# perform fully seperable DWT
+coeff_array_fswt, _ = pywt.fswt(img, wavelet='db1')
+
+nnz_dwt = np.sum(coeff_array_dwt != 0)
+nnz_fswt = np.sum(coeff_array_fswt != 0)
+
+print("Number of nonzero wavedecn coefficients = {}".format(np.sum(nnz_dwt)))
+print("Number of nonzero fswt coefficients = {}".format(np.sum(nnz_fswt)))
+
+img = mondrian()
+fig, axes = plt.subplots(1, 3)
+imshow_kwargs = dict(cmap=plt.cm.gray, interpolation='nearest')
+axes[0].imshow(img, **imshow_kwargs)
+axes[0].set_title('Anisotropic Image')
+axes[1].imshow(coeff_array_dwt != 0, **imshow_kwargs)
+axes[1].set_title('Nonzero DWT\ncoefficients\n(N={})'.format(nnz_dwt))
+axes[2].imshow(coeff_array_fswt != 0, **imshow_kwargs)
+axes[2].set_title('Nonzero FSWT\ncoefficients\n(N={})'.format(nnz_fswt))
+for ax in axes:
+    ax.set_axis_off()
+plt.show()

--- a/demo/fswt_mondrian.py
+++ b/demo/fswt_mondrian.py
@@ -59,10 +59,10 @@ coeffs_dwt = pywt.wavedecn(img, wavelet='db1', level=None)
 coeff_array_dwt, _ = pywt.coeffs_to_array(coeffs_dwt)
 
 # perform fully seperable DWT
-coeff_array_fswt, _ = pywt.fswt(img, wavelet='db1')
+fswt_result = pywt.fswt(img, wavelet='db1')
 
 nnz_dwt = np.sum(coeff_array_dwt != 0)
-nnz_fswt = np.sum(coeff_array_fswt != 0)
+nnz_fswt = np.sum(fswt_result.coeffs != 0)
 
 print("Number of nonzero wavedecn coefficients = {}".format(np.sum(nnz_dwt)))
 print("Number of nonzero fswt coefficients = {}".format(np.sum(nnz_fswt)))
@@ -74,8 +74,9 @@ axes[0].imshow(img, **imshow_kwargs)
 axes[0].set_title('Anisotropic Image')
 axes[1].imshow(coeff_array_dwt != 0, **imshow_kwargs)
 axes[1].set_title('Nonzero DWT\ncoefficients\n(N={})'.format(nnz_dwt))
-axes[2].imshow(coeff_array_fswt != 0, **imshow_kwargs)
+axes[2].imshow(fswt_result.coeffs != 0, **imshow_kwargs)
 axes[2].set_title('Nonzero FSWT\ncoefficients\n(N={})'.format(nnz_fswt))
 for ax in axes:
     ax.set_axis_off()
+
 plt.show()

--- a/demo/fswt_mondrian.py
+++ b/demo/fswt_mondrian.py
@@ -59,13 +59,13 @@ coeffs_dwt = pywt.wavedecn(img, wavelet='db1', level=None)
 coeff_array_dwt, _ = pywt.coeffs_to_array(coeffs_dwt)
 
 # perform fully seperable DWT
-fswt_result = pywt.fswt(img, wavelet='db1')
+fswavedecn_result = pywt.fswavedecn(img, wavelet='db1')
 
 nnz_dwt = np.sum(coeff_array_dwt != 0)
-nnz_fswt = np.sum(fswt_result.coeffs != 0)
+nnz_fswavedecn = np.sum(fswavedecn_result.coeffs != 0)
 
 print("Number of nonzero wavedecn coefficients = {}".format(np.sum(nnz_dwt)))
-print("Number of nonzero fswt coefficients = {}".format(np.sum(nnz_fswt)))
+print("Number of nonzero fswavedecn coefficients = {}".format(np.sum(nnz_fswavedecn)))
 
 img = mondrian()
 fig, axes = plt.subplots(1, 3)
@@ -74,8 +74,8 @@ axes[0].imshow(img, **imshow_kwargs)
 axes[0].set_title('Anisotropic Image')
 axes[1].imshow(coeff_array_dwt != 0, **imshow_kwargs)
 axes[1].set_title('Nonzero DWT\ncoefficients\n(N={})'.format(nnz_dwt))
-axes[2].imshow(fswt_result.coeffs != 0, **imshow_kwargs)
-axes[2].set_title('Nonzero FSWT\ncoefficients\n(N={})'.format(nnz_fswt))
+axes[2].imshow(fswavedecn_result.coeffs != 0, **imshow_kwargs)
+axes[2].set_title('Nonzero FSWT\ncoefficients\n(N={})'.format(nnz_fswavedecn))
 for ax in axes:
     ax.set_axis_off()
 

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -34,7 +34,8 @@ except TypeError:
 # Add any Sphinx extension module names here, as strings. They can be extensions
 # coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
 extensions = ['sphinx.ext.doctest', 'sphinx.ext.autodoc', 'sphinx.ext.todo',
-              'sphinx.ext.extlinks', 'sphinx.ext.mathjax', 'numpydoc',
+              'sphinx.ext.extlinks', 'sphinx.ext.mathjax',
+              'sphinx.ext.autosummary', 'numpydoc',
               'matplotlib.sphinxext.plot_directive']
 
 # Add any paths that contain templates here, relative to this directory.
@@ -101,7 +102,6 @@ pygments_style = 'sphinx'
 
 # A list of ignored prefixes for module index sorting.
 modindex_common_prefix = ['pywt.']
-
 
 # -- Options for HTML output ---------------------------------------------------
 
@@ -215,3 +215,7 @@ latex_documents = [
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
 exclude_patterns = ['substitutions.rst', ]
+
+# numpydoc_show_class_members = False
+numpydoc_class_members_toctree = False
+

--- a/doc/source/ref/nd-dwt-and-idwt.rst
+++ b/doc/source/ref/nd-dwt-and-idwt.rst
@@ -32,6 +32,6 @@ Multilevel fully separable reconstruction - ``ifswt``
 -----------------------------------------------------
 .. autofunction:: ifswt
 
-Multilevel fully separable reconstruction coeffs - ``TransformResult``
+Multilevel fully separable reconstruction coeffs - ``FswtResult``
 -----------------------------------------------------------------------
-.. autoclass:: TransformResult
+.. autoclass:: FswtResult

--- a/doc/source/ref/nd-dwt-and-idwt.rst
+++ b/doc/source/ref/nd-dwt-and-idwt.rst
@@ -6,6 +6,8 @@ nD Forward and Inverse Discrete Wavelet Transform
 
 .. currentmodule:: pywt
 
+.. autosummary:: _multilevel
+
 Single level - ``dwtn``
 -----------------------
 .. autofunction:: dwtn
@@ -29,3 +31,7 @@ Multilevel fully separable decomposition - ``fswt``
 Multilevel fully separable reconstruction - ``ifswt``
 -----------------------------------------------------
 .. autofunction:: ifswt
+
+Multilevel fully separable reconstruction coeffs - ``TransformResult``
+-----------------------------------------------------------------------
+.. autoclass:: TransformResult

--- a/doc/source/ref/nd-dwt-and-idwt.rst
+++ b/doc/source/ref/nd-dwt-and-idwt.rst
@@ -21,3 +21,11 @@ Multilevel decomposition - ``wavedecn``
 Multilevel reconstruction - ``waverecn``
 ----------------------------------------
 .. autofunction:: waverecn
+
+Multilevel fully separable decomposition - ``fswt``
+---------------------------------------------------
+.. autofunction:: fswt
+
+Multilevel fully separable reconstruction - ``ifswt``
+-----------------------------------------------------
+.. autofunction:: ifswt

--- a/doc/source/ref/nd-dwt-and-idwt.rst
+++ b/doc/source/ref/nd-dwt-and-idwt.rst
@@ -24,14 +24,14 @@ Multilevel reconstruction - ``waverecn``
 ----------------------------------------
 .. autofunction:: waverecn
 
-Multilevel fully separable decomposition - ``fswt``
----------------------------------------------------
-.. autofunction:: fswt
+Multilevel fully separable decomposition - ``fswavedecn``
+---------------------------------------------------------
+.. autofunction:: fswavedecn
 
-Multilevel fully separable reconstruction - ``ifswt``
------------------------------------------------------
-.. autofunction:: ifswt
+Multilevel fully separable reconstruction - ``fswaverecn``
+----------------------------------------------------------
+.. autofunction:: fswaverecn
 
-Multilevel fully separable reconstruction coeffs - ``FswtResult``
+Multilevel fully separable reconstruction coeffs - ``FswaverecnResult``
 -----------------------------------------------------------------------
-.. autoclass:: FswtResult
+.. autoclass:: FswaverecnResult

--- a/pywt/_multilevel.py
+++ b/pywt/_multilevel.py
@@ -1188,8 +1188,13 @@ def fswt(data, wavelet, mode='symmetric', levels=None, axes=None):
     Notes
     -----
     This transformation has been variously referred to as the (fully) separable
-    wavelet transform (e.g. refs _[1], _[4]) or the tensor-product wavelet
-    (refs _[2], _[3]).
+    wavelet transform (e.g. refs _[1], _[3]), the tensor-product wavelet
+    (_[2]) or the hyperbolic wavelet transform (_[4]).  It is well suited to
+    data with anisotropic smoothness.
+
+    In _[2] it was demonstrated that FSWT performs at least as well as the DWT
+    for image compression.  Computation time is a factor 2 larger than that for
+    the DWT.
 
     See Also
     --------
@@ -1202,17 +1207,16 @@ def fswt(data, wavelet, mode='symmetric', levels=None, axes=None):
     lands, 1989.  (see Section 2.3)
     http://resolver.tudelft.nl/uuid:a4d195c3-1f89-4d66-913d-db9af0969509
 
-    ..[2] R. D. Nowak and R. G. Baraniuk.  Wavelet-based transformations for
-    nonlinear signal processing. IEEE Trans. Signal Process., vol. 47, no.
-    7, pp. 1852–1865, Jul. 1999.
-
-    ..[3] C. P. Rosiene and T. Q. Nguyen. "Tensor-product wavelet vs. Mallat
+    ..[2] C. P. Rosiene and T. Q. Nguyen. "Tensor-product wavelet vs. Mallat
     decomposition: A comparative analysis,” in Proc. IEEE Int. Symp. Circuits
     and Systems, Orlando, FL, Jun. 1999, pp. 431–434.
 
-    ..[4] V. Velisavljevic, B. Beferull-Lozano, M. Vetterli and P.L. Dragotti.
+    ..[3] V. Velisavljevic, B. Beferull-Lozano, M. Vetterli and P.L. Dragotti.
     Directionlets: Anisotropic Multidirectional Representation With Separable
     Filtering. IEEE TRANSACTIONS ON IMAGE PROCESSING, VOL. 15, NO. 7, JULY 2006
+
+    ..[4] R. A. DeVore, S. V. Konyagin, and V. N. Temlyakov. "Hyperbolic
+    wavelet approximation," Constr. Approx. 14 (1998), 1–26.
     """
     data = np.asarray(data)
     if axes is None:
@@ -1264,13 +1268,23 @@ def ifswt(coeffs_arr, coeff_slices, wavelet, mode='symmetric', axes=None):
 
     See Also
     --------
-    fswt : inverse of ifswt
+    ifswt : inverse of fswt
 
     Notes
     -----
     This transformation has been variously referred to as the (fully) separable
-    wavelet transform (e.g. refs _[1], _[4]) or the tensor-product wavelet
-    (refs _[2], _[3]).
+    wavelet transform (e.g. refs _[1], _[3]), the tensor-product wavelet
+    (_[2]) or the hyperbolic wavelet transform (_[4]).  It is well suited to
+    data with anisotropic smoothness.
+
+    In _[2] it was demonstrated that FSWT performs at least as well as the DWT
+    for image compression.  Computation time is a factor 2 larger than that for
+    the DWT.
+
+
+    See Also
+    --------
+    ifswt : inverse of fswt
 
     References
     ----------
@@ -1279,17 +1293,16 @@ def ifswt(coeffs_arr, coeff_slices, wavelet, mode='symmetric', axes=None):
     lands, 1989.  (see Section 2.3)
     http://resolver.tudelft.nl/uuid:a4d195c3-1f89-4d66-913d-db9af0969509
 
-    ..[2] R. D. Nowak and R. G. Baraniuk.  Wavelet-based transformations for
-    nonlinear signal processing. IEEE Trans. Signal Process., vol. 47, no.
-    7, pp. 1852–1865, Jul. 1999.
-
-    ..[3] C. P. Rosiene and T. Q. Nguyen. "Tensor-product wavelet vs. Mallat
+    ..[2] C. P. Rosiene and T. Q. Nguyen. "Tensor-product wavelet vs. Mallat
     decomposition: A comparative analysis,” in Proc. IEEE Int. Symp. Circuits
     and Systems, Orlando, FL, Jun. 1999, pp. 431–434.
 
-    ..[4] V. Velisavljevic, B. Beferull-Lozano, M. Vetterli and P.L. Dragotti.
+    ..[3] V. Velisavljevic, B. Beferull-Lozano, M. Vetterli and P.L. Dragotti.
     Directionlets: Anisotropic Multidirectional Representation With Separable
     Filtering. IEEE TRANSACTIONS ON IMAGE PROCESSING, VOL. 15, NO. 7, JULY 2006
+
+    ..[4] R. A. DeVore, S. V. Konyagin, and V. N. Temlyakov. "Hyperbolic
+    wavelet approximation," Constr. Approx. 14 (1998), 1–26.
     """
     coeffs_arr = np.asarray(coeffs_arr)
     if axes is None:

--- a/pywt/_multilevel.py
+++ b/pywt/_multilevel.py
@@ -25,7 +25,7 @@ from ._utils import _as_wavelet, _wavelets_per_axis, _modes_per_axis
 __all__ = ['wavedec', 'waverec', 'wavedec2', 'waverec2', 'wavedecn',
            'waverecn', 'coeffs_to_array', 'array_to_coeffs', 'ravel_coeffs',
            'unravel_coeffs', 'dwtn_max_level', 'wavedecn_size',
-           'wavedecn_shapes', 'fswt', 'ifswt', 'TransformResult']
+           'wavedecn_shapes', 'fswt', 'ifswt', 'FswtResult']
 
 
 def _check_level(sizes, dec_lens, level):
@@ -1167,7 +1167,7 @@ def _check_fswt_axes(data, axes):
         raise ValueError("Axis greater than data dimensions")
 
 
-class TransformResult(object):
+class FswtResult(object):
     """Object representing fully separable wavelet transform coefficients.
 
     Parameters
@@ -1175,7 +1175,7 @@ class TransformResult(object):
     coeffs : ndarray
         The coefficient array.
     coeff_slices : dict
-        Dictionary of slices corresponding to each detail or approximatin
+        Dictionary of slices corresponding to each detail or approximation
         coefficient array.
     wavelets : list of pywt.DiscreteWavelet objects
         The wavelets used.  Will be a list with length equal to
@@ -1449,20 +1449,21 @@ def fswt(data, wavelet, mode='symmetric', levels=None, axes=None):
         # stack the coefficients from all levels into a single array
         coeffs_arr = np.concatenate(coeffs, axis=ax)
 
-    return TransformResult(coeffs_arr, coeff_slices, wavelets, modes, axes)
+    return FswtResult(coeffs_arr, coeff_slices, wavelets, modes, axes)
 
 
-def ifswt(transform_result):
+def ifswt(fswt_result):
     """Fully Separable Inverse Wavelet Transform.
 
     Parameters
     ----------
-    transform_result : TransformResult object
-        TransformResult object from ``fswt``.
+    fswt_result : FswtResult object
+        FswtResult object from ``fswt``.
 
     Returns
     -------
-    nD array of reconstructed data.
+    reconstructed : ndarray
+        Array of reconstructed data.
 
     Notes
     -----
@@ -1498,11 +1499,11 @@ def ifswt(transform_result):
     .. [4] RA DeVore, SV Konyagin and VN Temlyakov. "Hyperbolic wavelet
        approximation," Constr. Approx. 14 (1998), 1-26.
     """
-    coeffs_arr = transform_result.coeffs
-    coeff_slices = transform_result.coeff_slices
-    axes = transform_result.axes
-    modes = transform_result.modes
-    wavelets = transform_result.wavelets
+    coeffs_arr = fswt_result.coeffs
+    coeff_slices = fswt_result.coeff_slices
+    axes = fswt_result.axes
+    modes = fswt_result.modes
+    wavelets = fswt_result.wavelets
 
     _check_fswt_axes(coeffs_arr, axes)
     if len(axes) != len(coeff_slices):

--- a/pywt/_multilevel.py
+++ b/pywt/_multilevel.py
@@ -54,7 +54,7 @@ def wavedec(data, wavelet, mode='symmetric', level=None, axis=-1):
     wavelet : Wavelet object or name string
         Wavelet to use
     mode : str, optional
-        Signal extension mode, see Modes (default: 'symmetric')
+        Signal extension mode, see `Modes` (default: 'symmetric')
     level : int, optional
         Decomposition level (must be >= 0). If level is None (default) then it
         will be calculated using the `dwt_max_level` function.
@@ -116,7 +116,7 @@ def waverec(coeffs, wavelet, mode='symmetric', axis=-1):
     wavelet : Wavelet object or name string
         Wavelet to use
     mode : str, optional
-        Signal extension mode, see Modes (default: 'symmetric')
+        Signal extension mode, see `Modes` (default: 'symmetric')
     axis: int, optional
         Axis over which to compute the inverse DWT. If not given, the
         last axis is used.
@@ -181,7 +181,7 @@ def wavedec2(data, wavelet, mode='symmetric', level=None, axes=(-2, -1)):
         Wavelet to use.  This can also be a tuple containing a wavelet to
         apply along each axis in `axes`.
     mode : str or 2-tuple of str, optional
-        Signal extension mode, see Modes (default: 'symmetric').  This can
+        Signal extension mode, see `Modes` (default: 'symmetric').  This can
         also be a tuple containing a mode to apply along each axis in `axes`.
     level : int, optional
         Decomposition level (must be >= 0). If level is None (default) then it
@@ -255,7 +255,7 @@ def waverec2(coeffs, wavelet, mode='symmetric', axes=(-2, -1)):
         Wavelet to use.  This can also be a tuple containing a wavelet to
         apply along each axis in `axes`.
     mode : str or 2-tuple of str, optional
-        Signal extension mode, see Modes (default: 'symmetric').  This can
+        Signal extension mode, see `Modes` (default: 'symmetric').  This can
         also be a tuple containing a mode to apply along each axis in `axes`.
     axes : 2-tuple of ints, optional
         Axes over which to compute the IDWT. Repeated elements are not allowed.
@@ -356,7 +356,7 @@ def wavedecn(data, wavelet, mode='symmetric', level=None, axes=None):
         Wavelet to use.  This can also be a tuple containing a wavelet to
         apply along each axis in `axes`.
     mode : str or tuple of str, optional
-        Signal extension mode, see Modes (default: 'symmetric').  This can
+        Signal extension mode, see `Modes` (default: 'symmetric').  This can
         also be a tuple containing a mode to apply along each axis in `axes`.
     level : int, optional
         Decomposition level (must be >= 0). If level is None (default) then it
@@ -454,7 +454,7 @@ def waverecn(coeffs, wavelet, mode='symmetric', axes=None):
         Wavelet to use.  This can also be a tuple containing a wavelet to
         apply along each axis in `axes`.
     mode : str or tuple of str, optional
-        Signal extension mode, see Modes (default: 'symmetric').  This can
+        Signal extension mode, see `Modes` (default: 'symmetric').  This can
         also be a tuple containing a mode to apply along each axis in `axes`.
     axes : sequence of ints, optional
         Axes over which to compute the IDWT.  Axes may not be repeated.
@@ -1153,7 +1153,7 @@ def unravel_coeffs(arr, coeff_slices, coeff_shapes, output_format='wavedecn'):
 def _check_fswt_axes(data, axes):
     """axes checks common to fswt, ifswt. """
     if len(axes) != len(set(axes)):
-        raise ValueError("The axes passed to wavedecn must be unique.")
+        raise ValueError("The axes passed to fswt must be unique.")
     try:
         [data.shape[ax] for ax in axes]
     except IndexError:
@@ -1163,6 +1163,12 @@ def _check_fswt_axes(data, axes):
 def fswt(data, wavelet, mode='symmetric', levels=None, axes=None):
     """Fully Separable Wavelet Transform.
 
+    This is a variant of the multilevel discrete wavelet transform where all
+    levels of decomposition are performed along a single axis prior to moving
+    onto the next axis.  Unlike in ``wavedecn``, the number of levels of
+    decomposition are not required to be the same along each axis which can be
+    a benefit for anisotropic data.
+
     Parameters
     ----------
     data: array_like
@@ -1170,12 +1176,12 @@ def fswt(data, wavelet, mode='symmetric', levels=None, axes=None):
     wavelet : Wavelet object or name string
         Wavelet to use
     mode : str, optional
-        Signal extension mode, see Modes (default: 'symmetric')
+        Signal extension mode, see `Modes` (default: 'symmetric')
     levels : int or sequence of ints, optional
         Decomposition levels along each axis (must be >= 0). If an integer is
-        provided, the same number of levels are used for all axes.If ``levels``
-        is None (default), ``dwt_max_level`` will be used to compute the
-        maximum number of levels possible for each axis.
+        provided, the same number of levels are used for all axes. If
+        ``levels`` is None (default), `dwt_max_level` will be used to compute
+        the maximum number of levels possible for each axis.
     axes : sequence of ints, optional
         Axes over which to compute the FSWT. Axes may not be repeated.  The
         default is to transform along all axes.
@@ -1197,11 +1203,11 @@ def fswt(data, wavelet, mode='symmetric', levels=None, axes=None):
     Notes
     -----
     This transformation has been variously referred to as the (fully) separable
-    wavelet transform (e.g. refs _[1], _[3]), the tensor-product wavelet
-    (_[2]) or the hyperbolic wavelet transform (_[4]).  It is well suited to
+    wavelet transform (e.g. refs [1]_, [3]_), the tensor-product wavelet
+    ([2]_) or the hyperbolic wavelet transform ([4]_).  It is well suited to
     data with anisotropic smoothness.
 
-    In _[2] it was demonstrated that FSWT performs at least as well as the DWT
+    In [2]_ it was demonstrated that FSWT performs at least as well as the DWT
     for image compression.  Computation time is a factor 2 larger than that for
     the DWT.
 
@@ -1211,22 +1217,22 @@ def fswt(data, wavelet, mode='symmetric', levels=None, axes=None):
 
     References
     ----------
-    ..[1] PH Westerink. Subband Coding of Images. Ph.D. dissertation, Dept.
-    Elect. Eng., Inf. Theory Group, Delft Univ. Technol., Delft, The
-    Netherlands, 1989.  (see Section 2.3)
-    http://resolver.tudelft.nl/uuid:a4d195c3-1f89-4d66-913d-db9af0969509
+    .. [1] PH Westerink. Subband Coding of Images. Ph.D. dissertation, Dept.
+       Elect. Eng., Inf. Theory Group, Delft Univ. Technol., Delft, The
+       Netherlands, 1989.  (see Section 2.3)
+       http://resolver.tudelft.nl/uuid:a4d195c3-1f89-4d66-913d-db9af0969509
 
-    ..[2] CP Rosiene and TQ Nguyen. Tensor-product wavelet vs. Mallat
-    decomposition: A comparative analysis, in Proc. IEEE Int. Symp. Circuits
-    and Systems, Orlando, FL, Jun. 1999, pp. 431-434.
+    .. [2] CP Rosiene and TQ Nguyen. Tensor-product wavelet vs. Mallat
+       decomposition: A comparative analysis, in Proc. IEEE Int. Symp.
+       Circuits and Systems, Orlando, FL, Jun. 1999, pp. 431-434.
 
-    ..[3] V Velisavljevic, B Beferull-Lozano, M Vetterli and PL Dragotti.
-    Directionlets: Anisotropic Multidirectional Representation With Separable
-    Filtering. IEEE Transactions on Image Processing, Vol. 15, No. 7, July
-    2006.
+    .. [3] V Velisavljevic, B Beferull-Lozano, M Vetterli and PL Dragotti.
+       Directionlets: Anisotropic Multidirectional Representation With
+       Separable Filtering. IEEE Transactions on Image Processing, Vol. 15,
+       No. 7, July 2006.
 
-    ..[4] RA DeVore, SV Konyagin and VN Temlyakov. "Hyperbolic wavelet
-    approximation," Constr. Approx. 14 (1998), 1-26.
+    .. [4] RA DeVore, SV Konyagin and VN Temlyakov. "Hyperbolic wavelet
+       approximation," Constr. Approx. 14 (1998), 1-26.
     """
     data = np.asarray(data)
     if axes is None:
@@ -1262,8 +1268,6 @@ def ifswt(coeffs_arr, coeff_slices, wavelet, mode='symmetric', axes=None):
 
     Parameters
     ----------
-    Returns
-    -------
     coeffs_arr : array-like
         n-dimensional array of wavelet coefficients
     coeff_slices : list of lists
@@ -1275,7 +1279,7 @@ def ifswt(coeffs_arr, coeff_slices, wavelet, mode='symmetric', axes=None):
     wavelet : Wavelet object or name string
         Wavelet to use
     mode : str, optional
-        Signal extension mode, see Modes (default: 'symmetric')
+        Signal extension mode, see `Modes` (default: 'symmetric')
     axes : sequence of ints, optional
         Axes over which to compute the FSWT. Axes may not be repeated.  The
         default is to transform along all axes.
@@ -1291,14 +1295,13 @@ def ifswt(coeffs_arr, coeff_slices, wavelet, mode='symmetric', axes=None):
     Notes
     -----
     This transformation has been variously referred to as the (fully) separable
-    wavelet transform (e.g. refs _[1], _[3]), the tensor-product wavelet
-    (_[2]) or the hyperbolic wavelet transform (_[4]).  It is well suited to
+    wavelet transform (e.g. refs [1]_, [3]_), the tensor-product wavelet
+    ([2]_) or the hyperbolic wavelet transform ([4]_).  It is well suited to
     data with anisotropic smoothness.
 
-    In _[2] it was demonstrated that FSWT performs at least as well as the DWT
+    In [2]_ it was demonstrated that FSWT performs at least as well as the DWT
     for image compression.  Computation time is a factor 2 larger than that for
     the DWT.
-
 
     See Also
     --------
@@ -1306,22 +1309,22 @@ def ifswt(coeffs_arr, coeff_slices, wavelet, mode='symmetric', axes=None):
 
     References
     ----------
-    ..[1] PH Westerink. Subband Coding of Images. Ph.D. dissertation, Dept.
-    Elect. Eng., Inf. Theory Group, Delft Univ. Technol., Delft, The
-    Netherlands, 1989.  (see Section 2.3)
-    http://resolver.tudelft.nl/uuid:a4d195c3-1f89-4d66-913d-db9af0969509
+    .. [1] PH Westerink. Subband Coding of Images. Ph.D. dissertation, Dept.
+       Elect. Eng., Inf. Theory Group, Delft Univ. Technol., Delft, The
+       Netherlands, 1989.  (see Section 2.3)
+       http://resolver.tudelft.nl/uuid:a4d195c3-1f89-4d66-913d-db9af0969509
 
-    ..[2] CP Rosiene and TQ Nguyen. Tensor-product wavelet vs. Mallat
-    decomposition: A comparative analysis, in Proc. IEEE Int. Symp. Circuits
-    and Systems, Orlando, FL, Jun. 1999, pp. 431-434.
+    .. [2] CP Rosiene and TQ Nguyen. Tensor-product wavelet vs. Mallat
+       decomposition: A comparative analysis, in Proc. IEEE Int. Symp.
+       Circuits and Systems, Orlando, FL, Jun. 1999, pp. 431-434.
 
-    ..[3] V Velisavljevic, B Beferull-Lozano, M Vetterli and PL Dragotti.
-    Directionlets: Anisotropic Multidirectional Representation With Separable
-    Filtering. IEEE Transactions on Image Processing, Vol. 15, No. 7, July
-    2006.
+    .. [3] V Velisavljevic, B Beferull-Lozano, M Vetterli and PL Dragotti.
+       Directionlets: Anisotropic Multidirectional Representation With
+       Separable Filtering. IEEE Transactions on Image Processing, Vol. 15,
+       No. 7, July 2006.
 
-    ..[4] RA DeVore, SV Konyagin and VN Temlyakov. "Hyperbolic wavelet
-    approximation," Constr. Approx. 14 (1998), 1-26.
+    .. [4] RA DeVore, SV Konyagin and VN Temlyakov. "Hyperbolic wavelet
+       approximation," Constr. Approx. 14 (1998), 1-26.
     """
     coeffs_arr = np.asarray(coeffs_arr)
     if axes is None:

--- a/pywt/_multilevel.py
+++ b/pywt/_multilevel.py
@@ -1211,21 +1211,22 @@ def fswt(data, wavelet, mode='symmetric', levels=None, axes=None):
 
     References
     ----------
-    ..[1] P. H. Westerink. Subband Coding of Images. Ph.D. dissertation, Dept.
-    Elect. Eng., Inf. Theory Group, Delft Univ. Technol., Delft, The Nether-
-    lands, 1989.  (see Section 2.3)
+    ..[1] PH Westerink. Subband Coding of Images. Ph.D. dissertation, Dept.
+    Elect. Eng., Inf. Theory Group, Delft Univ. Technol., Delft, The
+    Netherlands, 1989.  (see Section 2.3)
     http://resolver.tudelft.nl/uuid:a4d195c3-1f89-4d66-913d-db9af0969509
 
-    ..[2] C. P. Rosiene and T. Q. Nguyen. "Tensor-product wavelet vs. Mallat
-    decomposition: A comparative analysis,” in Proc. IEEE Int. Symp. Circuits
-    and Systems, Orlando, FL, Jun. 1999, pp. 431–434.
+    ..[2] CP Rosiene and TQ Nguyen. "Tensor-product wavelet vs. Mallat
+    decomposition: A comparative analysis, in Proc. IEEE Int. Symp. Circuits
+    and Systems, Orlando, FL, Jun. 1999, pp. 431434.
 
-    ..[3] V. Velisavljevic, B. Beferull-Lozano, M. Vetterli and P.L. Dragotti.
+    ..[3] V Velisavljevic, B Beferull-Lozano, M Vetterli and PL Dragotti.
     Directionlets: Anisotropic Multidirectional Representation With Separable
-    Filtering. IEEE TRANSACTIONS ON IMAGE PROCESSING, VOL. 15, NO. 7, JULY 2006
+    Filtering. IEEE Transactions on Image Processing, Vol. 15, No. 7, July
+    2006.
 
-    ..[4] R. A. DeVore, S. V. Konyagin, and V. N. Temlyakov. "Hyperbolic
-    wavelet approximation," Constr. Approx. 14 (1998), 1–26.
+    ..[4] RA DeVore, SV Konyagin and VN Temlyakov. "Hyperbolic wavelet
+    approximation," Constr. Approx. 14 (1998), 126.
     """
     data = np.asarray(data)
     if axes is None:
@@ -1305,21 +1306,22 @@ def ifswt(coeffs_arr, coeff_slices, wavelet, mode='symmetric', axes=None):
 
     References
     ----------
-    ..[1] P. H. Westerink. Subband Coding of Images. Ph.D. dissertation, Dept.
-    Elect. Eng., Inf. Theory Group, Delft Univ. Technol., Delft, The Nether-
-    lands, 1989.  (see Section 2.3)
+    ..[1] PH Westerink. Subband Coding of Images. Ph.D. dissertation, Dept.
+    Elect. Eng., Inf. Theory Group, Delft Univ. Technol., Delft, The
+    Netherlands, 1989.  (see Section 2.3)
     http://resolver.tudelft.nl/uuid:a4d195c3-1f89-4d66-913d-db9af0969509
 
-    ..[2] C. P. Rosiene and T. Q. Nguyen. "Tensor-product wavelet vs. Mallat
-    decomposition: A comparative analysis,” in Proc. IEEE Int. Symp. Circuits
-    and Systems, Orlando, FL, Jun. 1999, pp. 431–434.
+    ..[2] CP Rosiene and TQ Nguyen. "Tensor-product wavelet vs. Mallat
+    decomposition: A comparative analysis, in Proc. IEEE Int. Symp. Circuits
+    and Systems, Orlando, FL, Jun. 1999, pp. 431434.
 
-    ..[3] V. Velisavljevic, B. Beferull-Lozano, M. Vetterli and P.L. Dragotti.
+    ..[3] V Velisavljevic, B Beferull-Lozano, M Vetterli and PL Dragotti.
     Directionlets: Anisotropic Multidirectional Representation With Separable
-    Filtering. IEEE TRANSACTIONS ON IMAGE PROCESSING, VOL. 15, NO. 7, JULY 2006
+    Filtering. IEEE Transactions on Image Processing, Vol. 15, No. 7, July
+    2006.
 
-    ..[4] R. A. DeVore, S. V. Konyagin, and V. N. Temlyakov. "Hyperbolic
-    wavelet approximation," Constr. Approx. 14 (1998), 1–26.
+    ..[4] RA DeVore, SV Konyagin and VN Temlyakov. "Hyperbolic wavelet
+    approximation," Constr. Approx. 14 (1998), 126.
     """
     coeffs_arr = np.asarray(coeffs_arr)
     if axes is None:

--- a/pywt/_multilevel.py
+++ b/pywt/_multilevel.py
@@ -1216,9 +1216,9 @@ def fswt(data, wavelet, mode='symmetric', levels=None, axes=None):
     Netherlands, 1989.  (see Section 2.3)
     http://resolver.tudelft.nl/uuid:a4d195c3-1f89-4d66-913d-db9af0969509
 
-    ..[2] CP Rosiene and TQ Nguyen. "Tensor-product wavelet vs. Mallat
+    ..[2] CP Rosiene and TQ Nguyen. Tensor-product wavelet vs. Mallat
     decomposition: A comparative analysis, in Proc. IEEE Int. Symp. Circuits
-    and Systems, Orlando, FL, Jun. 1999, pp. 431434.
+    and Systems, Orlando, FL, Jun. 1999, pp. 431-434.
 
     ..[3] V Velisavljevic, B Beferull-Lozano, M Vetterli and PL Dragotti.
     Directionlets: Anisotropic Multidirectional Representation With Separable
@@ -1226,7 +1226,7 @@ def fswt(data, wavelet, mode='symmetric', levels=None, axes=None):
     2006.
 
     ..[4] RA DeVore, SV Konyagin and VN Temlyakov. "Hyperbolic wavelet
-    approximation," Constr. Approx. 14 (1998), 126.
+    approximation," Constr. Approx. 14 (1998), 1-26.
     """
     data = np.asarray(data)
     if axes is None:
@@ -1311,9 +1311,9 @@ def ifswt(coeffs_arr, coeff_slices, wavelet, mode='symmetric', axes=None):
     Netherlands, 1989.  (see Section 2.3)
     http://resolver.tudelft.nl/uuid:a4d195c3-1f89-4d66-913d-db9af0969509
 
-    ..[2] CP Rosiene and TQ Nguyen. "Tensor-product wavelet vs. Mallat
+    ..[2] CP Rosiene and TQ Nguyen. Tensor-product wavelet vs. Mallat
     decomposition: A comparative analysis, in Proc. IEEE Int. Symp. Circuits
-    and Systems, Orlando, FL, Jun. 1999, pp. 431434.
+    and Systems, Orlando, FL, Jun. 1999, pp. 431-434.
 
     ..[3] V Velisavljevic, B Beferull-Lozano, M Vetterli and PL Dragotti.
     Directionlets: Anisotropic Multidirectional Representation With Separable
@@ -1321,7 +1321,7 @@ def ifswt(coeffs_arr, coeff_slices, wavelet, mode='symmetric', axes=None):
     2006.
 
     ..[4] RA DeVore, SV Konyagin and VN Temlyakov. "Hyperbolic wavelet
-    approximation," Constr. Approx. 14 (1998), 126.
+    approximation," Constr. Approx. 14 (1998), 1-26.
     """
     coeffs_arr = np.asarray(coeffs_arr)
     if axes is None:

--- a/pywt/_multilevel.py
+++ b/pywt/_multilevel.py
@@ -165,8 +165,9 @@ def waverec(coeffs, wavelet, mode='symmetric', axis=-1):
             except IndexError:
                 raise ValueError("Axis greater than coefficient dimensions")
             except AttributeError:
-                raise AttributeError("Wrong coefficient format, if using 'array_to_coeffs' please specify "
-                                     "the 'output_format' parameter")
+                raise AttributeError(
+                    "Wrong coefficient format, if using 'array_to_coeffs' "
+                    "please specify the 'output_format' parameter")
         a = idwt(a, d, wavelet, mode, axis)
 
     return a
@@ -1300,9 +1301,9 @@ class FswtResult(object):
 
         Parameters
         ----------
-            levels : tuple of int
-                The number of degrees of decomposition along each transformed
-                axis.
+        levels : tuple of int
+            The number of degrees of decomposition along each transformed
+            axis.
         """
         self._validate_index(levels)
         sl = self._get_coef_sl(levels)
@@ -1313,12 +1314,12 @@ class FswtResult(object):
 
         Parameters
         ----------
-            levels : tuple of int
-                The number of degrees of decomposition along each transformed
-                axis.
-            x : ndarray
-                The data corresponding to assign. It must match the expected
-                shape and dtype of the specified subband.
+        levels : tuple of int
+            The number of degrees of decomposition along each transformed
+            axis.
+        x : ndarray
+            The data corresponding to assign. It must match the expected
+            shape and dtype of the specified subband.
         """
         self._validate_index(levels)
         sl = self._get_coef_sl(levels)
@@ -1373,17 +1374,10 @@ def fswt(data, wavelet, mode='symmetric', levels=None, axes=None):
 
     Returns
     -------
-    coeffs_arr : array
-        n-dimensional array of wavelet coefficients
-    coeff_slices : list of list of slices
-        Lists of slice objects.  The first index corresponds to the transform
-        axes.  The list of slices for each axes has a length equal to the
-        number of levels.  Example:  The approximation coefficients for a 2D
-        transform correspond to:
-        ``a = coeffs_arr[coeff_slices[0][0], coeff_slices[1][0]]``
-        whereas detail coefficients for ``n`` levels of decomposition along the
-        first axis and ``m`` levels along the second would be given by:
-        ``dnm = coeffs_arr[coeff_slices[0][-n], coeff_slices[1][-m]]``
+    fswt_result : FswtResult object
+        Contains the wavelet coefficients, slice objects to allow obtaining
+        the coefficients per detail or approximation level, and more.
+        See `FswtResult` for details.
 
     Notes
     -----

--- a/pywt/_multilevel.py
+++ b/pywt/_multilevel.py
@@ -260,11 +260,7 @@ def waverec2(coeffs, wavelet, mode='symmetric', axes=(-2, -1)):
         apply along each axis in `axes`.
     mode : str or 2-tuple of str, optional
         Signal extension mode, see `Modes` (default: 'symmetric').  This can
-<<<<<<< HEAD
         also be a tuple containing a mode to apply along each axis in `axes`.
-=======
-        also be a tuple containing a mode to apply along each axis in ``axes``.
->>>>>>> 646e10b... use a TransformResults class to store the results of FSWT
     axes : 2-tuple of ints, optional
         Axes over which to compute the IDWT. Repeated elements are not allowed.
 
@@ -1345,7 +1341,7 @@ class FswavedecnResult(object):
 
 
 def fswavedecn(data, wavelet, mode='symmetric', levels=None, axes=None):
-    """Fully Separable Wavelet Transform.
+    """Fully Separable Wavelet Decomposition.
 
     This is a variant of the multilevel discrete wavelet transform where all
     levels of decomposition are performed along a single axis prior to moving
@@ -1369,7 +1365,7 @@ def fswavedecn(data, wavelet, mode='symmetric', levels=None, axes=None):
         ``levels`` is None (default), `dwt_max_level` will be used to compute
         the maximum number of levels possible for each axis.
     axes : sequence of ints, optional
-        Axes over which to compute the FSWT. Axes may not be repeated.  The
+        Axes over which to compute the transform. Axes may not be repeated. The
         default is to transform along all axes.
 
     Returns
@@ -1386,9 +1382,9 @@ def fswavedecn(data, wavelet, mode='symmetric', levels=None, axes=None):
     ([2]_) or the hyperbolic wavelet transform ([4]_).  It is well suited to
     data with anisotropic smoothness.
 
-    In [2]_ it was demonstrated that FSWT performs at least as well as the DWT
-    for image compression.  Computation time is a factor 2 larger than that for
-    the DWT.
+    In [2]_ it was demonstrated that fully separable transform performs at
+    least as well as the DWT for image compression.  Computation time is a
+    factor 2 larger than that for the DWT.
 
     See Also
     --------
@@ -1447,7 +1443,7 @@ def fswavedecn(data, wavelet, mode='symmetric', levels=None, axes=None):
 
 
 def fswaverecn(fswavedecn_result):
-    """Fully Separable Inverse Wavelet Transform.
+    """Fully Separable Inverse Wavelet Reconstruction.
 
     Parameters
     ----------
@@ -1466,9 +1462,9 @@ def fswaverecn(fswavedecn_result):
     ([2]_) or the hyperbolic wavelet transform ([4]_).  It is well suited to
     data with anisotropic smoothness.
 
-    In [2]_ it was demonstrated that FSWT performs at least as well as the DWT
-    for image compression. Computation time is a factor 2 larger than that for
-    the DWT.
+    In [2]_ it was demonstrated that the fully separable transform performs at
+    least as well as the DWT for image compression. Computation time is a
+    factor 2 larger than that for the DWT.
 
     See Also
     --------

--- a/pywt/_multilevel.py
+++ b/pywt/_multilevel.py
@@ -1222,6 +1222,8 @@ def fswt(data, wavelet, mode='symmetric', levels=None, axes=None):
         axes = tuple(np.arange(data.ndim))
     if levels is None or np.isscalar(levels):
         levels = [levels, ] * len(axes)
+    if len(levels) != len(axes):
+        raise ValueError("levels must match the length of the axes list")
     coeff_slices = [slice(None), ] * len(axes)
     coeffs_arr = data
     for ax_count, ax in enumerate(axes):
@@ -1313,12 +1315,12 @@ def ifswt(coeffs_arr, coeff_slices, wavelet, mode='symmetric', axes=None):
     if len(axes) != len(coeff_slices):
         raise ValueError("dimension mismatch")
     arr = coeffs_arr
-    csl = [slice(None), ] * len(axes)
+    csl = [slice(None), ] * arr.ndim
     for ax_count, ax in enumerate(axes):
         coeffs = []
-        for sl in coeff_slices[ax]:
-            csl[ax_count] = sl
+        for sl in coeff_slices[ax_count]:
+            csl[ax] = sl
             coeffs.append(arr[csl])
-        csl[ax_count] = slice(None)
+        csl[ax] = slice(None)
         arr = waverec(coeffs, wavelet, mode=mode, axis=ax)
     return arr

--- a/pywt/_multilevel.py
+++ b/pywt/_multilevel.py
@@ -1150,6 +1150,16 @@ def unravel_coeffs(arr, coeff_slices, coeff_shapes, output_format='wavedecn'):
     return coeffs
 
 
+def _check_fswt_axes(data, axes):
+    """axes checks common to fswt, ifswt. """
+    if len(axes) != len(set(axes)):
+        raise ValueError("The axes passed to wavedecn must be unique.")
+    try:
+        [data.shape[ax] for ax in axes]
+    except IndexError:
+        raise ValueError("Axis greater than data dimensions")
+
+
 def fswt(data, wavelet, mode='symmetric', levels=None, axes=None):
     """Fully Separable Wavelet Transform.
 
@@ -1220,6 +1230,8 @@ def fswt(data, wavelet, mode='symmetric', levels=None, axes=None):
     data = np.asarray(data)
     if axes is None:
         axes = tuple(np.arange(data.ndim))
+    _check_fswt_axes(data, axes)
+
     if levels is None or np.isscalar(levels):
         levels = [levels, ] * len(axes)
     if len(levels) != len(axes):
@@ -1312,8 +1324,10 @@ def ifswt(coeffs_arr, coeff_slices, wavelet, mode='symmetric', axes=None):
     coeffs_arr = np.asarray(coeffs_arr)
     if axes is None:
         axes = tuple(np.arange(coeffs_arr.ndim))
+    _check_fswt_axes(coeffs_arr, axes)
     if len(axes) != len(coeff_slices):
         raise ValueError("dimension mismatch")
+
     arr = coeffs_arr
     csl = [slice(None), ] * arr.ndim
     for ax_count, ax in enumerate(axes):

--- a/pywt/_multilevel.py
+++ b/pywt/_multilevel.py
@@ -10,7 +10,6 @@ and Inverse Discrete Wavelet Transform.
 
 from __future__ import division, print_function, absolute_import
 
-import warnings
 from copy import copy
 import numpy as np
 
@@ -23,7 +22,7 @@ from ._utils import _as_wavelet, _wavelets_per_axis, _modes_per_axis
 __all__ = ['wavedec', 'waverec', 'wavedec2', 'waverec2', 'wavedecn',
            'waverecn', 'coeffs_to_array', 'array_to_coeffs', 'ravel_coeffs',
            'unravel_coeffs', 'dwtn_max_level', 'wavedecn_size',
-           'wavedecn_shapes']
+           'wavedecn_shapes', 'fswt', 'ifswt']
 
 
 def _check_level(sizes, dec_lens, level):
@@ -1163,10 +1162,10 @@ def fswt(data, wavelet, mode='symmetric', levels=None, axes=None):
     mode : str, optional
         Signal extension mode, see Modes (default: 'symmetric')
     levels : int or sequence of ints, optional
-        Decomposition level (must be >= 0). If level is None (default) then it
-        will be calculated using the ``dwt_max_level`` function for each axis.
-        If an integer is provided, the same number of levels are used for all
-        axes.
+        Decomposition levels along each axis (must be >= 0). If an integer is
+        provided, the same number of levels are used for all axes.If ``levels``
+        is None (default), ``dwt_max_level`` will be used to compute the
+        maximum number of levels possible for each axis.
     axes : sequence of ints, optional
         Axes over which to compute the FSWT. Axes may not be repeated.  The
         default is to transform along all axes.
@@ -1181,8 +1180,8 @@ def fswt(data, wavelet, mode='symmetric', levels=None, axes=None):
         number of levels.  Example:  The approximation coefficients for a 2D
         transform correspond to:
         ``a = coeffs_arr[coeff_slices[0][0], coeff_slices[1][0]]``
-        whereas detail coefficients for `n` levels of decomposition along the
-        first axis and `m` levels along the second would be given by:
+        whereas detail coefficients for ``n`` levels of decomposition along the
+        first axis and ``m`` levels along the second would be given by:
         ``dnm = coeffs_arr[coeff_slices[0][n], coeff_slices[1][m]]``
 
     Notes
@@ -1253,7 +1252,11 @@ def ifswt(coeffs_arr, coeff_slices, wavelet, mode='symmetric', axes=None):
     coeffs_arr : array-like
         n-dimensional array of wavelet coefficients
     coeff_slices : list of lists
-        TODO
+        A list with length equal to the number signal dimensions.  Each element
+        is a list with length matching the number of transform levels along the
+        corresponding dimension.  In other words, ``coeff_slices[m][n]`` is a
+        slice for axis ``m`` of ``coeffs_arr`` that returns the coefficients
+        corresponding to level ``n``.
     wavelet : Wavelet object or name string
         Wavelet to use
     mode : str, optional

--- a/pywt/tests/test_multilevel.py
+++ b/pywt/tests/test_multilevel.py
@@ -846,7 +846,7 @@ def test_fswt_ifswt_roundtrip():
                 assert_(rec.dtype == dt_out)
 
 
-def test_fswt_ifswt_zero_levelS():
+def test_fswt_ifswt_zero_levels():
     # zero level transform gives coefs matching the original data
     rstate = np.random.RandomState(0)
     ndim = 2

--- a/pywt/tests/test_multilevel.py
+++ b/pywt/tests/test_multilevel.py
@@ -8,7 +8,7 @@ import numpy as np
 from numpy.testing import (run_module_suite, assert_almost_equal,
                            assert_allclose, assert_, assert_equal,
                            assert_raises, assert_raises_regex, dec,
-                           assert_array_equal)
+                           assert_array_equal, assert_warns)
 import pywt
 # Check that float32, float64, complex64, complex128 are preserved.
 # Other real types get converted to float64.
@@ -872,8 +872,8 @@ def test_fswt_ifswt_variable_levels():
     assert_raises(ValueError, pywt.fswt, data, 'haar', levels=(1, 1, 1, 1))
 
     # levels too large for array size
-    assert_raises(ValueError, pywt.fswt, data, 'haar',
-                  levels=np.log2(np.min(data.shape))+1)
+    assert_warns(UserWarning, pywt.fswt, data, 'haar',
+                 levels=int(np.log2(np.min(data.shape)))+1)
 
 
 def test_fswt_ifswt_variable_wavelets_and_modes():

--- a/pywt/tests/test_multilevel.py
+++ b/pywt/tests/test_multilevel.py
@@ -875,6 +875,29 @@ def test_fswt_ifswt_variable_levels():
                   levels=np.log2(np.min(data.shape))+1)
 
 
+def test_fswt_ifswt_variable_wavelets_and_modes():
+    # test with differing number of transform levels per axis
+    rstate = np.random.RandomState(0)
+    ndim = 3
+    data = rstate.standard_normal((16, )*ndim)
+    wavelets = ('haar', 'db2', 'sym3')
+    modes = ('periodic', 'symmetric', 'periodization')
+    coefs, coef_slices = pywt.fswt(data, wavelet=wavelets, mode=modes)
+    for ax in range(ndim):
+        # expect approx + dwt_max_level detail coeffs along each axis
+        assert_equal(len(coef_slices[ax]),
+                     pywt.dwt_max_level(data.shape[ax], wavelets[ax])+1)
+
+    rec = pywt.ifswt(coefs, coef_slices, wavelet=wavelets, mode=modes)
+    assert_allclose(rec, data, atol=1e-14)
+
+    # number of wavelets doesn't match number of axes
+    assert_raises(ValueError, pywt.fswt, data, wavelets[:2])
+
+    # number of modes doesn't match number of axes
+    assert_raises(ValueError, pywt.fswt, data, wavelets[0], mode=modes[:2])
+
+
 def test_fswt_ifswt_axes_subsets():
     """Fully separable DWT over only a subset of axes"""
     rstate = np.random.RandomState(0)

--- a/pywt/tests/test_multilevel.py
+++ b/pywt/tests/test_multilevel.py
@@ -838,7 +838,7 @@ def test_fswt_ifswt_roundtrip():
                 data = data.astype(dt_in)
                 coefs, coef_slices = pywt.fswt(data, 'haar', levels=levels)
                 rec = pywt.ifswt(coefs, coef_slices, 'haar')
-                if data.real.dtype == np.float32:
+                if data.real.dtype in [np.float32, np.float16]:
                     assert_allclose(rec, data, rtol=1e-7, atol=1e-6)
                 else:
                     assert_allclose(rec, data, rtol=1e-14, atol=1e-14)

--- a/pywt/tests/test_multilevel.py
+++ b/pywt/tests/test_multilevel.py
@@ -828,7 +828,7 @@ def test_per_axis_wavelets_and_modes():
 # Tests for fully separable multi-level transforms
 
 
-def test_fswt_ifswt_roundtrip():
+def test_fswavedecn_fswaverecn_roundtrip():
     # verify proper round trip result for 1D through 4D data
     # same DWT as wavedecn/waverecn so don't need to test all modes/wavelets
     rstate = np.random.RandomState(0)
@@ -837,8 +837,8 @@ def test_fswt_ifswt_roundtrip():
             for levels in (1, None):
                 data = rstate.standard_normal((8, )*ndim)
                 data = data.astype(dt_in)
-                T = pywt.fswt(data, 'haar', levels=levels)
-                rec = pywt.ifswt(T)
+                T = pywt.fswavedecn(data, 'haar', levels=levels)
+                rec = pywt.fswaverecn(T)
                 if data.real.dtype in [np.float32, np.float16]:
                     assert_allclose(rec, data, rtol=1e-6, atol=1e-6)
                 else:
@@ -847,71 +847,71 @@ def test_fswt_ifswt_roundtrip():
                 assert_(rec.dtype == dt_out)
 
 
-def test_fswt_ifswt_zero_levels():
+def test_fswavedecn_fswaverecn_zero_levels():
     # zero level transform gives coefs matching the original data
     rstate = np.random.RandomState(0)
     ndim = 2
     data = rstate.standard_normal((8, )*ndim)
-    T = pywt.fswt(data, 'haar', levels=0)
+    T = pywt.fswavedecn(data, 'haar', levels=0)
     assert_array_equal(T.coeffs, data)
-    rec = pywt.ifswt(T)
+    rec = pywt.fswaverecn(T)
     assert_array_equal(T.coeffs, rec)
 
 
-def test_fswt_ifswt_variable_levels():
+def test_fswavedecn_fswaverecn_variable_levels():
     # test with differing number of transform levels per axis
     rstate = np.random.RandomState(0)
     ndim = 3
     data = rstate.standard_normal((16, )*ndim)
-    T = pywt.fswt(data, 'haar', levels=(1, 2, 3))
-    rec = pywt.ifswt(T)
+    T = pywt.fswavedecn(data, 'haar', levels=(1, 2, 3))
+    rec = pywt.fswaverecn(T)
     assert_allclose(rec, data, atol=1e-14)
 
     # levels doesn't match number of axes
-    assert_raises(ValueError, pywt.fswt, data, 'haar', levels=(1, 1))
-    assert_raises(ValueError, pywt.fswt, data, 'haar', levels=(1, 1, 1, 1))
+    assert_raises(ValueError, pywt.fswavedecn, data, 'haar', levels=(1, 1))
+    assert_raises(ValueError, pywt.fswavedecn, data, 'haar', levels=(1, 1, 1, 1))
 
     # levels too large for array size
-    assert_warns(UserWarning, pywt.fswt, data, 'haar',
+    assert_warns(UserWarning, pywt.fswavedecn, data, 'haar',
                  levels=int(np.log2(np.min(data.shape)))+1)
 
 
-def test_fswt_ifswt_variable_wavelets_and_modes():
+def test_fswavedecn_fswaverecn_variable_wavelets_and_modes():
     # test with differing number of transform levels per axis
     rstate = np.random.RandomState(0)
     ndim = 3
     data = rstate.standard_normal((16, )*ndim)
     wavelets = ('haar', 'db2', 'sym3')
     modes = ('periodic', 'symmetric', 'periodization')
-    T = pywt.fswt(data, wavelet=wavelets, mode=modes)
+    T = pywt.fswavedecn(data, wavelet=wavelets, mode=modes)
     for ax in range(ndim):
         # expect approx + dwt_max_level detail coeffs along each axis
         assert_equal(len(T.coeff_slices[ax]),
                      pywt.dwt_max_level(data.shape[ax], wavelets[ax])+1)
 
-    rec = pywt.ifswt(T)
+    rec = pywt.fswaverecn(T)
     assert_allclose(rec, data, atol=1e-14)
 
     # number of wavelets doesn't match number of axes
-    assert_raises(ValueError, pywt.fswt, data, wavelets[:2])
+    assert_raises(ValueError, pywt.fswavedecn, data, wavelets[:2])
 
     # number of modes doesn't match number of axes
-    assert_raises(ValueError, pywt.fswt, data, wavelets[0], mode=modes[:2])
+    assert_raises(ValueError, pywt.fswavedecn, data, wavelets[0], mode=modes[:2])
 
 
-def test_fswt_ifswt_axes_subsets():
+def test_fswavedecn_fswaverecn_axes_subsets():
     """Fully separable DWT over only a subset of axes"""
     rstate = np.random.RandomState(0)
     # use anisotropic data to result in unique number of levels per axis
     data = rstate.standard_normal((4, 8, 16, 32))
     # test all combinations of 3 out of 4 axes transformed
     for axes in combinations((0, 1, 2, 3), 3):
-        T = pywt.fswt(data, 'haar', axes=axes)
-        rec = pywt.ifswt(T)
+        T = pywt.fswavedecn(data, 'haar', axes=axes)
+        rec = pywt.fswaverecn(T)
         assert_allclose(rec, data, atol=1e-14)
 
     # some axes exceed data dimensions
-    assert_raises(ValueError, pywt.fswt, data, 'haar', axes=(1, 5))
+    assert_raises(ValueError, pywt.fswavedecn, data, 'haar', axes=(1, 5))
 
 
 def test_error_on_continuous_wavelet():

--- a/pywt/tests/test_swt.py
+++ b/pywt/tests/test_swt.py
@@ -406,9 +406,9 @@ def test_per_axis_wavelets():
     assert_raises(ValueError, pywt.swtn, data, wavelets[:2], level)
     assert_raises(ValueError, pywt.iswtn, coefs, wavelets[:2])
 
-    # swt2/iswt2 also support per-axis wavelets/modes
     with warnings.catch_warnings():
         warnings.simplefilter('ignore', FutureWarning)
+        # swt2/iswt2 also support per-axis wavelets/modes
         data2 = data[..., 0]
         coefs2 = pywt.swt2(data2, wavelets[:2], level)
         assert_allclose(pywt.iswt2(coefs2, wavelets[:2]), data2, atol=1e-14)


### PR DESCRIPTION
This PR implements an alternative multi-level discrete wavelet transform for n-dimensional signals.  The two new functions added are `fswt` and `ifswt`, corresponding to the forward and inverse fully separable wavelet transform.

It differs from `wavedecn` in that it applies all levels of decomposition along a single axis before moving on to the next axis.  This variant has been named the "fully separable wavelet transform", "tensor wavelet transform" or "hyperbolic wavelet transform" and has advantages over the standard isotropic (Mallat) decomposition for anisotropic data.

I wanted to gauge whether there is interest in having this functionality in PyWavelets.  There is a summary of various publications on this technique here:
http://www.laurent-duval.eu/siva-wits-wavelet-anisotropic-non-standard-square-rectangular.html

The images below (with coefficients scaled up for visibility) illustrate the difference (4-level decomposition shown).

![dwt_types](https://cloud.githubusercontent.com/assets/6528957/19195945/93ee9d62-8c81-11e6-971f-fecca8401dc9.png)

TODO:
- [x] add tests
- [x] add example
- [x] return a transform object instead of 2 separate outputs
- [x] extend per-axis wavelet/mode support to fswt, ifswt
