### PR TITLE
TST: test OS X build on TravisCI.  Closes gh-75.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,8 @@ env:
 
 matrix:
   include:
-    - python: 2.7
+    - os: linux
+      python: 2.7
       env:
         - PYFLAKES=1
         - PEP8=1
@@ -22,28 +23,39 @@ matrix:
       script:
         - PYFLAKES_NODOCTEST=1 pyflakes pywt demo | grep -E -v 'unable to detect undefined names|assigned to but never used|imported but unused|redefinition of unused' > test.out; cat test.out; test \! -s test.out
         - pep8 pywt demo
-    - python: 3.5
+    - os: linux
+      python: 3.6
       env:
         - NUMPYSPEC=numpy
-    - python: 3.4
+    - os: linux
+      python: 3.4
       env:
         - NUMPYSPEC=numpy
-    - python: 2.7
+    - os: linux
+      python: 2.7
       env:
         - NUMPYSPEC="numpy==1.9.3"
-    - python: 3.5
+    - os: linux
+      python: 3.5
       env:
         - NUMPYSPEC=numpy
         - REFGUIDE_CHECK=1  # run doctests only
+    - os: osx
+      osx_image: xcode7.3
+      language: objective-c
+      env:
+        - NUMPYSPEC=numpy
+        - TRAVIS_PYTHON_VERSION=3.5
 
 cache: pip
 
 before_install:
   - uname -a
-  - free -m
   - df -h
   - ulimit -a
-  - python -V
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then source util/travis_osx_install.sh; fi
+  - ccache -s
+  - which python; python --version
   - pip install --upgrade pip
   - pip install --upgrade wheel
   # Set numpy version first, other packages link against it

--- a/util/travis_osx_install.sh
+++ b/util/travis_osx_install.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+brew update
+brew install ccache
+
+git clone https://github.com/MacPython/terryfy.git ~/terryfy
+source ~/terryfy/travis_tools.sh
+get_python_environment macpython $TRAVIS_PYTHON_VERSION ~/macpython_venv
+source ~/macpython_venv/bin/activate
+pip install virtualenv
+


### PR DESCRIPTION
Also add Python 3.6 to the build matrix.