### PR TITLE
allow separate wavelet/mode for each axis in routines based on dwtn/idwtn

### DIFF
--- a/pywt/_dwt.py
+++ b/pywt/_dwt.py
@@ -1,22 +1,17 @@
-import sys
-import numpy as np
 from numbers import Number
 
+import numpy as np
 
 from ._extensions._pywt import (Wavelet, Modes, _check_dtype, wavelist)
 from ._extensions._dwt import (dwt_single, dwt_axis, idwt_single, idwt_axis,
                                upcoef as _upcoef, downcoef as _downcoef,
                                dwt_max_level as _dwt_max_level,
                                dwt_coeff_len as _dwt_coeff_len)
+from ._utils import string_types
+
 
 __all__ = ["dwt", "idwt", "downcoef", "upcoef", "dwt_max_level",
            "dwt_coeff_len"]
-
-# define string_types as in six for Python 2/3 compatibility
-if sys.version_info[0] == 3:
-    string_types = str,
-else:
-    string_types = basestring,
 
 
 def dwt_max_level(data_len, filter_len):

--- a/pywt/_multidim.py
+++ b/pywt/_multidim.py
@@ -1,5 +1,5 @@
 # Copyright (c) 2006-2012 Filip Wasilewski <http://en.ig.ma/>
-# Copyright (c) 2012-2016 The PyWavelets Developers
+# Copyright (c) 2012-2017 The PyWavelets Developers
 #                         <https://github.com/PyWavelets/pywt>
 # See COPYING for license details.
 

--- a/pywt/_multidim.py
+++ b/pywt/_multidim.py
@@ -9,14 +9,15 @@
 
 from __future__ import division, print_function, absolute_import
 
-__all__ = ['dwt2', 'idwt2', 'dwtn', 'idwtn']
-
 from itertools import product
 
 import numpy as np
 
-from ._extensions._pywt import Wavelet, Modes
 from ._extensions._dwt import dwt_axis, idwt_axis
+from ._utils import _wavelets_per_axis, _modes_per_axis
+
+
+__all__ = ['dwt2', 'idwt2', 'dwtn', 'idwtn']
 
 
 def dwt2(data, wavelet, mode='symmetric', axes=(-2, -1)):
@@ -27,10 +28,13 @@ def dwt2(data, wavelet, mode='symmetric', axes=(-2, -1)):
     ----------
     data : array_like
         2D array with input data
-    wavelet : Wavelet object or name string
-        Wavelet to use
-    mode : str, optional
-        Signal extension mode, see Modes (default: 'symmetric')
+    wavelet : Wavelet object or name string, or 2-tuple of wavelets
+        Wavelet to use.  This can also be a tuple containing a wavelet to
+        apply along each axis in ``axes``.
+    mode : str or 2-tuple of strings, optional
+        Signal extension mode, see Modes (default: 'symmetric').  This can
+        also be a tuple of modes specifying the mode to use on each axis in
+        ``axes``.
     axes : 2-tuple of ints, optional
         Axes over which to compute the DWT. Repeated elements mean the DWT will
         be performed multiple times along these axes.
@@ -80,10 +84,13 @@ def idwt2(coeffs, wavelet, mode='symmetric', axes=(-2, -1)):
     coeffs : tuple
         (cA, (cH, cV, cD)) A tuple with approximation coefficients and three
         details coefficients 2D arrays like from `dwt2()`
-    wavelet : Wavelet object or name string
-        Wavelet to use
-    mode : str, optional
-        Signal extension mode, see Modes (default: 'symmetric')
+    wavelet : Wavelet object or name string, or 2-tuple of wavelets
+        Wavelet to use.  This can also be a tuple containing a wavelet to
+        apply along each axis in ``axes``.
+    mode : str or 2-tuple of strings, optional
+        Signal extension mode, see Modes (default: 'symmetric').  This can
+        also be a tuple of modes specifying the mode to use on each axis in
+        ``axes``.
     axes : 2-tuple of ints, optional
         Axes over which to compute the IDWT. Repeated elements mean the IDWT
         will be performed multiple times along these axes.
@@ -122,9 +129,12 @@ def dwtn(data, wavelet, mode='symmetric', axes=None):
     data : array_like
         n-dimensional array with input data.
     wavelet : Wavelet object or name string
