### PR TITLE
MAINT: fix more compiler warnings

### DIFF
--- a/pywt/_extensions/_dwt.pxd
+++ b/pywt/_extensions/_dwt.pxd
@@ -1,3 +1,4 @@
 from ._pywt cimport Wavelet, data_t
 
-cpdef upcoef(bint do_rec_a, data_t[::1] coeffs, Wavelet wavelet, int level, int take)
+cpdef upcoef(bint do_rec_a, data_t[::1] coeffs, Wavelet wavelet, int level,
+             size_t take)

--- a/pywt/_extensions/_dwt.pyx
+++ b/pywt/_extensions/_dwt.pyx
@@ -233,7 +233,8 @@ cpdef idwt_axis(np.ndarray coefs_a, np.ndarray coefs_d,
 
     return output
 
-cpdef upcoef(bint do_rec_a, data_t[::1] coeffs, Wavelet wavelet, int level, int take):
+cpdef upcoef(bint do_rec_a, data_t[::1] coeffs, Wavelet wavelet, int level,
+             size_t take):
     cdef data_t[::1] rec
     cdef int i, retval
     cdef size_t rec_len, left_bound, right_bound, coeffs_size

--- a/pywt/_extensions/_swt.pyx
+++ b/pywt/_extensions/_swt.pyx
@@ -33,9 +33,9 @@ def swt_max_level(size_t input_len):
 def swt(data_t[::1] data, Wavelet wavelet, size_t level, size_t start_level):
     cdef data_t[::1] cA, cD
     cdef Wavelet w
-    cdef int i, retval
+    cdef int retval
     cdef size_t end_level = start_level + level
-    cdef size_t data_size, output_len
+    cdef size_t data_size, output_len, i
 
     if data.size % 2:
         raise ValueError("Length of data must be even.")
@@ -105,7 +105,8 @@ cpdef swt_axis(np.ndarray data, Wavelet wavelet, size_t level,
     # Explicit input_shape necessary to prevent memory leak
     cdef size_t[::1] input_shape, output_shape
     cdef size_t end_level = start_level + level
-    cdef int i, retval
+    cdef int retval
+    cdef size_t i
 
     if data.size % 2:
         raise ValueError("Length of data must be even.")

--- a/pywt/_extensions/c/wavelets.c
+++ b/pywt/_extensions/c/wavelets.c
@@ -584,9 +584,6 @@ DiscreteWavelet* copy_discrete_wavelet(DiscreteWavelet* base)
 
     if(base == NULL) return NULL;
 
-    if(base->dec_len < 0 || base->rec_len < 0)
-        return NULL;
-
     w = wtmalloc(sizeof(DiscreteWavelet));
     if(w == NULL) return NULL;
 

--- a/pywt/_extensions/c/wt.template.c
+++ b/pywt/_extensions/c/wt.template.c
@@ -443,7 +443,7 @@ int CAT(TYPE, _idwt)(const TYPE * const restrict coeffs_a, const size_t coeffs_a
 /* basic SWT step (TODO: optimize) */
 int CAT(TYPE, _swt_)(const TYPE * const restrict input, pywt_index_t input_len,
                      const TYPE * const restrict filter, pywt_index_t filter_len,
-                     TYPE * const restrict output, pywt_index_t output_len,
+                     TYPE * const restrict output, size_t output_len,
                      unsigned int level){
 
     TYPE * e_filter;


### PR DESCRIPTION
All compiler warnings on OS X + Clang are now gone, except for the unavoidable ones coming from Cython.