### PR TITLE
Add pyqtgraph demo for plotting wavelets

### DIFF
--- a/demo/plot_wavelets_pyqtgraph.py
+++ b/demo/plot_wavelets_pyqtgraph.py
@@ -1,0 +1,50 @@
+import sys
+
+from PyQt4 import QtGui
+
+import pywt
+import pyqtgraph as pg
+
+
+families = ['db', 'sym', 'coif', 'bior', 'rbio']
+
+
+def main():
+    app = QtGui.QApplication(sys.argv)
+    tabs = QtGui.QTabWidget()
+
+    for family in families:
+        vb = pg.GraphicsWindow()
+        for i, name in enumerate(pywt.wavelist(family)):
+            pen = pg.intColor(i)
+            wavelet = pywt.Wavelet(name)
+            if wavelet.orthogonal:
+                phi, psi, x = wavelet.wavefun(level=5)
+                ax = vb.addPlot(title=wavelet.name + " phi")
+                ax.plot(phi, pen=pen)
+                bx = vb.addPlot(title=wavelet.name + " psi")
+                bx.plot(psi, pen=pen)
+            else:
+                phi, psi, phi_r, psi_r, x = wavelet.wavefun(level=5)
+                ax = vb.addPlot(title=wavelet.name + " phi")
+                ax.plot(phi, pen=pen)
+                bx = vb.addPlot(title=wavelet.name + " psi")
+                bx.plot(psi, pen=pen)
+                ax = vb.addPlot(title=wavelet.name + " phi_r")
+                ax.plot(phi_r, pen=pen)
+                bx = vb.addPlot(title=wavelet.name + " psi_r")
+                bx.plot(psi_r, pen=pen)
+            if ((not wavelet.orthogonal) and i % 2 == 0) or i % 4 == 0:
+                vb.nextRow()
+        tabs.addTab(vb, family)
+
+    tabs.resize(1200, 800)
+
+    tabs.setWindowTitle('Wavelets')
+    tabs.showMaximized()
+
+    sys.exit(app.exec_())
+
+
+if __name__ == '__main__':
+    main()

--- a/demo/plot_wavelets_pyqtgraph.py
+++ b/demo/plot_wavelets_pyqtgraph.py
@@ -1,8 +1,7 @@
 import sys
 
-from PyQt4 import QtGui
-
 import pywt
+from PyQt4 import QtGui
 import pyqtgraph as pg
 
 
@@ -14,7 +13,11 @@ def main():
     tabs = QtGui.QTabWidget()
 
     for family in families:
+        scroller = QtGui.QScrollArea()
         vb = pg.GraphicsWindow()
+        vb.setMinimumHeight(3000)
+        vb.setMinimumWidth(1900)
+        scroller.setWidget(vb)
         for i, name in enumerate(pywt.wavelist(family)):
             pen = pg.intColor(i)
             wavelet = pywt.Wavelet(name)
@@ -34,15 +37,13 @@ def main():
                 ax.plot(phi_r, pen=pen)
                 bx = vb.addPlot(title=wavelet.name + " psi_r")
                 bx.plot(psi_r, pen=pen)
-            if ((not wavelet.orthogonal) and i % 2 == 0) or i % 4 == 0:
+            if i % 2 == 0:
                 vb.nextRow()
-        tabs.addTab(vb, family)
-
-    tabs.resize(1200, 800)
+        tabs.addTab(scroller, family)
 
     tabs.setWindowTitle('Wavelets')
-    tabs.showMaximized()
-
+    tabs.resize(1920, 1080)
+    tabs.show()
     sys.exit(app.exec_())
 
 

--- a/demo/plot_wavelets_pyqtgraph.py
+++ b/demo/plot_wavelets_pyqtgraph.py
@@ -1,7 +1,7 @@
 import sys
 
 import pywt
-from PyQt4 import QtGui
+from pyqtgraph.Qt import QtGui
 import pyqtgraph as pg
 
 


### PR DESCRIPTION
This is similar to plot_wavelets.py demo except it uses pyqtgraph, where each wavelet is in its own plot and can be zoomed.

Attached is a screenshot, each wavelet family is on its own tab, this shows bior:

![wavelets](https://cloud.githubusercontent.com/assets/123017/20468177/ab0f0696-af48-11e6-856c-b2a144afb7bc.png)