-        Wavelet to use.
-    mode : str, optional
-        Signal extension mode, see `Modes`.  Default is 'symmetric'.
+        Wavelet to use.  This can also be a list containing a wavelet to
+        apply along each axis in ``axes``.
+    mode : str or list of string, optional
+        Signal extension mode used in the decomposition,
+        see Modes (default: 'symmetric').  This can also be a list of modes
+        specifying the mode to use on each axis in ``axes``.
     axes : sequence of ints, optional
         Axes over which to compute the DWT. Repeated elements mean the DWT will
         be performed multiple times along these axes. A value of ``None`` (the
@@ -168,17 +178,16 @@ def dwtn(data, wavelet, mode='symmetric', axes=None):
 
     if axes is None:
         axes = range(data.ndim)
-    axes = (a + data.ndim if a < 0 else a for a in axes)
+    axes = [a + data.ndim if a < 0 else a for a in axes]
 
-    mode = Modes.from_object(mode)
-    if not isinstance(wavelet, Wavelet):
-        wavelet = Wavelet(wavelet)
+    modes = _modes_per_axis(mode, axes)
+    wavelets = _wavelets_per_axis(wavelet, axes)
 
     coeffs = [('', data)]
-    for axis in axes:
+    for axis, wav, mode in zip(axes, wavelets, modes):
         new_coeffs = []
         for subband, x in coeffs:
-            cA, cD = dwt_axis(x, wavelet, mode, axis)
+            cA, cD = dwt_axis(x, wav, mode, axis)
             new_coeffs.extend([(subband + 'a', cA),
                                (subband + 'd', cD)])
         coeffs = new_coeffs
@@ -218,10 +227,12 @@ def idwtn(coeffs, wavelet, mode='symmetric', axes=None):
         Dictionary as in output of `dwtn`. Missing or None items
         will be treated as zeroes.
     wavelet : Wavelet object or name string
-        Wavelet to use
-    mode : str, optional
+        Wavelet to use.  This can also be a list containing a wavelet to
+        apply along each axis in ``axes``.
+    mode : str or list of string, optional
         Signal extension mode used in the decomposition,
-        see Modes (default: 'symmetric').
+        see Modes (default: 'symmetric').  This can also be a list of modes
+        specifying the mode to use on each axis in ``axes``.
     axes : sequence of ints, optional
         Axes over which to compute the IDWT. Repeated elements mean the IDWT
         will be performed multiple times along these axes. A value of ``None``
@@ -236,10 +247,6 @@ def idwtn(coeffs, wavelet, mode='symmetric', axes=None):
         Original signal reconstructed from input data.
 
     """
-    if not isinstance(wavelet, Wavelet):
-        wavelet = Wavelet(wavelet)
-    mode = Modes.from_object(mode)
-
     # Raise error for invalid key combinations
     coeffs = _fix_coeffs(coeffs)
 
@@ -267,9 +274,12 @@ def idwtn(coeffs, wavelet, mode='symmetric', axes=None):
         ndim = ndim_transform
     else:
         ndim = len(coeff_shape)
-    axes = (a + ndim if a < 0 else a for a in axes)
+    axes = [a + ndim if a < 0 else a for a in axes]
 
-    for key_length, axis in reversed(list(enumerate(axes))):
+    modes = _modes_per_axis(mode, axes)
+    wavelets = _wavelets_per_axis(wavelet, axes)
+    for key_length, (axis, wav, mode) in reversed(
+            list(enumerate(zip(axes, wavelets, modes)))):
         if axis < 0 or axis >= ndim:
             raise ValueError("Axis greater than data dimensions")
 
@@ -280,7 +290,7 @@ def idwtn(coeffs, wavelet, mode='symmetric', axes=None):
             L = coeffs.get(key + 'a', None)
             H = coeffs.get(key + 'd', None)
 
-            new_coeffs[key] = idwt_axis(L, H, wavelet, mode, axis)
+            new_coeffs[key] = idwt_axis(L, H, wav, mode, axis)
         coeffs = new_coeffs
 
     return coeffs['']

--- a/pywt/_multidim.py
+++ b/pywt/_multidim.py
@@ -1,5 +1,5 @@
 # Copyright (c) 2006-2012 Filip Wasilewski <http://en.ig.ma/>
-# Copyright (c) 2012-2017 The PyWavelets Developers
+# Copyright (c) 2012-2016 The PyWavelets Developers
 #                         <https://github.com/PyWavelets/pywt>
 # See COPYING for license details.
 
@@ -128,12 +128,12 @@ def dwtn(data, wavelet, mode='symmetric', axes=None):
     ----------
     data : array_like
         n-dimensional array with input data.
-    wavelet : Wavelet object or name string
-        Wavelet to use.  This can also be a list containing a wavelet to
+    wavelet : Wavelet object or name string, or tuple of wavelets
+        Wavelet to use.  This can also be a tuple containing a wavelet to
         apply along each axis in ``axes``.
-    mode : str or list of string, optional
+    mode : str or tuple of string, optional
         Signal extension mode used in the decomposition,
-        see Modes (default: 'symmetric').  This can also be a list of modes
+        see Modes (default: 'symmetric').  This can also be a tuple of modes
         specifying the mode to use on each axis in ``axes``.
     axes : sequence of ints, optional
         Axes over which to compute the DWT. Repeated elements mean the DWT will
@@ -226,12 +226,12 @@ def idwtn(coeffs, wavelet, mode='symmetric', axes=None):
     coeffs: dict
         Dictionary as in output of `dwtn`. Missing or None items
         will be treated as zeroes.
-    wavelet : Wavelet object or name string
-        Wavelet to use.  This can also be a list containing a wavelet to
+    wavelet : Wavelet object or name string, or tuple of wavelets
+        Wavelet to use.  This can also be a tuple containing a wavelet to
         apply along each axis in ``axes``.
     mode : str or list of string, optional
         Signal extension mode used in the decomposition,
-        see Modes (default: 'symmetric').  This can also be a list of modes
+        see Modes (default: 'symmetric').  This can also be a tuple of modes
         specifying the mode to use on each axis in ``axes``.
     axes : sequence of ints, optional
         Axes over which to compute the IDWT. Repeated elements mean the IDWT

--- a/pywt/_multilevel.py
+++ b/pywt/_multilevel.py
@@ -18,6 +18,7 @@ from ._extensions._pywt import Wavelet
 from ._extensions._dwt import dwt_max_level
 from ._dwt import dwt, idwt
 from ._multidim import dwt2, idwt2, dwtn, idwtn, _fix_coeffs
+from ._utils import _wavelets_per_axis
 
 __all__ = ['wavedec', 'waverec', 'wavedec2', 'waverec2', 'wavedecn',
            'waverecn', 'coeffs_to_array', 'array_to_coeffs']
@@ -195,9 +196,6 @@ def wavedec2(data, wavelet, mode='symmetric', level=None, axes=(-2, -1)):
     if data.ndim < 2:
         raise ValueError("Expected input data to have at least 2 dimensions.")
 
-    if not isinstance(wavelet, Wavelet):
-        wavelet = Wavelet(wavelet)
-
     axes = tuple(axes)
     if len(axes) != 2:
         raise ValueError("Expected 2 axes")
@@ -207,7 +205,11 @@ def wavedec2(data, wavelet, mode='symmetric', level=None, axes=(-2, -1)):
         axes_sizes = [data.shape[ax] for ax in axes]
     except IndexError:
         raise ValueError("Axis greater than data dimensions")
-    level = _check_level(min(axes_sizes), wavelet.dec_len, level)
+
+    wavelets = _wavelets_per_axis(wavelet, axes)
+    dec_lengths = [w.dec_len for w in wavelets]
+
+    level = _check_level(min(axes_sizes), max(dec_lengths), level)
 
     coeffs_list = []
 
@@ -355,9 +357,6 @@ def wavedecn(data, wavelet, mode='symmetric', level=None, axes=None):
     if len(data.shape) < 1:
         raise ValueError("Expected at least 1D input data.")
 
-    if not isinstance(wavelet, Wavelet):
-        wavelet = Wavelet(wavelet)
-
     if np.isscalar(axes):
         axes = (axes, )
     if axes is None:
@@ -371,7 +370,11 @@ def wavedecn(data, wavelet, mode='symmetric', level=None, axes=None):
         axes_shapes = [data.shape[ax] for ax in axes]
     except IndexError:
         raise ValueError("Axis greater than data dimensions")
-    level = _check_level(min(axes_shapes), wavelet.dec_len, level)
+
+    wavelets = _wavelets_per_axis(wavelet, axes)
+    dec_lengths = [w.dec_len for w in wavelets]
+
+    level = _check_level(min(axes_shapes), max(dec_lengths), level)
 
     coeffs_list = []
 

--- a/pywt/_multilevel.py
+++ b/pywt/_multilevel.py
@@ -1,5 +1,5 @@
 # Copyright (c) 2006-2012 Filip Wasilewski <http://en.ig.ma/>
-# Copyright (c) 2012-2016 The PyWavelets Developers
+# Copyright (c) 2012-2017 The PyWavelets Developers
 #                         <https://github.com/PyWavelets/pywt>
 # See COPYING for license details.
 

--- a/pywt/_multilevel.py
+++ b/pywt/_multilevel.py
@@ -1,5 +1,5 @@
 # Copyright (c) 2006-2012 Filip Wasilewski <http://en.ig.ma/>
-# Copyright (c) 2012-2017 The PyWavelets Developers
+# Copyright (c) 2012-2016 The PyWavelets Developers
 #                         <https://github.com/PyWavelets/pywt>
 # See COPYING for license details.
 
@@ -158,10 +158,12 @@ def wavedec2(data, wavelet, mode='symmetric', level=None, axes=(-2, -1)):
     ----------
     data : ndarray
         2D input data
-    wavelet : Wavelet object or name string
-        Wavelet to use
-    mode : str, optional
-        Signal extension mode, see Modes (default: 'symmetric')
+    wavelet : Wavelet object or name string, or 2-tuple of wavelets
+        Wavelet to use.  This can also be a tuple containing a wavelet to
+        apply along each axis in ``axes``.
+    mode : str or 2-tuple of str, optional
+        Signal extension mode, see Modes (default: 'symmetric').  This can
+        also be a tuple containing a mode to apply along each axis in ``axes``.
     level : int, optional
         Decomposition level (must be >= 0). If level is None (default) then it
         will be calculated using the ``dwt_max_level`` function.
@@ -230,10 +232,12 @@ def waverec2(coeffs, wavelet, mode='symmetric', axes=(-2, -1)):
 
     coeffs : list or tuple
         Coefficients list [cAn, (cHn, cVn, cDn), ... (cH1, cV1, cD1)]
-    wavelet : Wavelet object or name string
-        Wavelet to use
-    mode : str, optional
-        Signal extension mode, see Modes (default: 'symmetric')
+    wavelet : Wavelet object or name string, or 2-tuple of wavelets
+        Wavelet to use.  This can also be a tuple containing a wavelet to
+        apply along each axis in ``axes``.
+    mode : str or 2-tuple of str, optional
+        Signal extension mode, see Modes (default: 'symmetric').  This can
+        also be a tuple containing a mode to apply along each axis in ``axes``.
     axes : 2-tuple of ints, optional
         Axes over which to compute the IDWT. Repeated elements are not allowed.
 
@@ -298,10 +302,12 @@ def wavedecn(data, wavelet, mode='symmetric', level=None, axes=None):
     ----------
     data : ndarray
         nD input data
-    wavelet : Wavelet object or name string
-        Wavelet to use
-    mode : str, optional
-        Signal extension mode, see Modes (default: 'symmetric')
+    wavelet : Wavelet object or name string, or tuple of wavelets
+        Wavelet to use.  This can also be a tuple containing a wavelet to
+        apply along each axis in ``axes``.
+    mode : str or tuple of str, optional
+        Signal extension mode, see Modes (default: 'symmetric').  This can
+        also be a tuple containing a mode to apply along each axis in ``axes``.
     level : int, optional
         Decomposition level (must be >= 0). If level is None (default) then it
         will be calculated using the ``dwt_max_level`` function.
@@ -411,10 +417,12 @@ def waverecn(coeffs, wavelet, mode='symmetric', axes=None):
 
     coeffs : array_like
         Coefficients list [cAn, {details_level_n}, ... {details_level_1}]
-    wavelet : Wavelet object or name string
-        Wavelet to use
-    mode : str, optional
-        Signal extension mode, see Modes (default: 'symmetric')
+    wavelet : Wavelet object or name string, or tuple of wavelets
+        Wavelet to use.  This can also be a tuple containing a wavelet to
+        apply along each axis in ``axes``.
+    mode : str or tuple of str, optional
+        Signal extension mode, see Modes (default: 'symmetric').  This can
+        also be a tuple containing a mode to apply along each axis in ``axes``.
     axes : sequence of ints, optional
         Axes over which to compute the IDWT.  Axes may not be repeated.
 
@@ -462,7 +470,8 @@ def waverecn(coeffs, wavelet, mode='symmetric', axes=None):
         # level 0 transform (just returns the approximation coefficients)
         return coeffs[0]
     if a is None and not any(ds):
-        raise ValueError("At least one coefficient must contain a valid value.")
+        raise ValueError(
+            "At least one coefficient must contain a valid value.")
 
     coeff_ndims = []
     if a is not None:

--- a/pywt/_swt.py
+++ b/pywt/_swt.py
@@ -164,7 +164,7 @@ def swt2(data, wavelet, level, start_level=0, axes=(-2, -1)):
     ----------
     data : array_like
         2D array with input data
-    wavelet : Wavelet object or name string
+    wavelet : Wavelet object or name string, or 2-tuple of wavelets
         Wavelet to use.  This can also be a tuple of wavelets to apply per
         axis in ``axes``.
     level : int
@@ -246,7 +246,7 @@ def iswt2(coeffs, wavelet):
         where cA is approximation, cH is horizontal details, cV is
         vertical details, cD is diagonal details and n is the number of
         levels.  Index 1 corresponds to ``start_level`` from ``pywt.swt2``.
-    wavelet : Wavelet object or name string
+    wavelet : Wavelet object or name string, or 2-tuple of wavelets
         Wavelet to use.  This can also be a 2-tuple of wavelets to apply per
         axis.
 
@@ -344,7 +344,7 @@ def swtn(data, wavelet, level, start_level=0, axes=None):
     ----------
     data : array_like
         n-dimensional array with input data.
-    wavelet : Wavelet object or name string
+    wavelet : Wavelet object or name string, or tuple of wavelets
         Wavelet to use.  This can also be a tuple of wavelets to apply per
         axis in ``axes``.
     level : int
@@ -429,7 +429,7 @@ def iswtn(coeffs, wavelet, axes=None):
     ----------
     coeffs : list
         [{coeffs_level_n}, ..., {coeffs_level_1}]: list of dict
-    wavelet : Wavelet object or name string
+    wavelet : Wavelet object or name string, or tuple of wavelets
         Wavelet to use.  This can also be a tuple of wavelets to apply per
         axis in ``axes``.
     axes : sequence of ints, optional

--- a/pywt/_swt.py
+++ b/pywt/_swt.py
@@ -165,7 +165,8 @@ def swt2(data, wavelet, level, start_level=0, axes=(-2, -1)):
     data : array_like
         2D array with input data
     wavelet : Wavelet object or name string
-        Wavelet to use
+        Wavelet to use.  This can also be a tuple of wavelets to apply per
+        axis in ``axes``.
     level : int
         The number of decomposition steps to perform.
     start_level : int, optional
@@ -246,7 +247,8 @@ def iswt2(coeffs, wavelet):
         vertical details, cD is diagonal details and n is the number of
         levels.  Index 1 corresponds to ``start_level`` from ``pywt.swt2``.
     wavelet : Wavelet object or name string
-        Wavelet to use
+        Wavelet to use.  This can also be a 2-tuple of wavelets to apply per
+        axis.
 
     Returns
     -------
@@ -267,10 +269,14 @@ def iswt2(coeffs, wavelet):
     """
 
     output = coeffs[-1][0].copy()  # Avoid modification of input data
+    if output.ndim != 2:
+        raise ValueError(
+            "iswt2 only supports 2D arrays.  see iswtn for a general "
+            "n-dimensionsal ISWT")
     # num_levels, equivalent to the decomposition level, n
     num_levels = len(coeffs)
-    if not isinstance(wavelet, Wavelet):
-        wavelet = Wavelet(wavelet)
+    wavelets = _wavelets_per_axis(wavelet, axes=(0, 1))
+
     for j in range(num_levels, 0, -1):
         step_size = int(pow(2, j-1))
         last_index = step_size
@@ -297,22 +303,22 @@ def iswt2(coeffs, wavelet):
                            (cH[even_idx_h, even_idx_w],
                             cV[even_idx_h, even_idx_w],
                             cD[even_idx_h, even_idx_w])),
