### PR TITLE
TST: fix compatibility issue with coverage 4.3 release

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,6 +1,5 @@
 [run]
 branch = True
-include = */pywt/*
 # Not sure what stringsource is
 omit =
     */version.py


### PR DESCRIPTION
Current tests on TravisCI fail with message
"--include and --source are mutually exclusive".

Due to change in https://bitbucket.org/ned/coveragepy/commits/cfedeb61c5179

The --source argumment comes in somehow via the nose coverage plugin,
in combination with the odd build/test command we use in .travis.yml