### PR TITLE
FIX: update several doctests to reflect the new wavelets added

### DIFF
--- a/doc/source/ref/wavelets.rst
+++ b/doc/source/ref/wavelets.rst
@@ -142,6 +142,8 @@ Built-in wavelets - ``wavelist()``
       Orthogonal:     True
       Biorthogonal:   True
       Symmetry:       asymmetric
+      DWT:            True
+      CWT:            False
     >>> print(format_array(wavelet.dec_lo), format_array(wavelet.dec_hi))
     [0.70710678118655, 0.70710678118655] [-0.70710678118655, 0.70710678118655]
     >>> print(format_array(wavelet.rec_lo), format_array(wavelet.rec_hi))

--- a/doc/source/regression/dwt-idwt.rst
+++ b/doc/source/regression/dwt-idwt.rst
@@ -74,10 +74,10 @@ extension mode (please refer to the PyWavelets' documentation for the
 :ref:`extension modes <Modes>` available:
 
     >>> pywt.Modes.modes
-    ['zero', 'constant', 'symmetric', 'periodic', 'smooth', 'periodization']
+    ['zero', 'constant', 'symmetric', 'reflect', 'periodic', 'smooth', 'periodization']
 
     >>> [int(pywt.dwt_coeff_len(len(x), w.dec_len, mode)) for mode in pywt.Modes.modes]
-    [6, 6, 6, 6, 6, 4]
+    [6, 6, 6, 6, 6, 6, 4]
 
 As you see in the above example, the :ref:`periodization <Modes.periodization>`
 (periodization) mode is slightly different from the others. It's aim when

--- a/doc/source/regression/modes.rst
+++ b/doc/source/regression/modes.rst
@@ -19,43 +19,7 @@ Import :mod:`pywt` first
 List of available signal extension :ref:`modes <Modes>`:
 
     >>> print(pywt.Modes.modes)
-    ['zero', 'constant', 'symmetric', 'periodic', 'smooth', 'periodization']
-
-
-Test that :func:`dwt` and :func:`idwt` can be performed using every mode:
-
-    >>> x = [1,2,1,5,-1,8,4,6]
-    >>> for mode in pywt.Modes.modes:
-    ...     cA, cD = pywt.dwt(x, 'db2', mode)
-    ...     print("Mode: %s" % mode)
-    ...     print("cA: " + format_array(cA))
-    ...     print("cD: " + format_array(cD))
-    ...     print("Reconstruction: " + format_array(
-    ...         pywt.idwt(cA, cD, 'db2', mode)))
-    Mode: zero
-    cA: [-0.03468  1.73309  3.40612  6.32929  6.95095]
-    cD: [-0.12941 -2.156   -5.95035 -1.21545 -1.8625 ]
-    Reconstruction: [ 1.  2.  1.  5. -1.  8.  4.  6.]
-    Mode: constant
-    cA: [ 1.2848   1.73309  3.40612  6.32929  7.51936]
-    cD: [-0.48296 -2.156   -5.95035 -1.21545  0.25882]
-    Reconstruction: [ 1.  2.  1.  5. -1.  8.  4.  6.]
-    Mode: symmetric
-    cA: [ 1.76777  1.73309  3.40612  6.32929  7.77817]
-    cD: [-0.61237 -2.156   -5.95035 -1.21545  1.22474]
-    Reconstruction: [ 1.  2.  1.  5. -1.  8.  4.  6.]
-    Mode: periodic
-    cA: [ 6.91627  1.73309  3.40612  6.32929  6.91627]
-    cD: [-1.99191 -2.156   -5.95035 -1.21545 -1.99191]
-    Reconstruction: [ 1.  2.  1.  5. -1.  8.  4.  6.]
-    Mode: smooth
-    cA: [-0.51764  1.73309  3.40612  6.32929  7.45001]
-    cD: [ 0.      -2.156   -5.95035 -1.21545  0.     ]
-    Reconstruction: [ 1.  2.  1.  5. -1.  8.  4.  6.]
-    Mode: periodization
-    cA: [ 4.05317  3.05257  2.85381  8.42522]
-    cD: [ 0.18947  4.18258  4.33738  2.60428]
-    Reconstruction: [ 1.  2.  1.  5. -1.  8.  4.  6.]
+    ['zero', 'constant', 'symmetric', 'reflect', 'periodic', 'smooth', 'periodization']
 
 
 Invalid mode name should rise a :exc:`ValueError`:
@@ -68,38 +32,18 @@ Invalid mode name should rise a :exc:`ValueError`:
 
 You can also refer to modes via :ref:`Modes <Modes>` class attributes:
 
-    >>> for mode_name in ['zero', 'constant', 'symmetric', 'periodic', 'smooth', 'periodization']:
+    >>> x = [1, 2, 1, 5, -1, 8, 4, 6]
+    >>> for mode_name in ['zero', 'constant', 'symmetric', 'reflect', 'periodic', 'smooth', 'periodization']:
     ...     mode = getattr(pywt.Modes, mode_name)
-    ...     cA, cD = pywt.dwt([1,2,1,5,-1,8,4,6], 'db2', mode)
+    ...     cA, cD = pywt.dwt(x, 'db2', mode)
     ...     print("Mode: %d (%s)" % (mode, mode_name))
-    ...     print("cA: " + format_array(cA))
-    ...     print("cD: " + format_array(cD))
-    ...     print("Reconstruction: " + format_array(
-    ...         pywt.idwt(cA, cD, 'db2', mode)))
     Mode: 0 (zero)
-    cA: [-0.03468  1.73309  3.40612  6.32929  6.95095]
-    cD: [-0.12941 -2.156   -5.95035 -1.21545 -1.8625 ]
-    Reconstruction: [ 1.  2.  1.  5. -1.  8.  4.  6.]
     Mode: 2 (constant)
-    cA: [ 1.2848   1.73309  3.40612  6.32929  7.51936]
-    cD: [-0.48296 -2.156   -5.95035 -1.21545  0.25882]
-    Reconstruction: [ 1.  2.  1.  5. -1.  8.  4.  6.]
     Mode: 1 (symmetric)
-    cA: [ 1.76777  1.73309  3.40612  6.32929  7.77817]
-    cD: [-0.61237 -2.156   -5.95035 -1.21545  1.22474]
-    Reconstruction: [ 1.  2.  1.  5. -1.  8.  4.  6.]
+    Mode: 6 (reflect)
     Mode: 4 (periodic)
-    cA: [ 6.91627  1.73309  3.40612  6.32929  6.91627]
-    cD: [-1.99191 -2.156   -5.95035 -1.21545 -1.99191]
-    Reconstruction: [ 1.  2.  1.  5. -1.  8.  4.  6.]
     Mode: 3 (smooth)
-    cA: [-0.51764  1.73309  3.40612  6.32929  7.45001]
-    cD: [ 0.      -2.156   -5.95035 -1.21545  0.     ]
-    Reconstruction: [ 1.  2.  1.  5. -1.  8.  4.  6.]
     Mode: 5 (periodization)
-    cA: [ 4.05317  3.05257  2.85381  8.42522]
-    cD: [ 0.18947  4.18258  4.33738  2.60428]
-    Reconstruction: [ 1.  2.  1.  5. -1.  8.  4.  6.]
 
 
 The default mode is :ref:`symmetric <Modes.symmetric>`:

--- a/doc/source/regression/wavelet.rst
+++ b/doc/source/regression/wavelet.rst
@@ -164,34 +164,32 @@ Now when we know a bit about the builtin Wavelets, let's see how to create
 Note that such custom wavelets **will not** have all the properties set
 to correct values:
 
-    .. TODO: fix this doctest
-    .. >>> print(my_wavelet)
-    .. Wavelet My Haar Wavelet
-    ..   Family name:
-    ..   Short name:
-    ..   Filters length: 2
-    ..   Orthogonal:     False
-    ..   Biorthogonal:   False
-    ..   Symmetry:       unknown
-    ..   DWT:            True
-    ..   CWT:            False
+    >>> print(my_wavelet)
+    Wavelet My Haar Wavelet
+      Family name:
+      Short name:
+      Filters length: 2
+      Orthogonal:     False
+      Biorthogonal:   False
+      Symmetry:       unknown
+      DWT:            True
+      CWT:            False
 
-    You can however set a few of them on your own:
+    You can however set a couple of them on your own:
 
-    .. >>> my_wavelet.orthogonal = True
-    .. >>> my_wavelet.biorthogonal = True
+    >>> my_wavelet.orthogonal = True
+    >>> my_wavelet.biorthogonal = True
 
-    .. TODO: fix this doctest
-    .. >>> print(my_wavelet)
-    .. Wavelet My Haar Wavelet
-    ..   Family name:
-    ..   Short name:
-    ..   Filters length: 2
-    ..   Orthogonal:     True
-    ..   Biorthogonal:   True
-    ..   Symmetry:       unknown
-    ..   DWT:            True
-    ..   CWT:            False
+    >>> print(my_wavelet)
+    Wavelet My Haar Wavelet
+      Family name:
+      Short name:
+      Filters length: 2
+      Orthogonal:     True
+      Biorthogonal:   True
+      Symmetry:       unknown
+      DWT:            True
+      CWT:            False
 
 And now... the `wavefun`!
 -------------------------

--- a/doc/source/regression/wavelet.rst
+++ b/doc/source/regression/wavelet.rst
@@ -20,7 +20,7 @@ commonly used families are:
 
     >>> import pywt
     >>> pywt.families()
-    ['haar', 'db', 'sym', 'coif', 'bior', 'rbio', 'dmey']
+    ['haar', 'db', 'sym', 'coif', 'bior', 'rbio', 'dmey', 'gaus', 'mexh', 'morl', 'cgau', 'shan', 'fbsp', 'cmor']
 
 The :func:`wavelist` function with family name passed as an argument is used to
 obtain the list of wavelet names in each family.
@@ -28,18 +28,22 @@ obtain the list of wavelet names in each family.
     >>> for family in pywt.families():
     ...     print("%s family: " % family + ', '.join(pywt.wavelist(family)))
     haar family: haar
-    db family: db1, db2, db3, db4, db5, db6, db7, db8, db9, db10, db11, db12, db13, db14, db15, db16, db17, db18, db19, db20
+    db family: db1, db2, db3, db4, db5, db6, db7, db8, db9, db10, db11, db12, db13, db14, db15, db16, db17, db18, db19, db20, db21, db22, db23, db24, db25, db26, db27, db28, db29, db30, db31, db32, db33, db34, db35, db36, db37, db38
     sym family: sym2, sym3, sym4, sym5, sym6, sym7, sym8, sym9, sym10, sym11, sym12, sym13, sym14, sym15, sym16, sym17, sym18, sym19, sym20
-    coif family: coif1, coif2, coif3, coif4, coif5
+    coif family: coif1, coif2, coif3, coif4, coif5, coif6, coif7, coif8, coif9, coif10, coif11, coif12, coif13, coif14, coif15, coif16, coif17
     bior family: bior1.1, bior1.3, bior1.5, bior2.2, bior2.4, bior2.6, bior2.8, bior3.1, bior3.3, bior3.5, bior3.7, bior3.9, bior4.4, bior5.5, bior6.8
     rbio family: rbio1.1, rbio1.3, rbio1.5, rbio2.2, rbio2.4, rbio2.6, rbio2.8, rbio3.1, rbio3.3, rbio3.5, rbio3.7, rbio3.9, rbio4.4, rbio5.5, rbio6.8
     dmey family: dmey
+    gaus family: gaus1, gaus2, gaus3, gaus4, gaus5, gaus6, gaus7, gaus8
+    mexh family: mexh
+    morl family: morl
+    cgau family: cgau1, cgau2, cgau3, cgau4, cgau5, cgau6, cgau7, cgau8
+    shan family: shan
+    fbsp family: fbsp
+    cmor family: cmor
 
 To get the full list of builtin wavelets' names just use the :func:`wavelist`
-with no argument. As you can see currently there are 76 builtin wavelets.
-
-    >>> len(pywt.wavelist())
-    76
+with no argument.
 
 
 Creating Wavelet objects
@@ -70,6 +74,8 @@ orthogonality and symmetry.
       Orthogonal:     True
       Biorthogonal:   True
       Symmetry:       asymmetric
+      DWT:            True
+      CWT:            False
 
 But the most important information are the wavelet filters coefficients, which
 are used in :ref:`Discrete Wavelet Transform <ref-dwt>`. These coefficients can
@@ -81,14 +87,7 @@ highpass reconstruction filters respectively:
     >>> def print_array(arr):
     ...     print("[%s]" % ", ".join(["%.14f" % x for x in arr]))
 
-    >>> print_array(w.dec_lo)
-    [0.03522629188210, -0.08544127388224, -0.13501102001039, 0.45987750211933, 0.80689150931334, 0.33267055295096]
-    >>> print_array(w.dec_hi)
-    [-0.33267055295096, 0.80689150931334, -0.45987750211933, -0.13501102001039, 0.08544127388224, 0.03522629188210]
-    >>> print_array(w.rec_lo)
-    [0.33267055295096, 0.80689150931334, 0.45987750211933, -0.13501102001039, -0.08544127388224, 0.03522629188210]
-    >>> print_array(w.rec_hi)
-    [0.03522629188210, 0.08544127388224, -0.13501102001039, -0.45987750211933, 0.80689150931334, -0.33267055295096]
+
 
 Another way to get the filters data is to use the :attr:`~Wavelet.filter_bank`
 attribute, which returns all four filters in a tuple:
@@ -143,7 +142,6 @@ Now when we know a bit about the builtin Wavelets, let's see how to create
     1) Passing the filter bank object that implements the `filter_bank`
        attribute. The attribute must return four filters coefficients.
 
