### PR TITLE
DOC: avoid a few sphinx warnings

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -121,7 +121,7 @@ html_title = 'PyWavelets Documentation'
 # The name of an image file (within the static path) to use as favicon of the
 # docs.  This file should be a Windows icon file (.ico) being 16x16 or 32x32
 # pixels large.
-html_favicon = 'favicon.ico'
+html_favicon = '_static/favicon.ico'
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -66,7 +66,7 @@ print "PyWavelets (VERSION %s)" % (version,)
 #today_fmt = '%B %d, %Y'
 
 # List of documents that shouldn't be included in the build.
-unused_docs = ['substitutions', 'overview']
+unused_docs = ['substitutions', ]
 
 # List of directories, relative to source directory, that shouldn't be searched
 # for source files.
@@ -201,3 +201,7 @@ latex_documents = [
 
 # If false, no module index is generated.
 #latex_use_modindex = True
+
+# List of patterns, relative to source directory, that match files and
+# directories to ignore when looking for source files.
+exclude_patterns = ['substitutions.rst', ]

--- a/doc/source/overview.rst
+++ b/doc/source/overview.rst
@@ -1,1 +1,0 @@
-Moved to :ref:`index <dev-index>`.

--- a/doc/source/ref/2d-dwt-and-idwt.rst
+++ b/doc/source/ref/2d-dwt-and-idwt.rst
@@ -1,7 +1,6 @@
 .. _ref-dwt2:
 
 .. currentmodule:: pywt
-.. include:: ../substitutions.rst
 
 =================================================
 2D Forward and Inverse Discrete Wavelet Transform

--- a/doc/source/ref/cwt.rst
+++ b/doc/source/ref/cwt.rst
@@ -1,7 +1,6 @@
 .. _ref-cwt:
 
 .. currentmodule:: pywt
-.. include:: ../substitutions.rst
 
 =================================
 Continous Wavelet Transform (CWT)

--- a/doc/source/ref/dwt-coefficient-handling.rst
+++ b/doc/source/ref/dwt-coefficient-handling.rst
@@ -1,5 +1,4 @@
 .. _ref-dwt-coef:
-.. include:: ../substitutions.rst
 
 =========================
 Handling DWT Coefficients

--- a/doc/source/ref/dwt-discrete-wavelet-transform.rst
+++ b/doc/source/ref/dwt-discrete-wavelet-transform.rst
@@ -1,7 +1,6 @@
 .. _ref-dwt:
 
 .. currentmodule:: pywt
-.. include:: ../substitutions.rst
 
 ================================
 Discrete Wavelet Transform (DWT)

--- a/doc/source/ref/idwt-inverse-discrete-wavelet-transform.rst
+++ b/doc/source/ref/idwt-inverse-discrete-wavelet-transform.rst
@@ -1,7 +1,6 @@
 .. _ref-idwt:
 
 .. currentmodule:: pywt
-.. include:: ../substitutions.rst
 
 =========================================
 Inverse Discrete Wavelet Transform (IDWT)

--- a/doc/source/ref/iswt-inverse-stationary-wavelet-transform.rst
+++ b/doc/source/ref/iswt-inverse-stationary-wavelet-transform.rst
@@ -1,8 +1,6 @@
 .. _ref-iswt:
 
 .. currentmodule:: pywt
-.. include:: ../substitutions.rst
-
 
 Inverse Stationary Wavelet Transform
 ------------------------------------

--- a/doc/source/ref/nd-dwt-and-idwt.rst
+++ b/doc/source/ref/nd-dwt-and-idwt.rst
@@ -1,5 +1,4 @@
 .. _ref-dwtn:
-.. include:: ../substitutions.rst
 
 =================================================
 nD Forward and Inverse Discrete Wavelet Transform

--- a/doc/source/ref/other-functions.rst
+++ b/doc/source/ref/other-functions.rst
@@ -1,7 +1,6 @@
 .. _ref-other:
 
 .. currentmodule:: pywt
-.. include:: ../substitutions.rst
 
 ===============
 Other functions

--- a/doc/source/ref/swt-stationary-wavelet-transform.rst
+++ b/doc/source/ref/swt-stationary-wavelet-transform.rst
@@ -1,8 +1,6 @@
 .. _ref-swt:
 
 .. currentmodule:: pywt
-.. include:: ../substitutions.rst
-
 
 Stationary Wavelet Transform
 ----------------------------

--- a/doc/source/substitutions.rst
+++ b/doc/source/substitutions.rst
@@ -1,10 +1,2 @@
-.. |mode| replace:: Signal extension mode to deal with the border distortion problem. See :ref:`Modes <ref-modes>` for details.
-
-.. |data| replace::
-    Input signal can be NumPy array, Python list or other iterable object. Both *single* and *double* precision floating-point data types are supported and the output type depends on the input type. If the input data is not in one of these types it will be converted to the default *double* precision data format before performing computations.
-
 .. |wavelet| replace::
    Wavelet to use in the transform. This can be a name of the wavelet from the :func:`wavelist` list or a :class:`Wavelet` object instance.
-
-.. |axis| replace::
-   Axis to perform the transform over, in the case of multi-dimensional input.


### PR DESCRIPTION
This PR fixes 3 sphinx warnings by:
1.) removing `overview.rst` which is not used
2.) adding `exclude_patterns = ['substitutions.rst', ]` to avoid warnings about it not being in a toctree
3.) using correct relative path to favicon.ico to suppress a warning about it not being found

The `exclude_patterns` parameter was added to `conf.py` back in Sphinx 1.0, so I think that should be fine to use at this point.

As there is now only one remaining document (wavelet packets) linking to `substitutions.rst` we could alternatively just move the substitution to that file instead.

The only remaining warning I see is the following, which I think is fine (it is just a Travis badge):
```
/Users/lee8rx/src/my_git/pyir/pywt/doc/source/dev/testing.rst:None: WARNING: nonlocal image URI found: https://secure.travis-ci.org/PyWavelets/pywt.png?branch=master
```