### PR TITLE
MAINT: better exception message for Wavelet('continuous_familyname')

### DIFF
--- a/pywt/_extensions/_pywt.pyx
+++ b/pywt/_extensions/_pywt.pyx
@@ -337,7 +337,12 @@ cdef public class Wavelet [type WaveletType, object WaveletObject]:
             if (wavelet.is_discrete_wavelet(family_code)):
                 self.w = <wavelet.DiscreteWavelet*> wavelet.discrete_wavelet(family_code, family_number)
             if self.w is NULL:
-                raise ValueError("Invalid wavelet name.")
+                if self.name in wavelist(kind='continuous'):
+                    raise ValueError("The `Wavelet` class is for discrete "
+                          "wavelets, %s is a continuous wavelet.  Use "
+                          "pywt.ContinuousWavelet instead" % self.name)
+                else:
+                    raise ValueError("Invalid wavelet name.")
             self.number = family_number
         else:
             if hasattr(filter_bank, "filter_bank"):

--- a/pywt/tests/test__pywt.py
+++ b/pywt/tests/test__pywt.py
@@ -135,5 +135,11 @@ def test_wavelist():
     assert_raises(ValueError, pywt.wavelist, kind='foobar')
 
 
+def test_wavelet_errormsgs():
+    try:
+        pywt.Wavelet('gaus1')
+    except ValueError as e:
+        assert_(e.args[0].startswith('The `Wavelet` class'))
+
 if __name__ == '__main__':
     run_module_suite()


### PR DESCRIPTION
Motivated by user confusion on the mailing list.