-
        >>> class MyHaarFilterBank(object):
        ...     @property
        ...     def filter_bank(self):
@@ -166,29 +164,34 @@ Now when we know a bit about the builtin Wavelets, let's see how to create
 Note that such custom wavelets **will not** have all the properties set
 to correct values:
 
-    >>> print(my_wavelet)
-    Wavelet My Haar Wavelet
-      Family name:
-      Short name:
-      Filters length: 2
-      Orthogonal:     False
-      Biorthogonal:   False
-      Symmetry:       unknown
+    .. TODO: fix this doctest
+    .. >>> print(my_wavelet)
+    .. Wavelet My Haar Wavelet
+    ..   Family name:
+    ..   Short name:
+    ..   Filters length: 2
+    ..   Orthogonal:     False
+    ..   Biorthogonal:   False
+    ..   Symmetry:       unknown
+    ..   DWT:            True
+    ..   CWT:            False
 
     You can however set a few of them on your own:
 
-    >>> my_wavelet.orthogonal = True
-    >>> my_wavelet.biorthogonal = True
+    .. >>> my_wavelet.orthogonal = True
+    .. >>> my_wavelet.biorthogonal = True
 
-    >>> print(my_wavelet)
-    Wavelet My Haar Wavelet
-      Family name:
-      Short name:
-      Filters length: 2
-      Orthogonal:     True
-      Biorthogonal:   True
-      Symmetry:       unknown
-
+    .. TODO: fix this doctest
+    .. >>> print(my_wavelet)
+    .. Wavelet My Haar Wavelet
+    ..   Family name:
+    ..   Short name:
+    ..   Filters length: 2
+    ..   Orthogonal:     True
+    ..   Biorthogonal:   True
+    ..   Symmetry:       unknown
+    ..   DWT:            True
+    ..   CWT:            False
 
 And now... the `wavefun`!
 -------------------------

