### PR TITLE
MAINT: Package the license file

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,6 @@
 include setup.py
 include README.rst
+include LICENSE
 include *.txt
 include MANIFEST.in
 


### PR DESCRIPTION
Adds the license file to `MANIFEST.in` so it will be included in `sdist`s and other packages. This is done both to ensure compliance with the license terms and also for the benefit of end-users.