### PR TITLE
FIX: dwt, idwt with complex data now pass axis argument properly

### DIFF
--- a/pywt/_dwt.py
+++ b/pywt/_dwt.py
@@ -126,8 +126,8 @@ def dwt(data, wavelet, mode='symmetric', axis=-1):
     """
     if np.iscomplexobj(data):
         data = np.asarray(data)
-        cA_r, cD_r = dwt(data.real, wavelet, mode)
-        cA_i, cD_i = dwt(data.imag, wavelet, mode)
+        cA_r, cD_r = dwt(data.real, wavelet, mode, axis)
+        cA_i, cD_i = dwt(data.imag, wavelet, mode, axis)
         return (cA_r + 1j*cA_i, cD_r + 1j*cD_i)
 
     # accept array_like input; make a copy to ensure a contiguous array
@@ -196,8 +196,8 @@ def idwt(cA, cD, wavelet, mode='symmetric', axis=-1):
         elif cD is None:
             cA = np.asarray(cA)
             cD = np.zeros_like(cA)
-        return (idwt(cA.real, cD.real, wavelet, mode) +
-                1j*idwt(cA.imag, cD.imag, wavelet, mode))
+        return (idwt(cA.real, cD.real, wavelet, mode, axis) +
+                1j*idwt(cA.imag, cD.imag, wavelet, mode, axis))
 
     if cA is not None:
         dt = _check_dtype(cA)

--- a/pywt/tests/test_dwt_idwt.py
+++ b/pywt/tests/test_dwt_idwt.py
@@ -142,6 +142,8 @@ def test_idwt_single_axis():
     x = [[3, 7, 1, 1],
          [-2, 5, 4, 6]]
 
+    x = np.asarray(x)
+    x = x + 1j*x   # test with complex data
     cA, cD = pywt.dwt(x, 'db2', axis=-1)
 
     x0 = pywt.idwt(cA[0], cD[0], 'db2', axis=-1)


### PR DESCRIPTION
This fixes a failure to pass the `axis` argument when the data is complex in `dwt` and `idwt`.  I previously fixed this for 2D and nD cases in #205.  I didn't discover the 1D bug until working on tests as part of #204.