--- a/pywt/_extensions/_pywt.pyx
+++ b/pywt/_extensions/_pywt.pyx
@@ -183,7 +183,7 @@ def wavelist(family=None):
     --------
     >>> import pywt
     >>> pywt.wavelist('coif')
-    ['coif1', 'coif2', 'coif3', 'coif4', 'coif5']
+    ['coif1', 'coif2', 'coif3', 'coif4', 'coif5', 'coif6', 'coif7', 'coif8', 'coif9', 'coif10', 'coif11', 'coif12', 'coif13', 'coif14', 'coif15', 'coif16', 'coif17']
 
     """
     cdef object wavelets, sorting_list
@@ -255,7 +255,7 @@ def families(int short=True):
 
 def DiscreteContinuousWavelet(name=u"", object filter_bank=None):
     """
-    DiscreteContinuousWavelet(name, filter_bank=None) returns a 
+    DiscreteContinuousWavelet(name, filter_bank=None) returns a
     Wavelet or a ContinuousWavelet object depending of the given name.
 
     In order to use a built-in wavelet the parameter name must be
@@ -264,7 +264,7 @@ def DiscreteContinuousWavelet(name=u"", object filter_bank=None):
     be specified. It can be either a list of four filters or an object
     that a `filter_bank` attribute which returns a list of four
     filters - just like the Wavelet instance itself.
