### PR TITLE
update wp_scalogram demo work with matplotlib 2.0

### DIFF
--- a/demo/wp_scalogram.py
+++ b/demo/wp_scalogram.py
@@ -40,7 +40,8 @@ ax.set_yticks(np.arange(0.5, len(labels) + 0.5), labels)
 # Show spectrogram and wavelet packet coefficients
 fig2 = plt.figure()
 ax2 = fig2.add_subplot(211)
-ax2.specgram(data, NFFT=64, noverlap=32, cmap=cmap)
+ax2.specgram(data, NFFT=64, noverlap=32, Fs=2, cmap=cmap,
+             interpolation='bilinear')
 ax2.set_title("Spectrogram of signal")
 ax3 = fig2.add_subplot(212)
 ax3.imshow(values, origin='upper', extent=[-1, 1, -1, 1],


### PR DESCRIPTION
After upgrading to matplotlib 2.0, I get the following error in the `wp_scalogram.py` demo:

```
Traceback (most recent call last):
  File "wp_scalogram.py", line 43, in <module>
    ax2.specgram(data, NFFT=64, noverlap=32, cmap=cmap)
  File "/Users/lee8rx/anaconda/lib/python3.5/site-packages/matplotlib/__init__.py", line 1892, in inner
    return func(ax, *args, **kwargs)
  File "/Users/lee8rx/anaconda/lib/python3.5/site-packages/matplotlib/axes/_axes.py", line 7232, in specgram
    pad_xextent = (NFFT-noverlap) / Fs / 2
TypeError: unsupported operand type(s) for /: 'int' and 'NoneType'
```
If I specify `Fs = 2`, I get the same result as previously (e.g. y axis range from [0, 1.0]).  I have no experience with the `specgram` function, so I am not certain if this is the best solution, but it seems to work.

here is the image from matplotlib 1.5.3:
![mpl_1 5 3](https://cloud.githubusercontent.com/assets/6528957/22098831/7e1d5476-ddf6-11e6-96af-dd2acb30518d.png)


and here is matplotlib 2.0:
![mpl_2 0 0](https://cloud.githubusercontent.com/assets/6528957/22098835/87a66744-ddf6-11e6-91ce-f25083a4d375.png)


note that the default interpolation changed to `nearest` and the new `viridis` default colormap is used 