### PR TITLE
avoid some compiler warnings

### DIFF
--- a/pywt/_extensions/_pywt.pyx
+++ b/pywt/_extensions/_pywt.pyx
@@ -33,6 +33,15 @@ _attr_deprecation_msg = ('{old} has been renamed to {new} and will '
                          'of pywt.')
 
 
+# raises exception if the wavelet name is undefined
+cdef int is_discrete_wav(WAVELET_NAME name):
+    cdef int is_discrete
+    discrete = wavelet.is_discrete_wavelet(name)
+    if discrete == -1:
+        raise ValueError("unrecognized wavelet family name")
+    return discrete
+
+
 class _Modes(object):
     """
     Because the most common and practical way of representing digital signals
@@ -206,7 +215,7 @@ def wavelist(family=None, kind='all'):
             return True
 
         family_code, family_number = wname_to_code(name)
-        is_discrete = wavelet.is_discrete_wavelet(family_code)
+        is_discrete = is_discrete_wav(family_code)
         if kind == 'discrete':
             return is_discrete
         else:
@@ -299,7 +308,7 @@ def DiscreteContinuousWavelet(name=u"", object filter_bank=None):
     if filter_bank is None:
         name = name.lower()
         family_code, family_number = wname_to_code(name)
-        if (wavelet.is_discrete_wavelet(family_code)):
+        if is_discrete_wav(family_code):
             return Wavelet(name, filter_bank)
         else:
             return ContinuousWavelet(name)
@@ -334,7 +343,7 @@ cdef public class Wavelet [type WaveletType, object WaveletObject]:
             # builtin wavelet
             self.name = name.lower()
             family_code, family_number = wname_to_code(self.name)
-            if (wavelet.is_discrete_wavelet(family_code)):
+            if is_discrete_wav(family_code):
                 self.w = <wavelet.DiscreteWavelet*> wavelet.discrete_wavelet(family_code, family_number)
             if self.w is NULL:
                 raise ValueError("Invalid wavelet name.")

--- a/pywt/_extensions/c/convolution.template.c
+++ b/pywt/_extensions/c/convolution.template.c
@@ -1,4 +1,4 @@
-/* Copyright (c) 2006-2012 Filip Wasilewski <http://en.ig.ma/> 
+/* Copyright (c) 2006-2012 Filip Wasilewski <http://en.ig.ma/>
  * Copyright (c) 2012-2016 The PyWavelets Developers
  *                         <https://github.com/PyWavelets/pywt>
  * See COPYING for license details.
@@ -545,9 +545,9 @@ int CAT(TYPE, _upsampling_convolution_valid_sf)(const TYPE * const restrict inpu
 }
 
 /* -> swt - todo */
-int CAT(TYPE, _upsampled_filter_convolution)(const TYPE* input, const size_t N,
-                                             const TYPE* filter, const size_t F,
-                                             TYPE* output,
+int CAT(TYPE, _upsampled_filter_convolution)(const TYPE * const restrict input, const size_t N,
+                                             const TYPE * const restrict filter, const size_t F,
+                                             TYPE * const restrict output,
                                              const size_t step, MODE mode)
 {
     return -1;

--- a/pywt/_extensions/c/convolution.template.h
+++ b/pywt/_extensions/c/convolution.template.h
@@ -1,4 +1,4 @@
-/* Copyright (c) 2006-2012 Filip Wasilewski <http://en.ig.ma/> 
+/* Copyright (c) 2006-2012 Filip Wasilewski <http://en.ig.ma/>
  * Copyright (c) 2012-2016 The PyWavelets Developers
  *                         <https://github.com/PyWavelets/pywt>
  * See COPYING for license details.
@@ -84,9 +84,9 @@ int CAT(TYPE, _upsampling_convolution_valid_sf)(const TYPE * const restrict inpu
 
 /* TODO
  * for SWT
- * int upsampled_filter_convolution(const TYPE* input, const int N,
- *                                  const TYPE* filter, const int F,
- *                                  TYPE* output, int step, int mode);
+ * int upsampled_filter_convolution(const TYPE * const restrict input, const int N,
+ *                                  const TYPE * const restrict filter, const int F,
+ *                                  TYPE * const restrict output, int step, int mode);
  */
 
 

--- a/pywt/_extensions/c/cwt.template.c
+++ b/pywt/_extensions/c/cwt.template.c
@@ -58,7 +58,7 @@ TYPE CAT(TYPE, _sin)(const TYPE x)
         return sinf(x);
 }
 
-TYPE CAT(TYPE, _pi)()
+TYPE CAT(TYPE, _pi)(void)
 {
     if (sizeof(TYPE) == sizeof(double))
         return M_PI;

--- a/pywt/_extensions/c/cwt.template.c
+++ b/pywt/_extensions/c/cwt.template.c
@@ -29,7 +29,7 @@ TYPE CAT(TYPE, _pow)(const TYPE x, const TYPE y)
 TYPE CAT(TYPE, _sqrt)(const TYPE x)
 {
     if (sizeof(TYPE) == sizeof(double))
-        return sqrt(x);        
+        return sqrt(x);
     else
         return sqrtf(x);
 }
@@ -37,7 +37,7 @@ TYPE CAT(TYPE, _sqrt)(const TYPE x)
 TYPE CAT(TYPE, _exp)(const TYPE x)
 {
     if (sizeof(TYPE) == sizeof(double))
-        return exp(x);        
+        return exp(x);
     else
         return expf(x);
 }
@@ -45,7 +45,7 @@ TYPE CAT(TYPE, _exp)(const TYPE x)
 TYPE CAT(TYPE, _cos)(const TYPE x)
 {
     if (sizeof(TYPE) == sizeof(double))
-        return cos(x);        
+        return cos(x);
     else
         return cosf(x);
 }
@@ -61,7 +61,7 @@ TYPE CAT(TYPE, _sin)(const TYPE x)
 TYPE CAT(TYPE, _pi)()
 {
     if (sizeof(TYPE) == sizeof(double))
-        return M_PI;        
+        return M_PI;
     else
         return (TYPE)M_PI;
 }
@@ -75,16 +75,16 @@ void CAT(TYPE, _gaus)(const TYPE * const restrict input,
     {
            switch (number) {
                case 1:
-                    output[i] = -2*input[i]*CAT(TYPE, _exp)(-CAT(TYPE, _pow)(input[i], 2.0))/CAT(TYPE, _sqrt)(CAT(TYPE, _sqrt)(CAT(TYPE, _pi)()/2)); 
+                    output[i] = -2*input[i]*CAT(TYPE, _exp)(-CAT(TYPE, _pow)(input[i], 2.0))/CAT(TYPE, _sqrt)(CAT(TYPE, _sqrt)(CAT(TYPE, _pi)()/2));
                     break;
                 case 2:
                     output[i] = -2*(2*CAT(TYPE, _pow)(input[i], 2.0)-1)*CAT(TYPE, _exp)(-CAT(TYPE, _pow)(input[i], 2.0))/CAT(TYPE, _sqrt)(3*CAT(TYPE, _sqrt)(CAT(TYPE, _pi)()/2));
                     break;
                 case 3:
-                    output[i] = -4*(-2*CAT(TYPE, _pow)(input[i], 3.0)+3*input[i])*CAT(TYPE, _exp)(-CAT(TYPE, _pow)(input[i], 2.0))/CAT(TYPE, _sqrt)(15*CAT(TYPE, _sqrt)(CAT(TYPE, _pi)()/2)); 
+                    output[i] = -4*(-2*CAT(TYPE, _pow)(input[i], 3.0)+3*input[i])*CAT(TYPE, _exp)(-CAT(TYPE, _pow)(input[i], 2.0))/CAT(TYPE, _sqrt)(15*CAT(TYPE, _sqrt)(CAT(TYPE, _pi)()/2));
                     break;
                 case 4:
-                    output[i] = 4*(-12*CAT(TYPE, _pow)(input[i], 2.0)+4*CAT(TYPE, _pow)(input[i], 4.0)+3)*CAT(TYPE, _exp)(-CAT(TYPE, _pow)(input[i], 2.0))/CAT(TYPE, _sqrt)(105*CAT(TYPE, _sqrt)(CAT(TYPE, _pi)()/2));  
+                    output[i] = 4*(-12*CAT(TYPE, _pow)(input[i], 2.0)+4*CAT(TYPE, _pow)(input[i], 4.0)+3)*CAT(TYPE, _exp)(-CAT(TYPE, _pow)(input[i], 2.0))/CAT(TYPE, _sqrt)(105*CAT(TYPE, _sqrt)(CAT(TYPE, _pi)()/2));
                     break;
                 case 5:
                     output[i] =  8*(-4*CAT(TYPE, _pow)(input[i], 5.0)+20*CAT(TYPE, _pow)(input[i], 3.0)-15*input[i])*CAT(TYPE, _exp)(-CAT(TYPE, _pow)(input[i], 2.0))/CAT(TYPE, _sqrt)(105*9*CAT(TYPE, _sqrt)(CAT(TYPE, _pi)()/2));
@@ -93,10 +93,10 @@ void CAT(TYPE, _gaus)(const TYPE * const restrict input,
                     output[i] = -8*(8*CAT(TYPE, _pow)(input[i], 6.0)-60*CAT(TYPE, _pow)(input[i], 4.0)+90*CAT(TYPE, _pow)(input[i], 2.0)-15)*CAT(TYPE, _exp)(-CAT(TYPE, _pow)(input[i], 2.0))/CAT(TYPE, _sqrt)(105*9*11*CAT(TYPE, _sqrt)(CAT(TYPE, _pi)()/2));
                     break;
                 case 7:
-                    output[i] =  -16*(-8*CAT(TYPE, _pow)(input[i], 7.0)+84*CAT(TYPE, _pow)(input[i], 5.0)-210*CAT(TYPE, _pow)(input[i], 3.0)+105*(input[i]))*CAT(TYPE, _exp)(-CAT(TYPE, _pow)(input[i], 2.0))/CAT(TYPE, _sqrt)(105*9*11*13*CAT(TYPE, _sqrt)(CAT(TYPE, _pi)()/2));  
+                    output[i] =  -16*(-8*CAT(TYPE, _pow)(input[i], 7.0)+84*CAT(TYPE, _pow)(input[i], 5.0)-210*CAT(TYPE, _pow)(input[i], 3.0)+105*(input[i]))*CAT(TYPE, _exp)(-CAT(TYPE, _pow)(input[i], 2.0))/CAT(TYPE, _sqrt)(105*9*11*13*CAT(TYPE, _sqrt)(CAT(TYPE, _pi)()/2));
                     break;
                 case 8:
-                    output[i] =  16*(16*CAT(TYPE, _pow)(input[i], 8.0)-224*CAT(TYPE, _pow)(input[i], 6.0)+840*CAT(TYPE, _pow)(input[i], 4.0)-840*CAT(TYPE, _pow)(input[i], 2.0)+105)*CAT(TYPE, _exp)(-CAT(TYPE, _pow)(input[i], 2.0))/CAT(TYPE, _sqrt)(105*9*11*13*15*CAT(TYPE, _sqrt)(CAT(TYPE, _pi)()/2));  
+                    output[i] =  16*(16*CAT(TYPE, _pow)(input[i], 8.0)-224*CAT(TYPE, _pow)(input[i], 6.0)+840*CAT(TYPE, _pow)(input[i], 4.0)-840*CAT(TYPE, _pow)(input[i], 2.0)+105)*CAT(TYPE, _exp)(-CAT(TYPE, _pow)(input[i], 2.0))/CAT(TYPE, _sqrt)(105*9*11*13*15*CAT(TYPE, _sqrt)(CAT(TYPE, _pi)()/2));
                     break;
           }
     }
@@ -110,7 +110,7 @@ void CAT(TYPE, _mexh)(const TYPE * const restrict input, TYPE * const restrict o
     for (i = 0; i < N; i++)
     {
         output[i] = (1-CAT(TYPE, _pow)(input[i], 2.0))*CAT(TYPE, _exp)(-CAT(TYPE, _pow)(input[i], 2.0)/2)*2/(CAT(TYPE, _sqrt)(3)*CAT(TYPE, _sqrt)(CAT(TYPE, _sqrt)(CAT(TYPE, _pi)())));
-    }  
+    }
 }
 
 void CAT(TYPE, _morl)(const TYPE * const restrict input, TYPE * const restrict output, const size_t N)
@@ -119,7 +119,7 @@ void CAT(TYPE, _morl)(const TYPE * const restrict input, TYPE * const restrict o
     for (i = 0; i < N; i++)
     {
         output[i] = CAT(TYPE, _cos)(5*input[i])*CAT(TYPE, _exp)(-CAT(TYPE, _pow)(input[i], 2.0)/2);
-    }   
+    }
 }
 
 
@@ -186,7 +186,7 @@ const TYPE  FB, const TYPE  FC)
             output_r[i] *= CAT(TYPE, _sin)(input[i]*FB*CAT(TYPE, _pi)())/(input[i]*FB*CAT(TYPE, _pi)());
             output_i[i] *= CAT(TYPE, _sin)(input[i]*FB*CAT(TYPE, _pi)())/(input[i]*FB*CAT(TYPE, _pi)());
         }
-    }  
+    }
 }
 
 void CAT(TYPE, _fbsp)(const TYPE * const restrict input, TYPE * const restrict output_r, TYPE * const restrict output_i, const size_t N,
@@ -219,7 +219,7 @@ const TYPE  FB, const TYPE  FC)
         output_r[i] =CAT(TYPE, _cos)(2*CAT(TYPE, _pi)()*FC*input[i])*CAT(TYPE, _exp)(-CAT(TYPE, _pow)(input[i], 2.0)/FB)/CAT(TYPE, _sqrt)(CAT(TYPE, _pi)()*FB);
         output_i[i] = CAT(TYPE, _sin)(2*CAT(TYPE, _pi)()*FC*input[i])*CAT(TYPE, _exp)(-CAT(TYPE, _pow)(input[i], 2.0)/FB)/CAT(TYPE, _sqrt)(CAT(TYPE, _pi)()*FB);
 
-    }   
+    }
 }
 
 

--- a/pywt/_extensions/c/wavelets.c
+++ b/pywt/_extensions/c/wavelets.c
@@ -1,4 +1,4 @@
-/* Copyright (c) 2006-2012 Filip Wasilewski <http://en.ig.ma/> 
+/* Copyright (c) 2006-2012 Filip Wasilewski <http://en.ig.ma/>
  * Copyright (c) 2012-2016 The PyWavelets Developers
  *                         <https://github.com/PyWavelets/pywt>
  * See COPYING for license details.
@@ -559,7 +559,7 @@ DiscreteWavelet* blank_discrete_wavelet(size_t filters_length)
     return w;
 }
 
-ContinuousWavelet* blank_continous_wavelet()
+ContinuousWavelet* blank_continous_wavelet(void)
 {
     ContinuousWavelet* w;
 

--- a/pywt/_extensions/c/wavelets.c
+++ b/pywt/_extensions/c/wavelets.c
@@ -42,6 +42,8 @@ int is_discrete_wavelet(WAVELET_NAME name)
             return 0;
         case CMOR:
             return 0;
+        default:
+            return -1;
     }
 
 }

--- a/pywt/_extensions/c/wavelets.h
+++ b/pywt/_extensions/c/wavelets.h
@@ -1,4 +1,4 @@
-/* Copyright (c) 2006-2012 Filip Wasilewski <http://en.ig.ma/> 
+/* Copyright (c) 2006-2012 Filip Wasilewski <http://en.ig.ma/>
  * Copyright (c) 2012-2016 The PyWavelets Developers
  *                         <https://github.com/PyWavelets/pywt>
  * See COPYING for license details.
@@ -47,11 +47,11 @@ typedef struct  {
     unsigned int orthogonal:1;
     unsigned int biorthogonal:1;
     unsigned int compact_support:1;
-    
+
     int _builtin;
     char* family_name;
     char* short_name;
-    
+
 
 } BaseWavelet;
 
@@ -67,7 +67,7 @@ typedef struct {
     float* rec_lo_float;
     size_t dec_len;   /* length of decomposition filter */
     size_t rec_len;   /* length of reconstruction filter */
-    
+
     int vanishing_moments_psi;
     int vanishing_moments_phi;
 
@@ -89,24 +89,24 @@ typedef struct {
 
 int is_discrete_wavelet(WAVELET_NAME name);
 
-/* 
+/*
  * Allocate Wavelet struct and set its attributes
  * name - (currently) a character codename of a wavelet family
  * order - order of the wavelet (ie. coif3 has order 3)
  */
 DiscreteWavelet* discrete_wavelet(WAVELET_NAME name, unsigned int order);
 ContinuousWavelet* continous_wavelet(WAVELET_NAME name, unsigned int order);
-/* 
+/*
  * Allocate blank Discrete Wavelet with zero-filled filters of given length
  */
 DiscreteWavelet* blank_discrete_wavelet(size_t filters_length);
 
-ContinuousWavelet* blank_continous_wavelet();
+ContinuousWavelet* blank_continous_wavelet(void);
 
 /* Deep copy Discrete Wavelet */
 DiscreteWavelet* copy_discrete_wavelet(DiscreteWavelet* base);
 
-/* 
+/*
  * Free wavelet struct. Use this to free Wavelet allocated with
  * wavelet(...) or blank_wavelet(...) functions.
  */

--- a/pywt/_extensions/c/wt.template.c
+++ b/pywt/_extensions/c/wt.template.c
@@ -1,4 +1,4 @@
-/* Copyright (c) 2006-2012 Filip Wasilewski <http://en.ig.ma/> 
+/* Copyright (c) 2006-2012 Filip Wasilewski <http://en.ig.ma/>
  * Copyright (c) 2012-2016 The PyWavelets Developers
  *                         <https://github.com/PyWavelets/pywt>
  * See COPYING for license details.
@@ -441,9 +441,9 @@ int CAT(TYPE, _idwt)(const TYPE * const restrict coeffs_a, const size_t coeffs_a
 }
 
 /* basic SWT step (TODO: optimize) */
-int CAT(TYPE, _swt_)(TYPE input[], pywt_index_t input_len,
-                     const TYPE filter[], pywt_index_t filter_len,
-                     TYPE output[], pywt_index_t output_len,
+int CAT(TYPE, _swt_)(const TYPE * const restrict input, pywt_index_t input_len,
+                     const TYPE * const restrict filter, pywt_index_t filter_len,
+                     TYPE * const restrict output, pywt_index_t output_len,
                      unsigned int level){
 
     TYPE * e_filter;
@@ -489,9 +489,9 @@ int CAT(TYPE, _swt_)(TYPE input[], pywt_index_t input_len,
  * Approximation at specified level
  * input - approximation coeffs from upper level or signal if level == 1
  */
-int CAT(TYPE, _swt_a)(TYPE input[], pywt_index_t input_len,
-                      DiscreteWavelet* wavelet,
-                      TYPE output[], pywt_index_t output_len,
+int CAT(TYPE, _swt_a)(const TYPE * const restrict input, pywt_index_t input_len,
+                      const DiscreteWavelet * const restrict wavelet,
+                      TYPE * const restrict output, pywt_index_t output_len,
                       unsigned int level){
     return CAT(TYPE, _swt_)(input, input_len, wavelet->CAT(dec_lo_, TYPE),
                             wavelet->dec_len, output, output_len, level);
@@ -500,9 +500,9 @@ int CAT(TYPE, _swt_a)(TYPE input[], pywt_index_t input_len,
 /* Details at specified level
  * input - approximation coeffs from upper level or signal if level == 1
  */
-int CAT(TYPE, _swt_d)(TYPE input[], pywt_index_t input_len,
-                      DiscreteWavelet* wavelet,
-                      TYPE output[], pywt_index_t output_len,
+int CAT(TYPE, _swt_d)(const TYPE * const restrict input, pywt_index_t input_len,
+                      const DiscreteWavelet * const restrict wavelet,
+                      TYPE * const restrict output, pywt_index_t output_len,
                       unsigned int level){
     return CAT(TYPE, _swt_)(input, input_len, wavelet->CAT(dec_hi_, TYPE),
                             wavelet->dec_len, output, output_len, level);

--- a/pywt/_extensions/c/wt.template.h
+++ b/pywt/_extensions/c/wt.template.h
@@ -1,4 +1,4 @@
-/* Copyright (c) 2006-2012 Filip Wasilewski <http://en.ig.ma/> 
+/* Copyright (c) 2006-2012 Filip Wasilewski <http://en.ig.ma/>
  * Copyright (c) 2012-2016 The PyWavelets Developers
  *                         <https://github.com/PyWavelets/pywt>
  * See COPYING for license details.
@@ -61,17 +61,17 @@ int CAT(TYPE, _rec_d)(const TYPE * const restrict coeffs_d, const size_t coeffs_
 int CAT(TYPE, _idwt)(const TYPE * const restrict coeffs_a, const size_t coeffs_a_len,
                      const TYPE * const restrict coeffs_d, const size_t coeffs_d_len,
                      TYPE * const restrict output, const size_t output_len,
-                     const DiscreteWavelet * const wavelet, const MODE mode);
+                     const DiscreteWavelet * const restrict wavelet, const MODE mode);
 
 /* SWT decomposition at given level */
-int CAT(TYPE, _swt_a)(TYPE input[], pywt_index_t input_len,
-                      DiscreteWavelet* wavelet,
-                      TYPE output[], pywt_index_t output_len,
+int CAT(TYPE, _swt_a)(const TYPE * const restrict input, pywt_index_t input_len,
+                      const DiscreteWavelet * const restrict wavelet,
+                      TYPE * const restrict output, pywt_index_t output_len,
                       unsigned int level);
 
-int CAT(TYPE, _swt_d)(TYPE input[], pywt_index_t input_len,
-                      DiscreteWavelet* wavelet,
-                      TYPE output[], pywt_index_t output_len,
+int CAT(TYPE, _swt_d)(const TYPE * const restrict input, pywt_index_t input_len,
+                      const DiscreteWavelet * const restrict wavelet,
+                      TYPE * const restrict output, pywt_index_t output_len,
                       unsigned int level);
 
 int CAT(TYPE, _swt_axis)(const TYPE * const restrict input, const ArrayInfo input_info,

--- a/pywt/_extensions/c_wt.pxd
+++ b/pywt/_extensions/c_wt.pxd
@@ -37,15 +37,15 @@ cdef extern from "c/wt.h":
                           const DiscreteWavelet * const wavelet,
                           double * const output, const size_t output_len) nogil
 
-    cdef int double_idwt(double * const coeffs_a, const size_t coeffs_a_len,
-                         double * const coeffs_d, const size_t coeffs_d_len,
+    cdef int double_idwt(const double * const coeffs_a, const size_t coeffs_a_len,
+                         const double * const coeffs_d, const size_t coeffs_d_len,
                          double * const output, const size_t output_len,
                          const DiscreteWavelet * const wavelet, const MODE mode) nogil
 
-    cdef int double_swt_a(double input[], pywt_index_t input_len, DiscreteWavelet* wavelet,
-                          double output[], pywt_index_t output_len, int level) nogil
-    cdef int double_swt_d(double input[], pywt_index_t input_len, DiscreteWavelet* wavelet,
-                          double output[], pywt_index_t output_len, int level) nogil
+    cdef int double_swt_a(const double * const input, pywt_index_t input_len, const DiscreteWavelet * const wavelet,
+                          double * const output, pywt_index_t output_len, int level) nogil
+    cdef int double_swt_d(const double * const input, pywt_index_t input_len, const DiscreteWavelet * const wavelet,
+                          double * const output, pywt_index_t output_len, int level) nogil
 
 
 
@@ -81,10 +81,10 @@ cdef extern from "c/wt.h":
                         float * const output, const size_t output_len,
                         const DiscreteWavelet * const wavelet, const MODE mode) nogil
 
-    cdef int float_swt_a(float input[], pywt_index_t input_len, DiscreteWavelet* wavelet,
-                         float output[], pywt_index_t output_len, int level) nogil
-    cdef int float_swt_d(float input[], pywt_index_t input_len, DiscreteWavelet* wavelet,
-                         float output[], pywt_index_t output_len, int level) nogil
+    cdef int float_swt_a(const float * const input, pywt_index_t input_len, const DiscreteWavelet * const wavelet,
+                         float * const output, pywt_index_t output_len, int level) nogil
+    cdef int float_swt_d(const float * const input, pywt_index_t input_len, const DiscreteWavelet * const wavelet,
+                         float * const output, pywt_index_t output_len, int level) nogil
 
 cdef extern from "c/cwt.h":
     # Cython does not know the 'restrict' keyword


### PR DESCRIPTION
This PR fixes some of the compiler warnings raised by gcc/clang for current master. 

The separate commits each address a different type of warning.

The majority of the warnings fixed are related to the fact that SWT routines had inconsistent type declarations relative to the DWT routines.  Thus, the changes in #224 where one routine (downcoef_axis) supports both DWT and SWT was raising type-related warnings  (e.g. differences in presence of const/restrict on variables).