-    
+
     For a ContinuousWavelet, filter_bank cannot be used and must remain unset.
 
     """
@@ -410,7 +410,7 @@ cdef public class Wavelet [type WaveletType, object WaveletObject]:
         "Decomposition filters length"
         def __get__(self):
             return self.w.dec_len
-    
+
     property family_number:
         "Wavelet family number"
         def __get__(self):
@@ -819,7 +819,7 @@ cdef public class ContinuousWavelet [type ContinuousWaveletType, object Continuo
         cdef np.float32_t[::1] x32, psi32
 
         p = (pow(2., <double>level))
-        
+
         if self.w is not NULL:
             if length is None:
                 output_length = <pywt_index_t>p
@@ -832,21 +832,21 @@ cdef public class ContinuousWavelet [type ContinuousWaveletType, object Continuo
             if self.w.complex_cwt:
                 if (self.dt == np.float64):
                     psi_r, psi_i = cwt_psi_single(x64, self, output_length)
-                    return [np.asarray(psi_r, dtype=self.dt) + 1j * np.asarray(psi_i, dtype=self.dt), 
+                    return [np.asarray(psi_r, dtype=self.dt) + 1j * np.asarray(psi_i, dtype=self.dt),
                         np.asarray(x64, dtype=self.dt)]
                 else:
                     psi_r, psi_i = cwt_psi_single(x32, self, output_length)
-                    return [np.asarray(psi_r, dtype=self.dt) + 1j * np.asarray(psi_i, dtype=self.dt), 
+                    return [np.asarray(psi_r, dtype=self.dt) + 1j * np.asarray(psi_i, dtype=self.dt),
                             np.asarray(x32, dtype=self.dt)]
             else:
                 if (self.dt == np.float64):
                     psi = cwt_psi_single(x64, self, output_length)
-                    return [np.asarray(psi, dtype=self.dt), 
+                    return [np.asarray(psi, dtype=self.dt),
                             np.asarray(x64, dtype=self.dt)]
 
                 else:
                     psi = cwt_psi_single(x32, self, output_length)
-                    return [np.asarray(psi, dtype=self.dt), 
+                    return [np.asarray(psi, dtype=self.dt),
                             np.asarray(x32, dtype=self.dt)]
 
     def __str__(self):

--- a/pywt/_extensions/_pywt.pyx
+++ b/pywt/_extensions/_pywt.pyx
@@ -183,7 +183,7 @@ def wavelist(family=None):
     --------
     >>> import pywt
     >>> pywt.wavelist('coif')
-    ['coif1', 'coif2', 'coif3', 'coif4', 'coif5', 'coif6', 'coif7', 'coif8', 'coif9', 'coif10', 'coif11', 'coif12', 'coif13', 'coif14', 'coif15', 'coif16', 'coif17']
+    ['coif1', 'coif2', 'coif3', 'coif4', 'coif5', 'coif6', 'coif7', ...
 
     """
     cdef object wavelets, sorting_list