-                           wavelet, 'periodization')
+                           wavelets, 'periodization')
                 x2 = idwt2((output[even_idx_h, odd_idx_w],
                            (cH[even_idx_h, odd_idx_w],
                             cV[even_idx_h, odd_idx_w],
                             cD[even_idx_h, odd_idx_w])),
-                           wavelet, 'periodization')
+                           wavelets, 'periodization')
                 x3 = idwt2((output[odd_idx_h, even_idx_w],
                            (cH[odd_idx_h, even_idx_w],
                             cV[odd_idx_h, even_idx_w],
                             cD[odd_idx_h, even_idx_w])),
-                           wavelet, 'periodization')
+                           wavelets, 'periodization')
                 x4 = idwt2((output[odd_idx_h, odd_idx_w],
                            (cH[odd_idx_h, odd_idx_w],
                             cV[odd_idx_h, odd_idx_w],
                             cD[odd_idx_h, odd_idx_w])),
-                           wavelet, 'periodization')
+                           wavelets, 'periodization')
 
                 # perform a circular shifts
                 x2 = np.roll(x2, 1, axis=1)

--- a/pywt/_utils.py
+++ b/pywt/_utils.py
@@ -26,19 +26,19 @@ def _wavelets_per_axis(wavelet, axes):
 
     Parameters
     ----------
