### PR TITLE
BLD: add Python 3.6 to the Appveyor build matrix

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,6 +14,8 @@ environment:
       DISTUTILS_USE_SDK: "1"
     - PYTHON: "C:\\Python35"
     - PYTHON: "C:\\Python35-x64"
+    - PYTHON: "C:\\Python36"
+    - PYTHON: "C:\\Python36-x64"
 
 build: off
 


### PR DESCRIPTION
trying adding Python 3.6 on Appveyor