--- a/pywt/_extensions/c/wavelets.c
+++ b/pywt/_extensions/c/wavelets.c
@@ -40,7 +40,7 @@ int is_discrete_wavelet(WAVELET_NAME name)
         case CMOR:
             return 0;
     }
-    
+
 }
 
 
@@ -517,12 +517,12 @@ DiscreteWavelet* blank_discrete_wavelet(size_t filters_length)
         w->dec_hi_float = wtcalloc(filters_length, sizeof(float));
         w->rec_lo_float = wtcalloc(filters_length, sizeof(float));
         w->rec_hi_float = wtcalloc(filters_length, sizeof(float));
-    
+
         w->dec_lo_double = wtcalloc(filters_length, sizeof(double));
         w->dec_hi_double = wtcalloc(filters_length, sizeof(double));
         w->rec_lo_double = wtcalloc(filters_length, sizeof(double));
         w->rec_hi_double = wtcalloc(filters_length, sizeof(double));
-    
+
         if(w->dec_lo_float == NULL || w->dec_hi_float == NULL ||
            w->rec_lo_float == NULL || w->rec_hi_float == NULL ||
            w->dec_lo_double == NULL || w->dec_hi_double == NULL ||
@@ -537,13 +537,20 @@ DiscreteWavelet* blank_discrete_wavelet(size_t filters_length)
         w->dec_hi_float = NULL;
         w->rec_lo_float = NULL;
         w->rec_hi_float = NULL;
-    
+
         w->dec_lo_double = NULL;
         w->dec_hi_double = NULL;
         w->rec_lo_double = NULL;
         w->rec_hi_double = NULL;
     }
