### PR TITLE
ENH: improve iswt performance

### DIFF
--- a/pywt/_swt.py
+++ b/pywt/_swt.py
@@ -136,12 +136,13 @@ def iswt(coeffs, wavelet):
 
             # perform the inverse dwt on the selected indices,
             # making sure to use periodic boundary conditions
-            # copy used to ensure idwt_single inputs are contiguous
-            x1 = idwt_single(output[even_indices].copy(),
-                             cD[even_indices].copy(),
+            # Note:  indexing with an array of ints returns a contiguous
+            #        copy as required by idwt_single.
+            x1 = idwt_single(output[even_indices],
+                             cD[even_indices],
                              wavelet, mode)
-            x2 = idwt_single(output[odd_indices].copy(),
-                             cD[odd_indices].copy(),
+            x2 = idwt_single(output[odd_indices],
+                             cD[odd_indices],
                              wavelet, mode)
 
             # perform a circular shift right

--- a/pywt/_swt.py
+++ b/pywt/_swt.py
@@ -3,7 +3,7 @@ from ._extensions._pywt import Wavelet, Modes, _check_dtype
 
 import warnings
 import numpy as np
-from ._extensions._dwt import idwt_axis
+from ._extensions._dwt import idwt_single
 from ._extensions._swt import swt_axis as _swt_axis
 from ._dwt import idwt
 from ._multidim import idwt2
@@ -136,11 +136,13 @@ def iswt(coeffs, wavelet):
 
             # perform the inverse dwt on the selected indices,
             # making sure to use periodic boundary conditions
-            # idwt_axis instead of idwt_single to support non-contiguous arrays
-            x1 = idwt_axis(output[even_indices], cD[even_indices],
-                           wavelet, mode, 0)
-            x2 = idwt_axis(output[odd_indices], cD[odd_indices],
-                           wavelet, mode, 0)
+            # copy used to ensure idwt_single inputs are contiguous
+            x1 = idwt_single(output[even_indices].copy(),
+                             cD[even_indices].copy(),
+                             wavelet, mode)
+            x2 = idwt_single(output[odd_indices].copy(),
+                             cD[odd_indices].copy(),
+                             wavelet, mode)
 
             # perform a circular shift right
             x2 = np.roll(x2, 1)

--- a/pywt/tests/test_swt.py
+++ b/pywt/tests/test_swt.py
@@ -160,6 +160,26 @@ def test_swt_dtypes():
                     "swt2: " + errmsg)
 
 
+def test_swt_roudtrip_dtypes():
+    # verify perfect reconstruction for all dtypes
+    rstate = np.random.RandomState(5)
+    wavelet = pywt.Wavelet('haar')
+    for dt_in, dt_out in zip(dtypes_in, dtypes_out):
+        # swt, iswt
+        x = rstate.standard_normal((8, )).astype(dt_in)
+        c = pywt.swt(x, wavelet, level=2)
+        xr = pywt.iswt(c, wavelet)
+        assert_allclose(x, xr, rtol=1e-6, atol=1e-7)
+
+        # swt2, iswt2
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore', FutureWarning)
+            x = rstate.standard_normal((8, 8)).astype(dt_in)
+            c = pywt.swt2(x, wavelet, level=2)
+            xr = pywt.iswt2(c, wavelet)
+            assert_allclose(x, xr, rtol=1e-6, atol=1e-7)
+
+
 def test_swt2_ndim_error():
     x = np.ones(8)
     with warnings.catch_warnings():


### PR DESCRIPTION
minimal changes to `iswt` to call the Cython `idwt_axis` routine as opposed to the python `idwt` routine fixes the majority of the python 0.2.2 vs 0.5.1 performance disparity raised in #157.

round-trip results were not previously verified for complex dtypes so I added a test for that.  (The changes here require handling the complex types directly in `iswt` rather than relying on `idwt` to do it for us)