### PR TITLE
fix memory leak in swt_axis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -60,7 +60,7 @@ before_install:
   - pip install --upgrade wheel
   # Set numpy version first, other packages link against it
   - pip install $NUMPYSPEC
-  - pip install Cython matplotlib nose coverage codecov
+  - pip install Cython matplotlib nose coverage codecov futures
   - set -o pipefail
   - |
     if [ "${REFGUIDE_CHECK}" == "1" ]; then

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -23,7 +23,7 @@ install:
   - "util\\appveyor\\build.cmd %PYTHON%\\python.exe -m pip install
      numpy --cache-dir c:\\tmp\\pip-cache"
   - "util\\appveyor\\build.cmd %PYTHON%\\python.exe -m pip install
-     Cython nose coverage matplotlib --cache-dir c:\\tmp\\pip-cache"
+     Cython nose coverage matplotlib futures --cache-dir c:\\tmp\\pip-cache"
 
 test_script:
   - "util\\appveyor\\build.cmd %PYTHON%\\python.exe setup.py build --build-lib build\\lib\\"

--- a/pywt/_extensions/_swt.pyx
+++ b/pywt/_extensions/_swt.pyx
@@ -102,8 +102,7 @@ cpdef swt_axis(np.ndarray data, Wavelet wavelet, size_t level,
     # memory-views do not support n-dimensional arrays, use np.ndarray instead
     cdef common.ArrayInfo data_info, output_info
     cdef np.ndarray cD, cA
-    # Explicit input_shape necessary to prevent memory leak
-    cdef size_t[::1] input_shape, output_shape
+    cdef size_t[::1] output_shape
     cdef size_t end_level = start_level + level
     cdef int retval
     cdef size_t i
@@ -123,28 +122,23 @@ cpdef swt_axis(np.ndarray data, Wavelet wavelet, size_t level,
         raise ValueError(msg)
 
     data = data.astype(_check_dtype(data), copy=False)
-
-    input_shape = <size_t [:data.ndim]> <size_t *> data.shape
-    output_shape = input_shape.copy()
-    output_shape[axis] = common.swt_buffer_length(data.shape[axis])
-    if output_shape[axis] != input_shape[axis]:
-        raise RuntimeError("swt_axis assumes output_shape is the same as "
-                           "input_shape")
+    # For SWT, the output matches the shape of the input
+    output_shape = <size_t [:data.ndim]> <size_t *> data.shape
 
     data_info.ndim = data.ndim
     data_info.strides = <pywt_index_t *> data.strides
     data_info.shape = <size_t *> data.shape
 
-    cA = np.empty(output_shape, data.dtype)
-    output_info.ndim = cA.ndim
-    output_info.strides = <pywt_index_t *> cA.strides
-    output_info.shape = <size_t *> cA.shape
+    output_info.ndim = data.ndim
 
     ret = []
     for i in range(start_level+1, end_level+1):
-
+        cA = np.empty(output_shape, dtype=data.dtype)
+        cD = np.empty(output_shape, dtype=data.dtype)
+        # strides won't match data_info.strides if data is not C-contiguous
+        output_info.strides = <pywt_index_t *> cA.strides
+        output_info.shape = <size_t *> cA.shape
         if data.dtype == np.float64:
-            cA = np.zeros(output_shape, dtype=np.float64)
             with nogil:
                 retval = c_wt.double_downcoef_axis(
                     <double *> data.data, data_info,
@@ -153,8 +147,8 @@ cpdef swt_axis(np.ndarray data, Wavelet wavelet, size_t level,
                     common.COEF_APPROX, common.MODE_PERIODIZATION,
                     i, common.SWT_TRANSFORM)
             if retval:
-                raise RuntimeError("C wavelet transform failed")
-            cD = np.zeros(output_shape, dtype=np.float64)
+                raise RuntimeError(
+                    "C wavelet transform failed with error code %d" % retval)
             with nogil:
                 retval = c_wt.double_downcoef_axis(
                     <double *> data.data, data_info,
@@ -163,9 +157,9 @@ cpdef swt_axis(np.ndarray data, Wavelet wavelet, size_t level,
                     common.COEF_DETAIL, common.MODE_PERIODIZATION,
                     i, common.SWT_TRANSFORM)
             if retval:
-                raise RuntimeError("C wavelet transform failed")
+                raise RuntimeError(
+                    "C wavelet transform failed with error code %d" % retval)
         elif data.dtype == np.float32:
-            cA = np.zeros(output_shape, dtype=np.float32)
             with nogil:
                 retval = c_wt.float_downcoef_axis(
                     <float *> data.data, data_info,
@@ -174,8 +168,8 @@ cpdef swt_axis(np.ndarray data, Wavelet wavelet, size_t level,
                     common.COEF_APPROX, common.MODE_PERIODIZATION,
                     i, common.SWT_TRANSFORM)
             if retval:
-                raise RuntimeError("C wavelet transform failed")
-            cD = np.zeros(output_shape, dtype=np.float32)
+                raise RuntimeError(
+                    "C wavelet transform failed with error code %d" % retval)
             with nogil:
                 retval = c_wt.float_downcoef_axis(
                     <float *> data.data, data_info,
@@ -184,7 +178,8 @@ cpdef swt_axis(np.ndarray data, Wavelet wavelet, size_t level,
                     common.COEF_DETAIL, common.MODE_PERIODIZATION,
                     i, common.SWT_TRANSFORM)
             if retval:
-                raise RuntimeError("C wavelet transform failed")
+                raise RuntimeError(
+                    "C wavelet transform failed with error code %d" % retval)
         else:
             raise TypeError("Array must be floating point, not {}"
                             .format(data.dtype))
@@ -192,7 +187,9 @@ cpdef swt_axis(np.ndarray data, Wavelet wavelet, size_t level,
 
         # previous approx coeffs are the data for the next level
         data = cA
-        data_info = output_info
+        # update data_info to match the new data array
+        data_info.strides = <pywt_index_t *> data.strides
+        data_info.shape = <size_t *> data.shape
 
     ret.reverse()
     return ret

--- a/pywt/_extensions/c/wt.template.c
+++ b/pywt/_extensions/c/wt.template.c
@@ -36,7 +36,7 @@ int CAT(TYPE, _downcoef_axis)(const TYPE * const restrict input, const ArrayInfo
     if (input_info.ndim != output_info.ndim)
         return 1;
     if (axis >= input_info.ndim)
-        return 1;
+        return 2;
 
     for (i = 0; i < input_info.ndim; ++i){
         if (i == axis){
@@ -44,17 +44,17 @@ int CAT(TYPE, _downcoef_axis)(const TYPE * const restrict input, const ArrayInfo
             case DWT_TRANSFORM:
                 if (dwt_buffer_length(input_info.shape[i], wavelet->dec_len,
                                       dwt_mode) != output_info.shape[i])
-                    return 1;
+                    return 3;
                 break;
             case SWT_TRANSFORM:
                 if (swt_buffer_length(input_info.shape[i])
                     != output_info.shape[i])
-                    return 1;
+                    return 4;
                 break;
             }
         } else {
             if (input_info.shape[i] != output_info.shape[i])
-                return 1;
+                return 5;
         }
     }
 
@@ -160,7 +160,7 @@ int CAT(TYPE, _downcoef_axis)(const TYPE * const restrict input, const ArrayInfo
  cleanup:
     free(temp_input);
     free(temp_output);
-    return 2;
+    return 6;
 }
 
 

--- a/pywt/tests/test_concurrent.py
+++ b/pywt/tests/test_concurrent.py
@@ -1,0 +1,117 @@
+"""
+Tests used to verify running PyWavelets transforms in parallel via
+concurrent.futures.ThreadPoolExecutor does not raise errors.
+"""
+
+from __future__ import division, print_function, absolute_import
+
+import sys
+import warnings
+import numpy as np
+from functools import partial
+from numpy.testing import dec, run_module_suite, assert_array_equal
+
+import pywt
+
+try:
+    if sys.version_info[0] == 2:
+        import futures
+    else:
+        from concurrent import futures
+    futures_available = True
+except ImportError:
+    futures_available = False
+
+
+def _assert_all_coeffs_equal(coefs1, coefs2):
+    # return True only if all coefficients of SWT or DWT match over all levels
+    if len(coefs1) != len(coefs2):
+        return False
+    for (c1, c2) in zip(coefs1, coefs2):
+        if isinstance(c1, tuple):
+            # for swt, swt2, dwt, dwt2, wavedec, wavedec2
+            for a1, a2 in zip(c1, c2):
+                assert_array_equal(a1, a2)
+        elif isinstance(c1, dict):
+            # for swtn, dwtn, wavedecn
+            for k, v in c1.items():
+                assert_array_equal(v, c2[k])
+        else:
+            return False
+    return True
+
+
+@dec.skipif(not futures_available)
+def test_concurrent_swt():
+    # tests error-free concurrent operation (see gh-288)
+    # swt on 1D data calls the Cython swt
+    # other cases call swt_axes
+    with warnings.catch_warnings():
+        # can remove catch_warnings once the swt2 FutureWarning is removed
+        warnings.simplefilter('ignore', FutureWarning)
+        for swt_func, x in zip([pywt.swt, pywt.swt2, pywt.swtn],
+                               [np.ones(8), np.eye(16), np.eye(16)]):
+            transform = partial(swt_func, wavelet='haar', level=1)
+            for _ in range(10):
+                arrs = [x.copy() for _ in range(100)]
+                with futures.ThreadPoolExecutor() as ex:
+                    results = list(ex.map(transform, arrs))
+
+        # validate result from  one of the concurrent runs
+        expected_result = transform(x)
+        _assert_all_coeffs_equal(expected_result, results[-1])
+
+
+@dec.skipif(not futures_available)
+def test_concurrent_wavedec():
+    # wavedec on 1D data calls the Cython dwt_single
+    # other cases call dwt_axes
+    for wavedec_func, x in zip([pywt.wavedec, pywt.wavedec2, pywt.wavedecn],
+                               [np.ones(8), np.eye(16), np.eye(16)]):
+        transform = partial(wavedec_func, wavelet='haar', level=1)
+        for _ in range(10):
+            arrs = [x.copy() for _ in range(100)]
+            with futures.ThreadPoolExecutor() as ex:
+                results = list(ex.map(transform, arrs))
+
+        # validate result from  one of the concurrent runs
+        expected_result = transform(x)
+        _assert_all_coeffs_equal(expected_result, results[-1])
+
+
+@dec.skipif(not futures_available)
+def test_concurrent_dwt():
+    # dwt on 1D data calls the Cython dwt_single
+    # other cases call dwt_axes
+    for dwt_func, x in zip([pywt.dwt, pywt.dwt2, pywt.dwtn],
+                           [np.ones(8), np.eye(16), np.eye(16)]):
+        transform = partial(dwt_func, wavelet='haar')
+        for _ in range(10):
+            arrs = [x.copy() for _ in range(100)]
+            with futures.ThreadPoolExecutor() as ex:
+                results = list(ex.map(transform, arrs))
+
+        # validate result from  one of the concurrent runs
+        expected_result = transform(x)
+        _assert_all_coeffs_equal([expected_result, ], [results[-1], ])
+
+
+@dec.skipif(not futures_available)
+def test_concurrent_cwt():
+    time, sst = pywt.data.nino()
+    dt = time[1]-time[0]
+    transform = partial(pywt.cwt, scales=np.arange(1, 4), wavelet='cmor',
+                        sampling_period=dt)
+    for _ in range(10):
+        arrs = [sst.copy() for _ in range(50)]
+        with futures.ThreadPoolExecutor() as ex:
+            results = list(ex.map(transform, arrs))
+
+    # validate result from  one of the concurrent runs
+    expected_result = transform(sst)
+    for a1, a2 in zip(expected_result, results[-1]):
+        assert_array_equal(a1, a2)
+
+
+if __name__ == '__main__':
+    run_module_suite()

--- a/pywt/tests/test_concurrent.py
+++ b/pywt/tests/test_concurrent.py
@@ -7,6 +7,7 @@ from __future__ import division, print_function, absolute_import
 
 import sys
 import warnings
+import multiprocessing
 import numpy as np
 from functools import partial
 from numpy.testing import dec, run_module_suite, assert_array_equal
@@ -18,6 +19,7 @@ try:
         import futures
     else:
         from concurrent import futures
+    max_workers = multiprocessing.cpu_count()
     futures_available = True
 except ImportError:
     futures_available = False
@@ -54,7 +56,7 @@ def test_concurrent_swt():
             transform = partial(swt_func, wavelet='haar', level=1)
             for _ in range(10):
                 arrs = [x.copy() for _ in range(100)]
-                with futures.ThreadPoolExecutor() as ex:
+                with futures.ThreadPoolExecutor(max_workers=max_workers) as ex:
                     results = list(ex.map(transform, arrs))
 
         # validate result from  one of the concurrent runs
@@ -65,13 +67,13 @@ def test_concurrent_swt():
 @dec.skipif(not futures_available)
 def test_concurrent_wavedec():
     # wavedec on 1D data calls the Cython dwt_single
-    # other cases call dwt_axes
+    # other cases call dwt_axis
     for wavedec_func, x in zip([pywt.wavedec, pywt.wavedec2, pywt.wavedecn],
                                [np.ones(8), np.eye(16), np.eye(16)]):
         transform = partial(wavedec_func, wavelet='haar', level=1)
         for _ in range(10):
             arrs = [x.copy() for _ in range(100)]
-            with futures.ThreadPoolExecutor() as ex:
+            with futures.ThreadPoolExecutor(max_workers=max_workers) as ex:
                 results = list(ex.map(transform, arrs))
 
         # validate result from  one of the concurrent runs
@@ -82,13 +84,13 @@ def test_concurrent_wavedec():
 @dec.skipif(not futures_available)
 def test_concurrent_dwt():
     # dwt on 1D data calls the Cython dwt_single
-    # other cases call dwt_axes
+    # other cases call dwt_axis
     for dwt_func, x in zip([pywt.dwt, pywt.dwt2, pywt.dwtn],
                            [np.ones(8), np.eye(16), np.eye(16)]):
         transform = partial(dwt_func, wavelet='haar')
         for _ in range(10):
             arrs = [x.copy() for _ in range(100)]
-            with futures.ThreadPoolExecutor() as ex:
+            with futures.ThreadPoolExecutor(max_workers=max_workers) as ex:
                 results = list(ex.map(transform, arrs))
 
         # validate result from  one of the concurrent runs
@@ -104,7 +106,7 @@ def test_concurrent_cwt():
                         sampling_period=dt)
     for _ in range(10):
         arrs = [sst.copy() for _ in range(50)]
-        with futures.ThreadPoolExecutor() as ex:
+        with futures.ThreadPoolExecutor(max_workers=max_workers) as ex:
             results = list(ex.map(transform, arrs))
 
     # validate result from  one of the concurrent runs


### PR DESCRIPTION
Previous to this patch, `output_dims.shape` and `output_dims.strides` could end up pointing to an invalid memory location.  I have moved the setting of these attributes inside the levels loop so that they are always pointing to a current array.  

This allows removing one initial `np.empty` call prior to that loop.  I also change the `cA` and `cD` initializations to use `np.empty` rather than `np.zeros` for efficiency.

For the SWT, `input_shape` and `output_shape` are always the same, so I removed the `input_shape` variable.  I initially tried removing `output_dims` and just using `data_dims` in its place, but this breaks any case where the input array is not C-contiguous as the strides are then different.  (The outputs of this function are C-contiguous, but the input does not have to be).

closes gh-288