### PR TITLE
allow string input in dwt_max_level

### DIFF
--- a/pywt/tests/test__pywt.py
+++ b/pywt/tests/test__pywt.py
@@ -106,7 +106,21 @@ def test_dwt_max_level():
     assert_(pywt.dwt_max_level(16, 8) == 1)
     assert_(pywt.dwt_max_level(16, 9) == 1)
     assert_(pywt.dwt_max_level(16, 10) == 0)
+    assert_(pywt.dwt_max_level(16, np.int8(10)) == 0)
+    assert_(pywt.dwt_max_level(16, 10.) == 0)
     assert_(pywt.dwt_max_level(16, 18) == 0)
+
+    # accepts discrete Wavelet object or string as well
+    assert_(pywt.dwt_max_level(32, pywt.Wavelet('sym5')) == 1)
+    assert_(pywt.dwt_max_level(32, 'sym5') == 1)
+
+    # string input that is not a discrete wavelet
+    assert_raises(ValueError, pywt.dwt_max_level, 16, 'mexh')
+
+    # filter_len must be an integer >= 2
+    assert_raises(ValueError, pywt.dwt_max_level, 16, 1)
+    assert_raises(ValueError, pywt.dwt_max_level, 16, -1)
+    assert_raises(ValueError, pywt.dwt_max_level, 16, 3.3)
 
 
 def test_ContinuousWavelet_errs():


### PR DESCRIPTION
I noticed that usage of `dwt_max_level` with a `Wavelet` object as the second argument is fairly common, but is not documented.  I updated the docstring and modified the function to also accept a string name as well for convenience.

While doing this, I noticed that passing a negative `filter_len` would cause an `OverflowError`, while a `filter_len` of 0 or 1 would not cause an error, but just return 0.  I chose to change the behavior so that any `filter_len < 2` raises a `ValueError`. 