-    wavelet : Wavelet or list of Wavelets
+    wavelet : Wavelet or tuple of Wavelets
         If a single Wavelet is provided, it will used for all axes.  Otherwise
         one Wavelet per axis must be provided.
     axes : list
-        The list of axes to be transormed.
+        The tuple of axes to be transformed.
 
     Returns
     -------
     wavelets : list of Wavelet objects
-        A list of Wavlets equal in length to axes.
+        A tuple of Wavelets equal in length to ``axes``.
 
     """
-    axes = list(axes)
+    axes = tuple(axes)
     if isinstance(wavelet, string_types + (Wavelet, )):
         # same wavelet on all axes
         wavelets = [_as_wavelet(wavelet), ] * len(axes)
@@ -62,19 +62,19 @@ def _modes_per_axis(modes, axes):
 
     Parameters
     ----------
-    modes : str or list of strings
+    modes : str or tuple of strings
         If a single mode is provided, it will used for all axes.  Otherwise
         one mode per axis must be provided.
-    axes : list
-        The list of axes to be transormed.
+    axes : tuple
+        The tuple of axes to be transformed.
 
     Returns
     -------
-    modes : list of int
-        A list of Modes equal in length to axes.
+    modes : tuple of int
+        A tuple of Modes equal in length to ``axes``.
 
     """
