### PR TITLE
ENH: use single precision routines for half-precision inputs

### DIFF
--- a/pywt/_extensions/_pywt.pyx
+++ b/pywt/_extensions/_pywt.pyx
@@ -947,8 +947,12 @@ cpdef np.dtype _check_dtype(data):
     try:
         dt = data.dtype
         if dt not in (np.float64, np.float32):
-            # integer input was always accepted; convert to float64
-            dt = np.dtype('float64')
+            if dt == np.half:
+                # half-precision input converted to single precision
+                dt = np.dtype('float32')
+            else:
+                # integer input was always accepted; convert to float64
+                dt = np.dtype('float64')
     except AttributeError:
         dt = np.dtype('float64')
     return dt

--- a/pywt/tests/test_dwt_idwt.py
+++ b/pywt/tests/test_dwt_idwt.py
@@ -9,8 +9,10 @@ import pywt
 
 # Check that float32 and complex64 are preserved.  Other real types get
 # converted to float64.
-dtypes_in = [np.int8, np.float32, np.float64, np.complex64, np.complex128]
-dtypes_out = [np.float64, np.float32, np.float64, np.complex64, np.complex128]
+dtypes_in = [np.int8, np.float16, np.float32, np.float64, np.complex64,
+             np.complex128]
+dtypes_out = [np.float64, np.float32, np.float32, np.float64, np.complex64,
+              np.complex128]
 
 
 def test_dwt_idwt_basic():

--- a/pywt/tests/test_multidim.py
+++ b/pywt/tests/test_multidim.py
@@ -11,8 +11,10 @@ import pywt
 
 # Check that float32 and complex64 are preserved.  Other real types get
 # converted to float64.
-dtypes_in = [np.int8, np.float32, np.float64, np.complex64, np.complex128]
-dtypes_out = [np.float64, np.float32, np.float64, np.complex64, np.complex128]
+dtypes_in = [np.int8, np.float16, np.float32, np.float64, np.complex64,
+             np.complex128]
+dtypes_out = [np.float64, np.float32, np.float32, np.float64, np.complex64,
+              np.complex128]
 
 
 def test_dwtn_input():

--- a/pywt/tests/test_multilevel.py
+++ b/pywt/tests/test_multilevel.py
@@ -11,15 +11,17 @@ import pywt
 
 # Check that float32 and complex64 are preserved.  Other real types get
 # converted to float64.
-dtypes_in = [np.int8, np.float32, np.float64, np.complex64, np.complex128]
-dtypes_out = [np.float64, np.float32, np.float64, np.complex64, np.complex128]
-
+dtypes_in = [np.int8, np.float16, np.float32, np.float64, np.complex64,
+             np.complex128]
+dtypes_out = [np.float64, np.float32, np.float32, np.float64, np.complex64,
+              np.complex128]
 
 # tolerances used in accuracy comparisons
 tol_single = 1e-6
 tol_double = 1e-13
-dtypes_and_tolerances = [(np.float32, tol_single), (np.float64, tol_double),
-                         (np.int8, tol_double), (np.complex64, tol_single),
+dtypes_and_tolerances = [(np.float16, tol_single), (np.float32, tol_single),
+                         (np.float64, tol_double), (np.int8, tol_double),
+                         (np.complex64, tol_single),
                          (np.complex128, tol_double)]
 
 

--- a/pywt/tests/test_swt.py
+++ b/pywt/tests/test_swt.py
@@ -14,9 +14,10 @@ from pywt._extensions._swt import swt_axis
 
 # Check that float32 and complex64 are preserved.  Other real types get
 # converted to float64.
-dtypes_in = [np.int8, np.float32, np.float64, np.complex64, np.complex128]
-dtypes_out = [np.float64, np.float32, np.float64, np.complex64, np.complex128]
-
+dtypes_in = [np.int8, np.float16, np.float32, np.float64, np.complex64,
+             np.complex128]
+dtypes_out = [np.float64, np.float32, np.float32, np.float64, np.complex64,
+              np.complex128]
 
 # tolerances used in accuracy comparisons
 tol_single = 1e-6


### PR DESCRIPTION
A small change to process half-precision inputs using single precision rather than double.  It's probably a rare use case, but I think that is a more sensible behavior.