### PR TITLE
ENH: add iswtn (n-dimensional inverse SWT)

### DIFF
--- a/pywt/tests/test_swt.py
+++ b/pywt/tests/test_swt.py
@@ -125,21 +125,20 @@ def test_swt_iswt_integration():
     # that they are each other's inverse.
 
     max_level = 3
-    wavelets = pywt.wavelist()
+    wavelets = pywt.wavelist(kind='discrete')
     if 'dmey' in wavelets:
         # The 'dmey' wavelet seems to be a bit special - disregard it for now
         wavelets.remove('dmey')
     for current_wavelet_str in wavelets:
-        current_wavelet = pywt.DiscreteContinuousWavelet(current_wavelet_str)
-        if isinstance(current_wavelet, pywt.Wavelet):
-            input_length_power = int(np.ceil(np.log2(max(
-                current_wavelet.dec_len,
-                current_wavelet.rec_len))))
-            input_length = 2**(input_length_power + max_level - 1)
-            X = np.arange(input_length)
-            coeffs = pywt.swt(X, current_wavelet, max_level)
-            Y = pywt.iswt(coeffs, current_wavelet)
-            assert_allclose(Y, X, rtol=1e-5, atol=1e-7)
+        current_wavelet = pywt.Wavelet(current_wavelet_str)
+        input_length_power = int(np.ceil(np.log2(max(
+            current_wavelet.dec_len,
+            current_wavelet.rec_len))))
+        input_length = 2**(input_length_power + max_level - 1)
+        X = np.arange(input_length)
+        coeffs = pywt.swt(X, current_wavelet, max_level)
+        Y = pywt.iswt(coeffs, current_wavelet)
+        assert_allclose(Y, X, rtol=1e-5, atol=1e-7)
 
 
 def test_swt_dtypes():
@@ -162,7 +161,7 @@ def test_swt_dtypes():
                     "swt2: " + errmsg)
 
 
-def test_swt_roudtrip_dtypes():
+def test_swt_roundtrip_dtypes():
     # verify perfect reconstruction for all dtypes
     rstate = np.random.RandomState(5)
     wavelet = pywt.Wavelet('haar')
@@ -190,7 +189,7 @@ def test_swt2_ndim_error():
 
 
 @dec.slow
-def test_swt2_iswt2_integration():
+def test_swt2_iswt2_integration(wavelets=None):
     # This function performs a round-trip swt2/iswt2 transform test on
     # all available types of wavelets in PyWavelets - except the
     # 'dmey' wavelet. The latter has been excluded because it does not
@@ -201,24 +200,28 @@ def test_swt2_iswt2_integration():
     # that they are each other's inverse.
 
     max_level = 3
-    wavelets = pywt.wavelist()
-    if 'dmey' in wavelets:
-        # The 'dmey' wavelet seems to be a bit special - disregard it for now
-        wavelets.remove('dmey')
+    if wavelets is None:
+        wavelets = pywt.wavelist(kind='discrete')
+        if 'dmey' in wavelets:
+            # The 'dmey' wavelet is a special case - disregard it for now
+            wavelets.remove('dmey')
     for current_wavelet_str in wavelets:
-        current_wavelet = pywt.DiscreteContinuousWavelet(current_wavelet_str)
-        if isinstance(current_wavelet, pywt.Wavelet):
-            input_length_power = int(np.ceil(np.log2(max(
-                current_wavelet.dec_len,
-                current_wavelet.rec_len))))
-            input_length = 2**(input_length_power + max_level - 1)
-            X = np.arange(input_length**2).reshape(input_length, input_length)
+        current_wavelet = pywt.Wavelet(current_wavelet_str)
+        input_length_power = int(np.ceil(np.log2(max(
+            current_wavelet.dec_len,
+            current_wavelet.rec_len))))
+        input_length = 2**(input_length_power + max_level - 1)
+        X = np.arange(input_length**2).reshape(input_length, input_length)
 
-            with warnings.catch_warnings():
-                warnings.simplefilter('ignore', FutureWarning)
-                coeffs = pywt.swt2(X, current_wavelet, max_level)
-                Y = pywt.iswt2(coeffs, current_wavelet)
-            assert_allclose(Y, X, rtol=1e-5, atol=1e-5)
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore', FutureWarning)
+            coeffs = pywt.swt2(X, current_wavelet, max_level)
+            Y = pywt.iswt2(coeffs, current_wavelet)
+        assert_allclose(Y, X, rtol=1e-5, atol=1e-5)
+
+
+def test_swt2_iswt2_quick():
+    test_swt2_iswt2_integration(wavelets=['db1', ])
 
 
 def test_swt2_axes():
