### PR TITLE
document coeff_to_array and array_to_coeff

### DIFF
--- a/doc/source/ref/dwt-coefficient-handling.rst
+++ b/doc/source/ref/dwt-coefficient-handling.rst
@@ -1,0 +1,20 @@
+.. _ref-dwt-coef:
+.. include:: ../substitutions.rst
+
+=========================
+Handling DWT Coefficients
+=========================
+
+Convenience routines are available for converting the outputs of the multilevel
+dwt functions (``wavedec``, ``wavedec2`` and ``wavedecn``) to and from a
+single, concatenated coefficient array.
+
+.. currentmodule:: pywt
+
+Concatenating all coefficients into a single array
+--------------------------------------------------
+.. autofunction:: coeffs_to_array
+
+Splitting concatenated coefficient array back into its components
+-----------------------------------------------------------------
+.. autofunction:: array_to_coeffs

--- a/doc/source/ref/index.rst
+++ b/doc/source/ref/index.rst
@@ -12,6 +12,7 @@ API Reference
    idwt-inverse-discrete-wavelet-transform
    2d-dwt-and-idwt
    nd-dwt-and-idwt
+   dwt-coefficient-handling
    swt-stationary-wavelet-transform
    wavelet-packets
    thresholding-functions

--- a/pywt/_multilevel.py
+++ b/pywt/_multilevel.py
@@ -817,6 +817,7 @@ def array_to_coeffs(arr, coeff_slices, output_format='wavedecn'):
     Examples
     --------
     >>> import pywt
+    >>> from numpy.testing import assert_array_almost_equal
     >>> cam = pywt.data.camera()
     >>> coeffs = pywt.wavedecn(cam, wavelet='db2', level=3)
     >>> arr, coeff_slices = pywt.coeffs_to_array(coeffs)

--- a/pywt/_multilevel.py
+++ b/pywt/_multilevel.py
@@ -691,6 +691,7 @@ def coeffs_to_array(coeffs, padding=0):
 
     Examples
     --------
+    >>> import pywt
     >>> cam = pywt.data.camera()
     >>> coeffs = pywt.wavedecn(cam, wavelet='db2', level=3)
     >>> arr, coeff_slices = pywt.coeffs_to_array(coeffs)
@@ -815,6 +816,7 @@ def array_to_coeffs(arr, coeff_slices, output_format='wavedecn'):
 
     Examples
     --------
+    >>> import pywt
     >>> cam = pywt.data.camera()
     >>> coeffs = pywt.wavedecn(cam, wavelet='db2', level=3)
     >>> arr, coeff_slices = pywt.coeffs_to_array(coeffs)

--- a/pywt/_multilevel.py
+++ b/pywt/_multilevel.py
@@ -660,6 +660,9 @@ def coeffs_to_array(coeffs, padding=0):
         `coeff_arr[coeff_slices[1]['dd']]` would extract the first level detail
         coefficients from `coeff_arr`.
 
+    See Also
+    --------
+    array_to_coeffs : the inverse of coeffs_to_array
 
     Notes
     -----
@@ -672,11 +675,11 @@ def coeffs_to_array(coeffs, padding=0):
     |               |               |                               |
     |     c[0]      |  c[1]['da']   |                               |
     |               |               |                               |
-    ----------------+---------------+           c[2]['da']          |
+    +---------------+---------------+           c[2]['da']          |
     |               |               |                               |
     | c[1]['ad']    |  c[1]['dd']   |                               |
     |               |               |                               |
-    ----------------+---------------+ ------------------------------+
+    +---------------+---------------+ ------------------------------+
     |                               |                               |
     |                               |                               |
     |                               |                               |
@@ -684,17 +687,14 @@ def coeffs_to_array(coeffs, padding=0):
     |                               |                               |
     |                               |                               |
     |                               |                               |
-    --------------------------------+-------------------------------+
-
-    See Also
-    --------
-    array_to_coeffs : the inverse of coeffs_to_array
+    +-------------------------------+-------------------------------+
 
     Examples
     --------
-    cam = pywt.data.camera()
-    coeffs = pywt.wavedecn(cam, wavelet='db2', level=3)
-    arr, coeff_slices = pywt.coeffs_to_array(coeffs)
+    >>> cam = pywt.data.camera()
+    >>> coeffs = pywt.wavedecn(cam, wavelet='db2', level=3)
+    >>> arr, coeff_slices = pywt.coeffs_to_array(coeffs)
+
     """
     if not isinstance(coeffs, list) or len(coeffs) == 0:
         raise ValueError("input must be a list of coefficients from wavedecn")
@@ -799,11 +799,11 @@ def array_to_coeffs(arr, coeff_slices, output_format='wavedecn'):
     |               |               |                               |
     |     c[0]      |  c[1]['da']   |                               |
     |               |               |                               |
-    ----------------+---------------+           c[2]['da']          |
+    +---------------+---------------+           c[2]['da']          |
     |               |               |                               |
     | c[1]['ad']    |  c[1]['dd']   |                               |
     |               |               |                               |
-    ----------------+---------------+ ------------------------------+
+    +---------------+---------------+ ------------------------------+
     |                               |                               |
     |                               |                               |
     |                               |                               |
@@ -811,16 +811,16 @@ def array_to_coeffs(arr, coeff_slices, output_format='wavedecn'):
     |                               |                               |
     |                               |                               |
     |                               |                               |
-    --------------------------------+-------------------------------+
+    +-------------------------------+-------------------------------+
 
     Examples
     --------
-    cam = pywt.data.camera()
-    coeffs = pywt.wavedecn(cam, wavelet='db2', level=3)
-    arr, coeff_slices = pywt.coeffs_to_array(coeffs)
-    coeffs_from_arr = pywt.array_to_coeffs(arr, coeff_slices)
-    cam_recon = pywt.waverecn(coeffs_from_arr, wavelet='db2')
-    assert_array_almost_equal(cam, cam_recon)
+    >>> cam = pywt.data.camera()
+    >>> coeffs = pywt.wavedecn(cam, wavelet='db2', level=3)
+    >>> arr, coeff_slices = pywt.coeffs_to_array(coeffs)
+    >>> coeffs_from_arr = pywt.array_to_coeffs(arr, coeff_slices)
+    >>> cam_recon = pywt.waverecn(coeffs_from_arr, wavelet='db2')
+    >>> assert_array_almost_equal(cam, cam_recon)
 
     """
     arr = np.asarray(arr)


### PR DESCRIPTION
The coefficient tables are easier to read in ASCII than in the sphinx rendering.  It would be nice if the HTML table showed lines at the table borders and between all cells, but I'm not sure if that's possible.