-    /* set properties to "blank" values */
+    /* set w->base properties to "blank" values */
+    w->base.support_width = -1;
+    w->base.orthogonal = 0;
+    w->base.biorthogonal = 0;
+    w->base.symmetry = UNKNOWN;
+    w->base.compact_support = 0;
+    w->base.family_name = "";
+    w->base.short_name = "";
     return w;
 }
 
@@ -593,7 +600,7 @@ DiscreteWavelet* copy_discrete_wavelet(DiscreteWavelet* base)
     {
         w->dec_lo_float = NULL;
         w->dec_hi_float = NULL;
-    
+
         w->dec_lo_double = NULL;
         w->dec_hi_double = NULL;
     }
@@ -613,7 +620,7 @@ DiscreteWavelet* copy_discrete_wavelet(DiscreteWavelet* base)
     {
         w->rec_lo_float = NULL;
         w->rec_hi_float = NULL;
-    
+
         w->rec_lo_double = NULL;
         w->rec_hi_double = NULL;
     }

--- a/pywt/_extensions/c/wavelets.c
+++ b/pywt/_extensions/c/wavelets.c
@@ -551,6 +551,8 @@ DiscreteWavelet* blank_discrete_wavelet(size_t filters_length)
     w->base.compact_support = 0;
     w->base.family_name = "";
     w->base.short_name = "";
+    w->vanishing_moments_psi = 0;
+    w->vanishing_moments_phi = 0;
     return w;
 }
 

--- a/pywt/tests/test_wavelet.py
+++ b/pywt/tests/test_wavelet.py
@@ -169,6 +169,17 @@ def test_custom_wavelet():
     filter_bank = ([val]*2, [-val, val], [val]*2, [val, -val])
     haar_custom2 = pywt.Wavelet('Custom Haar Wavelet',
                                 filter_bank=filter_bank)
+
+    # check expected default wavelet properties
+    assert_(~haar_custom2.orthogonal)
+    assert_(~haar_custom2.biorthogonal)
+    assert_(haar_custom2.symmetry == 'unknown')
+    assert_(haar_custom2.family_name == '')
+    assert_(haar_custom2.short_family_name == '')
+    assert_(haar_custom2.vanishing_moments_phi == 0)
+    assert_(haar_custom2.vanishing_moments_psi == 0)
+
+    # Some properties can be set by the user
     haar_custom2.orthogonal = True
     haar_custom2.biorthogonal = True
 


### PR DESCRIPTION
This is a fairly minimal set of changes needed to get all doctests to pass.  There are still 2 failing that I have commented out here at the moment.

**In addition to the updates a few tests were removed**

- Removed unneeded roundtrip tests of dwt/idwt with all modes.  There is already
unit testing for this.
- explicit testing of the number of wavelets was removed.
- The explicit test of db3 coefficients has been removed as more comprehensive unit tests of wavelet coefficients are now available.

There is more that could be removed, but the goal in this PR is to fix what was broken, not to overhaul the whole thing.

TODO:
- [x] Two tests related to calling `print` on wavelet objects have been commented out as they are causing a segfault for me.  This need to be fixed as I don't think this is tested elsewhere.