@@ -286,7 +289,7 @@ def test_swtn_axes():
 
 
 @dec.slow
-def test_swtn_iswtn_integration():
+def test_swtn_iswtn_integration(wavelets=None):
     # This function performs a round-trip swtn/iswtn transform for various
     # possible combinations of:
     #   1.) 1 out of 2 axes of a 2D array
@@ -297,33 +300,37 @@ def test_swtn_iswtn_integration():
     # This test does not validate swtn or iswtn individually, but only
     # confirms that iswtn yields an (almost) perfect reconstruction of swtn.
     max_level = 3
-    wavelets = pywt.wavelist()
-    if 'dmey' in wavelets:
-        # The 'dmey' wavelet seems to be a bit special - disregard it for now
-        wavelets.remove('dmey')
-    for ndim_transform in range(1, 2):
+    if wavelets is None:
+        wavelets = pywt.wavelist(kind='discrete')
+        if 'dmey' in wavelets:
+            # The 'dmey' wavelet is a special case - disregard it for now
+            wavelets.remove('dmey')
+    for ndim_transform in range(1, 3):
         ndim = ndim_transform + 1
         for axes in combinations(range(ndim), ndim_transform):
             for current_wavelet_str in wavelets:
-                wav = pywt.DiscreteContinuousWavelet(current_wavelet_str)
-                if isinstance(wav, pywt.Wavelet):
-                    if wav.dec_len > 8:
-                        continue  # avoid excessive test duration
-                    input_length_power = int(np.ceil(np.log2(max(
-                        wav.dec_len,
-                        wav.rec_len))))
-                    N = 2**(input_length_power + max_level - 1)
-                    X = np.arange(N**ndim).reshape((N, )*ndim)
+                wav = pywt.Wavelet(current_wavelet_str)
+                if wav.dec_len > 8:
+                    continue  # avoid excessive test duration
+                input_length_power = int(np.ceil(np.log2(max(
+                    wav.dec_len,
+                    wav.rec_len))))
+                N = 2**(input_length_power + max_level - 1)
+                X = np.arange(N**ndim).reshape((N, )*ndim)
 
-                    coeffs = pywt.swtn(X, wav, max_level, axes=axes)
-                    coeffs_copy = deepcopy(coeffs)
-                    Y = pywt.iswtn(coeffs, wav, axes=axes)
-                    assert_allclose(Y, X, rtol=1e-5, atol=1e-5)
+                coeffs = pywt.swtn(X, wav, max_level, axes=axes)
+                coeffs_copy = deepcopy(coeffs)
+                Y = pywt.iswtn(coeffs, wav, axes=axes)
+                assert_allclose(Y, X, rtol=1e-5, atol=1e-5)
 
-                    # verify the inverse transform didn't modify any coeffs
-                    for c, c2 in zip(coeffs, coeffs_copy):
-                        for k, v in c.items():
-                            assert_array_equal(c2[k], v)
+                # verify the inverse transform didn't modify any coeffs
+                for c, c2 in zip(coeffs, coeffs_copy):
+                    for k, v in c.items():
+                        assert_array_equal(c2[k], v)
+
+
+def test_swtn_iswtn_quick():
+    test_swtn_iswtn_integration(wavelets=['db1', ])
 
 
 def test_iswtn_errors():


### PR DESCRIPTION
In release 0.5.1 there is  `swtn` for an n-dimensional forward SWT with flexible choice of axes to transform.  This PR provides the corresponding inverse operation, ``iswtn``.

The redundancy of the SWT grows quickly as the number of dimensions (and transform levels) increases, but I think it is still worth having this generalized implementation available.

This logic here may be a bit hard to follow with all the slice objects, use of `itertools.product` for nested loops etc.  However, it is a direct extension of the approach used in ``iswt2``  (i.e. combining all possible combinations of odd/even shifts of `idwtn` along the transformed axes).  The tests are pretty thorough, so I am fairly confident that the implementation is correct.

This makes `iswt2` a bit redundant, but I think keeping a simpler 2D example around serves as a useful reference in understanding the approach behind `iswtn`.