-    axes = list(axes)
+    axes = tuple(axes)
     if isinstance(modes, string_types + (int, )):
         # same wavelet on all axes
         modes = [Modes.from_object(modes), ] * len(axes)

--- a/pywt/_utils.py
+++ b/pywt/_utils.py
@@ -1,0 +1,92 @@
+# Copyright (c) 2017 The PyWavelets Developers
+#                    <https://github.com/PyWavelets/pywt>
+# See COPYING for license details.
+import sys
+from collections import Iterable
+
+from ._extensions._pywt import Wavelet, Modes
+
+
+# define string_types as in six for Python 2/3 compatibility
+if sys.version_info[0] == 3:
+    string_types = str,
+else:
+    string_types = basestring,
+
+
+def _as_wavelet(wavelet):
+    """Convert wavelet name to a Wavelet object"""
+    if not isinstance(wavelet, Wavelet):
+        wavelet = Wavelet(wavelet)
+    return wavelet
+
+
+def _wavelets_per_axis(wavelet, axes):
+    """Initialize Wavelets for each axis to be transformed.
+
+    Parameters
+    ----------
+    wavelet : Wavelet or list of Wavelets
+        If a single Wavelet is provided, it will used for all axes.  Otherwise
+        one Wavelet per axis must be provided.
+    axes : list
+        The list of axes to be transormed.
+
+    Returns
+    -------
+    wavelets : list of Wavelet objects
+        A list of Wavlets equal in length to axes.
+
+    """
+    axes = list(axes)
+    if isinstance(wavelet, string_types + (Wavelet, )):
+        # same wavelet on all axes
+        wavelets = [_as_wavelet(wavelet), ] * len(axes)
+    elif isinstance(wavelet, Iterable):
+        # (potentially) unique wavelet per axis (e.g. for dual-tree DWT)
+        if len(wavelet) == 1:
+            wavelets = [_as_wavelet(wavelet[0]), ] * len(axes)
+        else:
+            if len(wavelet) != len(axes):
+                raise ValueError((
+                    "The number of wavelets must match the number of axes "
+                    "to be transformed."))
+            wavelets = [_as_wavelet(w) for w in wavelet]
+    else:
+        raise ValueError("wavelet must be a str, Wavelet or iterable")
+    return wavelets
+
+
+def _modes_per_axis(modes, axes):
+    """Initialize mode for each axis to be transformed.
+
+    Parameters
+    ----------
+    modes : str or list of strings
+        If a single mode is provided, it will used for all axes.  Otherwise
+        one mode per axis must be provided.
+    axes : list
+        The list of axes to be transormed.
+
+    Returns
+    -------
+    modes : list of int
+        A list of Modes equal in length to axes.
+
+    """
+    axes = list(axes)
+    if isinstance(modes, string_types + (int, )):
+        # same wavelet on all axes
+        modes = [Modes.from_object(modes), ] * len(axes)
+    elif isinstance(modes, Iterable):
+        if len(modes) == 1:
+            modes = [Modes.from_object(modes[0]), ] * len(axes)
+        else:
+            # (potentially) unique wavelet per axis (e.g. for dual-tree DWT)
+            if len(modes) != len(axes):
+                raise ValueError(("The number of modes must match the number "
+                                  "of axes to be transformed."))
+        modes = [Modes.from_object(mode) for mode in modes]
+    else:
+        raise ValueError("modes must be a str, Mode enum or iterable")
+    return modes

