### PR TITLE
FIX: initialize all properties of a blank discrete wavelet

### DIFF
--- a/pywt/_extensions/c/wavelets.c
+++ b/pywt/_extensions/c/wavelets.c
@@ -40,7 +40,7 @@ int is_discrete_wavelet(WAVELET_NAME name)
         case CMOR:
             return 0;
     }
-    
+
 }
 
 
@@ -517,12 +517,12 @@ DiscreteWavelet* blank_discrete_wavelet(size_t filters_length)
         w->dec_hi_float = wtcalloc(filters_length, sizeof(float));
         w->rec_lo_float = wtcalloc(filters_length, sizeof(float));
         w->rec_hi_float = wtcalloc(filters_length, sizeof(float));
-    
+
         w->dec_lo_double = wtcalloc(filters_length, sizeof(double));
         w->dec_hi_double = wtcalloc(filters_length, sizeof(double));
         w->rec_lo_double = wtcalloc(filters_length, sizeof(double));
         w->rec_hi_double = wtcalloc(filters_length, sizeof(double));
-    
+
         if(w->dec_lo_float == NULL || w->dec_hi_float == NULL ||
            w->rec_lo_float == NULL || w->rec_hi_float == NULL ||
            w->dec_lo_double == NULL || w->dec_hi_double == NULL ||
@@ -537,13 +537,20 @@ DiscreteWavelet* blank_discrete_wavelet(size_t filters_length)
         w->dec_hi_float = NULL;
         w->rec_lo_float = NULL;
         w->rec_hi_float = NULL;
-    
+
         w->dec_lo_double = NULL;
         w->dec_hi_double = NULL;
         w->rec_lo_double = NULL;
         w->rec_hi_double = NULL;
     }
-    /* set properties to "blank" values */
+    /* set w->base properties to "blank" values */
+    w->base.support_width = -1;
+    w->base.orthogonal = 0;
+    w->base.biorthogonal = 0;
+    w->base.symmetry = UNKNOWN;
+    w->base.compact_support = 0;
+    w->base.family_name = "";
+    w->base.short_name = "";
     return w;
 }
 
@@ -593,7 +600,7 @@ DiscreteWavelet* copy_discrete_wavelet(DiscreteWavelet* base)
     {
         w->dec_lo_float = NULL;
         w->dec_hi_float = NULL;
-    
+
         w->dec_lo_double = NULL;
         w->dec_hi_double = NULL;
     }
@@ -613,7 +620,7 @@ DiscreteWavelet* copy_discrete_wavelet(DiscreteWavelet* base)
     {
         w->rec_lo_float = NULL;
         w->rec_hi_float = NULL;
-    
+
         w->rec_lo_double = NULL;
         w->rec_hi_double = NULL;
     }

--- a/pywt/_extensions/c/wavelets.c
+++ b/pywt/_extensions/c/wavelets.c
@@ -551,6 +551,8 @@ DiscreteWavelet* blank_discrete_wavelet(size_t filters_length)
     w->base.compact_support = 0;
     w->base.family_name = "";
     w->base.short_name = "";
+    w->vanishing_moments_psi = 0;
+    w->vanishing_moments_phi = 0;
     return w;
 }
 

--- a/pywt/tests/test_wavelet.py
+++ b/pywt/tests/test_wavelet.py
@@ -169,6 +169,17 @@ def test_custom_wavelet():
     filter_bank = ([val]*2, [-val, val], [val]*2, [val, -val])
     haar_custom2 = pywt.Wavelet('Custom Haar Wavelet',
                                 filter_bank=filter_bank)
+
+    # check expected default wavelet properties
+    assert_(~haar_custom2.orthogonal)
+    assert_(~haar_custom2.biorthogonal)
+    assert_(haar_custom2.symmetry == 'unknown')
+    assert_(haar_custom2.family_name == '')
+    assert_(haar_custom2.short_family_name == '')
+    assert_(haar_custom2.vanishing_moments_phi == 0)
+    assert_(haar_custom2.vanishing_moments_psi == 0)
+
+    # Some properties can be set by the user
     haar_custom2.orthogonal = True
     haar_custom2.biorthogonal = True
 


### PR DESCRIPTION
The following example from the doctests segfaults on current master because some properties of the discrete wavelet do not get initialized to defaults by `blank_discrete_wavelet`.  The defaults set here match those that were present in the 0.4.0 release (when the corresponding function was named `blank_wavelet`).

```python
import pywt

from math import sqrt
my_filter_bank = ([sqrt(2)/2, sqrt(2)/2], [-sqrt(2)/2, sqrt(2)/2],
                  [sqrt(2)/2, sqrt(2)/2], [sqrt(2)/2, -sqrt(2)/2])
my_wavelet = pywt.Wavelet('My Haar Wavelet', filter_bank=my_filter_bank)
print(my_wavelet)
```
prior to this PR, when `print` calls the `__str__` method, it crashes on uninitialized character arrays
