### PR TITLE
MAINT: valid email address for maintainer field

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -210,7 +210,7 @@ if __name__ == '__main__':
     setup(
         name="PyWavelets",
         maintainer="The PyWavelets Developers",
-        maintainer_email="http://groups.google.com/group/pywavelets",
+        maintainer_email="pywavelets@googlegroups.com",
         url="https://github.com/PyWavelets/pywt",
         download_url="https://github.com/PyWavelets/pywt/releases",
         license="MIT",


### PR DESCRIPTION
Modern twine fails when uploading to pypi, citing the lack of a valid
email address for the maintainer.  Use Google groups email address
instead of URL.

Closes gh-241