### PR TITLE
BUG: fix breakage on 32-bit Python.

### DIFF
--- a/pywt/_extensions/_pywt.pyx
+++ b/pywt/_extensions/_pywt.pyx
@@ -152,9 +152,6 @@ cdef object wname_to_code(name):
     cdef object code_number
     try:
         code_number = __wname_to_code[name]
-        assert len(code_number) == 2
-        assert isinstance(code_number[0], int)
-        assert isinstance(code_number[1], int)
         return code_number
     except KeyError:
         raise ValueError("Unknown wavelet name '%s', check wavelist() for the "


### PR DESCRIPTION
The list of wavelets was switched to use an enum in the PR that
added CWT.  On 32-bit systems enums are C longs, not ints.
Hence the assert removed in this PR was wrong, and it shouldn't
be there in the first place.