--- a/pywt/tests/test_multidim.py
+++ b/pywt/tests/test_multidim.py
@@ -339,5 +339,39 @@ def test_dwt2_dimension_error():
     assert_raises(ValueError, pywt.dwt2, data2, wavelet, axes=(0, 1, 1))
 
 
+def test_per_axis_wavelets_and_modes():
+    # tests seperate wavelet and edge mode for each axis.
+    rstate = np.random.RandomState(1234)
+    data = rstate.randn(16, 16, 16)
+
+    # wavelet can be a string or wavelet object
+    wavelets = (pywt.Wavelet('haar'), 'sym2', 'db4')
+
+    # mode can be a string or a Modes enum
+    modes = ('symmetric', 'periodization',
+             pywt._extensions._pywt.Modes.reflect)
+
+    coefs = pywt.dwtn(data, wavelets, modes)
+    assert_allclose(pywt.idwtn(coefs, wavelets, modes), data, atol=1e-14)
+
+    coefs = pywt.dwtn(data, wavelets[:1], modes)
+    assert_allclose(pywt.idwtn(coefs, wavelets[:1], modes), data, atol=1e-14)
+
+    coefs = pywt.dwtn(data, wavelets, modes[:1])
+    assert_allclose(pywt.idwtn(coefs, wavelets, modes[:1]), data, atol=1e-14)
+
+    # length of wavelets or modes doesn't match the length of axes
+    assert_raises(ValueError, pywt.dwtn, data, wavelets[:2])
+    assert_raises(ValueError, pywt.dwtn, data, wavelets, mode=modes[:2])
+    assert_raises(ValueError, pywt.idwtn, coefs, wavelets[:2])
+    assert_raises(ValueError, pywt.idwtn, coefs, wavelets, mode=modes[:2])
+
+    # dwt2/idwt2 also support per-axis wavelets/modes
+    data2 = data[..., 0]
+    coefs2 = pywt.dwt2(data2, wavelets[:2], modes[:2])
+    assert_allclose(pywt.idwt2(coefs2, wavelets[:2], modes[:2]), data2,
+                    atol=1e-14)
+
+
 if __name__ == '__main__':
     run_module_suite()

