### PR TITLE
add FutureWarning about swt2 coefficient order

### DIFF
--- a/pywt/_multidim.py
+++ b/pywt/_multidim.py
@@ -11,6 +11,7 @@ from __future__ import division, print_function, absolute_import
 
 __all__ = ['dwt2', 'idwt2', 'swt2', 'dwtn', 'idwtn']
 
+import warnings
 from itertools import product
 
 import numpy as np
@@ -351,5 +352,11 @@ def swt2(data, wavelet, level, start_level=0):
 
         # for next iteration
         data = approx
+
+    warnings.warn(
+        "For consistency with the rest of PyWavelets, the order of the list "
+        "returned by swt2 will be reversed in the next release. "
+        "In other words, the levels will be sorted in descending rather than "
+        "ascending order.", FutureWarning)
 
     return ret

--- a/pywt/_multilevel.py
+++ b/pywt/_multilevel.py
@@ -10,6 +10,7 @@ and Inverse Discrete Wavelet Transform.
 
 from __future__ import division, print_function, absolute_import
 
+import warnings
 from copy import copy
 import numpy as np
 

--- a/pywt/_multilevel.py
+++ b/pywt/_multilevel.py
@@ -423,6 +423,12 @@ def iswt2(coeffs, wavelet):
                 x4 = np.roll(x4, 1, axis=1)
                 output[indices_h, indices_w] = (x1 + x2 + x3 + x4) / 4
 
+    warnings.warn(
+        "For consistency with the rest of PyWavelets, the order of levels in "
+        "coeffs expected by iswt2 will be reversed in the next release. "
+        "In other words, the levels will be sorted in descending rather than "
+        "ascending order.", FutureWarning)
+
     return output
 
 

--- a/pywt/tests/test_multilevel.py
+++ b/pywt/tests/test_multilevel.py
@@ -2,6 +2,7 @@
 
 from __future__ import division, print_function, absolute_import
 
+import warnings
 import numpy as np
 from numpy.testing import (run_module_suite, assert_almost_equal,
                            assert_allclose, assert_, assert_equal,
@@ -190,15 +191,19 @@ def test_swt_dtypes():
                 "swt: " + errmsg)
 
         # swt2
-        x = np.ones((8, 8), dtype=dt_in)
-        cA, (cH, cV, cD) = pywt.swt2(x, wavelet, level=1)[0]
-        assert_(cA.dtype == cH.dtype == cV.dtype == cD.dtype == dt_out,
-                "swt2: " + errmsg)
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore', FutureWarning)
+            x = np.ones((8, 8), dtype=dt_in)
+            cA, (cH, cV, cD) = pywt.swt2(x, wavelet, level=1)[0]
+            assert_(cA.dtype == cH.dtype == cV.dtype == cD.dtype == dt_out,
+                    "swt2: " + errmsg)
 
 
 def test_swt2_ndim_error():
     x = np.ones(8)
-    assert_raises(ValueError, pywt.swt2, x, 'haar', level=1)
+    with warnings.catch_warnings():
+        warnings.simplefilter('ignore', FutureWarning)
+        assert_raises(ValueError, pywt.swt2, x, 'haar', level=1)
 
 
 def test_swt2_iswt2_integration():
@@ -224,8 +229,11 @@ def test_swt2_iswt2_integration():
                 current_wavelet.rec_len))))
             input_length = 2**(input_length_power + max_level - 1)
             X = np.arange(input_length**2).reshape(input_length, input_length)
-            coeffs = pywt.swt2(X, current_wavelet, max_level)
-            Y = pywt.iswt2(coeffs, current_wavelet)
+
+            with warnings.catch_warnings():
+                warnings.simplefilter('ignore', FutureWarning)
+                coeffs = pywt.swt2(X, current_wavelet, max_level)
+                Y = pywt.iswt2(coeffs, current_wavelet)
             assert_allclose(Y, X, rtol=1e-5, atol=1e-5)
 
 ####


### PR DESCRIPTION
This adds a `FutureWarning` that the order of the list returned by `swt2` (and accepted as input by `iswt2`) will be swapped in future release.  Doing this was discussed in #81.  These functions return levels in ascending order, but should be changed to descending order in a future release for consistency with all of the other multilevel transforms in PyWavelets (`swt`, `wavedec*`).

(despite the tag, there is no an API change yet in this PR, just the warning that one is pending)