### PR TITLE
fix dwtn/idwtn with axes != None and complex data

### DIFF
--- a/pywt/_multidim.py
+++ b/pywt/_multidim.py
@@ -153,10 +153,9 @@ def dwtn(data, wavelet, mode='symmetric', axes=None):
     """
     data = np.asarray(data)
     if np.iscomplexobj(data):
-        keys = (''.join(k) for k in product('ad', repeat=data.ndim))
-        real = dwtn(data.real, wavelet, mode)
-        imag = dwtn(data.imag, wavelet, mode)
-        return dict((k, real[k] + 1j * imag[k]) for k in keys)
+        real = dwtn(data.real, wavelet, mode, axes)
+        imag = dwtn(data.imag, wavelet, mode, axes)
+        return dict((k, real[k] + 1j * imag[k]) for k in real.keys())
 
     if data.dtype == np.dtype('object'):
         raise TypeError("Input must be a numeric array-like")
@@ -243,8 +242,8 @@ def idwtn(coeffs, wavelet, mode='symmetric', axes=None):
     if any(np.iscomplexobj(v) for v in coeffs.values()):
         real_coeffs = dict((k, v.real) for k, v in coeffs.items())
         imag_coeffs = dict((k, v.imag) for k, v in coeffs.items())
-        return (idwtn(real_coeffs, wavelet, mode)
-                + 1j * idwtn(imag_coeffs, wavelet, mode))
+        return (idwtn(real_coeffs, wavelet, mode, axes) +
+                1j * idwtn(imag_coeffs, wavelet, mode, axes))
 
     ndim = max(len(key) for key in coeffs.keys())
 

--- a/pywt/tests/test_multidim.py
+++ b/pywt/tests/test_multidim.py
@@ -243,7 +243,7 @@ def test_dwtn_axes():
     data = np.array([[0, 1, 2, 3],
                      [1, 1, 1, 1],
                      [1, 4, 2, 8]])
-
+    data = data + 1j*data  # test with complex data
     coefs = pywt.dwtn(data, 'haar', axes=(1,))
     expected_a = list(map(lambda x: pywt.dwt(x, 'haar')[0], data))
     assert_equal(coefs['a'], expected_a)
@@ -261,6 +261,7 @@ def test_idwtn_axes():
     data = np.array([[0, 1, 2, 3],
                      [1, 1, 1, 1],
                      [1, 4, 2, 8]])
+    data = data + 1j*data  # test with complex data
     coefs = pywt.dwtn(data, 'haar', axes=(1, 1))
     assert_allclose(pywt.idwtn(coefs, 'haar', axes=(1, 1)), data, atol=1e-14)
 


### PR DESCRIPTION
This fixes a bug with `dwtn` and `idwtn` axes support present in v0.4.0 and current master.  If the data was complex, the axes argument was not getting passed along properly!

I updated two tests to use complex data.  These fail on current master and pass with this PR.