--- a/pywt/tests/test_multilevel.py
+++ b/pywt/tests/test_multilevel.py
@@ -566,5 +566,47 @@ def test_waverecn_axes_errors():
     assert_raises(ValueError, pywt.waverecn, c, 'haar', axes=(0, 1, 3))
 
 
+def test_per_axis_wavelets_and_modes():
+    # tests seperate wavelet and edge mode for each axis.
+    rstate = np.random.RandomState(1234)
+    data = rstate.randn(24, 24, 16)
+
+    # wavelet can be a string or wavelet object
+    wavelets = (pywt.Wavelet('haar'), 'sym2', 'db2')
+
+    # The default number of levels should be the minimum over this list
+    max_levels = [pywt._dwt.dwt_max_level(nd, nf) for nd, nf in
+                  zip(data.shape, wavelets)]
+
+    # mode can be a string or a Modes enum
+    modes = ('symmetric', 'periodization',
+             pywt._extensions._pywt.Modes.reflect)
+
+    coefs = pywt.wavedecn(data, wavelets, modes)
+    assert_allclose(pywt.waverecn(coefs, wavelets, modes), data, atol=1e-14)
+    assert_equal(min(max_levels), len(coefs[1:]))
+
+    coefs = pywt.wavedecn(data, wavelets[:1], modes)
+    assert_allclose(pywt.waverecn(coefs, wavelets[:1], modes), data,
+                    atol=1e-14)
+
+    coefs = pywt.wavedecn(data, wavelets, modes[:1])
+    assert_allclose(pywt.waverecn(coefs, wavelets, modes[:1]), data,
+                    atol=1e-14)
+
+    # length of wavelets or modes doesn't match the length of axes
+    assert_raises(ValueError, pywt.wavedecn, data, wavelets[:2])
+    assert_raises(ValueError, pywt.wavedecn, data, wavelets, mode=modes[:2])
+    assert_raises(ValueError, pywt.waverecn, coefs, wavelets[:2])
+    assert_raises(ValueError, pywt.waverecn, coefs, wavelets, mode=modes[:2])
+
+    # dwt2/idwt2 also support per-axis wavelets/modes
+    data2 = data[..., 0]
+    coefs2 = pywt.wavedec2(data2, wavelets[:2], modes[:2])
+    assert_allclose(pywt.waverec2(coefs2, wavelets[:2], modes[:2]), data2,
+                    atol=1e-14)
+    assert_equal(min(max_levels[:2]), len(coefs2[1:]))
+
+
 if __name__ == '__main__':
     run_module_suite()

