### PR TITLE
fix non-integer index error

### DIFF
--- a/pywt/data/_readers.py
+++ b/pywt/data/_readers.py
@@ -174,10 +174,10 @@ def nino():
     sst_csv = np.load(fname)['sst_csv']
     # sst_csv = pd.read_csv("http://www.cpc.ncep.noaa.gov/data/indices/ersst4.nino.mth.81-10.ascii", sep=' ', skipinitialspace=True)
     # take only full years
-    n = np.floor(sst_csv.shape[0]/12.)*12.
+    n = int(np.floor(sst_csv.shape[0]/12.)*12.)
     # Building the mean of three mounth
     # the 4. column is nino 3
-    sst = np.mean(np.reshape(np.array(sst_csv)[:n,4],(n/3,-1)),axis=1)
+    sst = np.mean(np.reshape(np.array(sst_csv)[:n, 4], (n//3, -1)), axis=1)
     sst = (sst - np.mean(sst)) / np.std(sst, ddof=1)
 
     dt = 0.25


### PR DESCRIPTION
This is a fix for the failure on Appveyor in the most recent commit (due to a non-integer shape in the data readers):

```
FAIL: Doctest: pywt.data._readers.nino
----------------------------------------------------------------------
Traceback (most recent call last):
  File "c:\python27\lib\doctest.py", line 2226, in runTest
    raise self.failureException(self.format_failure(new.getvalue()))
AssertionError: Failed doctest test for pywt.data._readers.nino
  File "C:\projects\pywt\build\lib\pywt\data\_readers.py", line 142, in nino
----------------------------------------------------------------------
File "C:\projects\pywt\build\lib\pywt\data\_readers.py", line 164, in pywt.data._readers.nino
Failed example:
    time, sst = pywt.data.nino()
Exception raised:
    Traceback (most recent call last):
      File "c:\python27\lib\doctest.py", line 1315, in __run
        compileflags, 1) in test.globs
      File "<doctest pywt.data._readers.nino[1]>", line 1, in <module>
        time, sst = pywt.data.nino()
      File "C:\projects\pywt\build\lib\pywt\data\_readers.py", line 180, in nino
        sst = np.mean(np.reshape(np.array(sst_csv)[:n,4],(n/3,-1)),axis=1)
    TypeError: slice indices must be integers or None or have an __index__ method
----------------------------------------------------------------------
File "C:\projects\pywt\build\lib\pywt\data\_readers.py", line 165, in pywt.data._readers.nino

```