--- a/pywt/tests/test_swt.py
+++ b/pywt/tests/test_swt.py
@@ -349,5 +349,26 @@ def test_iswtn_errors():
     assert_raises(RuntimeError, pywt.iswtn, coeffs, w, axes=axes)
 
 
+def test_per_axis_wavelets():
+    # tests seperate wavelet for each axis.
+    rstate = np.random.RandomState(1234)
+    data = rstate.randn(16, 16, 16)
+    level = 3
+
+    # wavelet can be a string or wavelet object
+    wavelets = (pywt.Wavelet('haar'), 'sym2', 'db4')
+
+    coefs = pywt.swtn(data, wavelets, level=level)
+    assert_allclose(pywt.iswtn(coefs, wavelets), data, atol=1e-14)
+
+    # 1-tuple also okay
+    coefs = pywt.swtn(data, wavelets[:1], level=level)
+    assert_allclose(pywt.iswtn(coefs, wavelets[:1]), data, atol=1e-14)
+
+    # length of wavelets doesn't match the length of axes
+    assert_raises(ValueError, pywt.swtn, data, wavelets[:2], level)
+    assert_raises(ValueError, pywt.iswtn, coefs, wavelets[:2])
+
+
 if __name__ == '__main__':
     run_module_suite()

--- a/pywt/tests/test_swt.py
+++ b/pywt/tests/test_swt.py
@@ -250,6 +250,15 @@ def test_swt2_axes():
         assert_raises(ValueError, pywt.swt2, X, current_wavelet, 1, axes=(0, ))
 
 
+def test_iswt2_2d_only():
+    # iswt2 is not currently compatible with data that is not 2D
+    x_3d = np.ones((4, 4, 4))
+    with warnings.catch_warnings():
+        warnings.simplefilter('ignore', FutureWarning)
+        c = pywt.swt2(x_3d, 'haar', level=1)
+        assert_raises(ValueError, pywt.iswt2, c, 'haar')
+
+
 def test_swtn_axes():
     atol = 1e-14
     current_wavelet = pywt.Wavelet('db2')
@@ -368,6 +377,11 @@ def test_per_axis_wavelets():
     # length of wavelets doesn't match the length of axes
     assert_raises(ValueError, pywt.swtn, data, wavelets[:2], level)
     assert_raises(ValueError, pywt.iswtn, coefs, wavelets[:2])
+
+    # swt2/iswt2 also support per-axis wavelets/modes
+    data2 = data[..., 0]
+    coefs2 = pywt.swt2(data2, wavelets[:2], level)
+    assert_allclose(pywt.iswt2(coefs2, wavelets[:2]), data2, atol=1e-14)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
An example where this could be useful is in video processing (or volume+time medical imaging applications) where it may make sense to use a different wavelet or edge mode on the time axis as opposed to the spatial axes.

This is also functionality that is needed for implementing the dual-tree complex DWT.  The n-dimensional dual-tree CDWT involves `2**n` seperate `wavedecn` decompositions with different choices among two different filters along each axis.  e.g. in 2D if the two dual-tree wavelets are `w0` and `w1`, there are 4 separate decompositions using wavelets `(w0, w0), (w0, w1), (w1, w0), (w1, w1)` where the elements of the tuple indicate which filter to apply along each axis.

The primary change is implemented in `dwtn` and `idwtn`.  It was then easy to extend to the following routines that are built on top of `dwtn` and `idwtn`:

- dwt2, idwt2
- wavedec2, waverec2
- wavedecn, waverecn
- swtn, iswtn