### PR TITLE
FIX: shape adjustment in waverec should not assume a transform along …

### DIFF
--- a/pywt/_multilevel.py
+++ b/pywt/_multilevel.py
@@ -144,10 +144,13 @@ def waverec(coeffs, wavelet, mode='symmetric', axis=-1):
 
     for d in ds:
         if (a is not None) and (d is not None):
-            if a.shape[axis] == d.shape[axis] + 1:
-                a = a[[slice(s) for s in d.shape]]
-            elif a.shape[axis] != d.shape[axis]:
-                raise RuntimeError("coefficient shape mismatch")
+            try:
+                if a.shape[axis] == d.shape[axis] + 1:
+                    a = a[[slice(s) for s in d.shape]]
+                elif a.shape[axis] != d.shape[axis]:
+                    raise ValueError("coefficient shape mismatch")
+            except IndexError:
+                raise ValueError("Axis greater than coefficient dimensions")
         a = idwt(a, d, wavelet, mode, axis)
 
     return a

--- a/pywt/_multilevel.py
+++ b/pywt/_multilevel.py
@@ -143,8 +143,11 @@ def waverec(coeffs, wavelet, mode='symmetric', axis=-1):
     a, ds = coeffs[0], coeffs[1:]
 
     for d in ds:
-        if (a is not None) and (d is not None) and (len(a) == len(d) + 1):
-            a = a[:-1]
+        if (a is not None) and (d is not None):
+            if a.shape[axis] == d.shape[axis] + 1:
+                a = a[[slice(s) for s in d.shape]]
+            elif a.shape[axis] != d.shape[axis]:
+                raise RuntimeError("coefficient shape mismatch")
         a = idwt(a, d, wavelet, mode, axis)
 
     return a

--- a/pywt/tests/test_multilevel.py
+++ b/pywt/tests/test_multilevel.py
@@ -540,6 +540,13 @@ def test_waverec_axis_error():
     assert_raises(ValueError, pywt.waverec, c, 'haar', axis=1)
 
 
+def test_waverec_shape_mismatch_error():
+    c = pywt.wavedec(np.ones(16), 'haar')
+    # truncate a detail coefficient to an incorrect shape
+    c[3] = c[3][:-1]
+    assert_raises(ValueError, pywt.waverec, c, 'haar', axis=1)
+
+
 def test_wavedec2_axes_errors():
     data = np.ones((4, 4))
     # integer axes not allowed

--- a/pywt/tests/test_multilevel.py
+++ b/pywt/tests/test_multilevel.py
@@ -488,6 +488,16 @@ def test_waverec_axes_subsets():
         assert_allclose(rec, data, atol=1e-14)
 
 
+def test_waverec_axis_db2():
+    """test for fix to issue gh-293"""
+    rstate = np.random.RandomState(0)
+    data = rstate.standard_normal((16, 16))
+    for axis in [0, 1]:
+        coefs = pywt.wavedec(data, 'db2', axis=axis)
+        rec = pywt.waverec(coefs, 'db2', axis=axis)
+        assert_allclose(rec, data, atol=1e-14)
+
+
 def test_waverec2_axes_subsets():
     rstate = np.random.RandomState(0)
     data = rstate.standard_normal((8, 8, 8))


### PR DESCRIPTION
…axis 0

see detailed description of the issue in #293

The basic issue relates to forward followed by inverse DWT of odd-sized data results in an array that is rounded up to the next largest even size.  The various multilevel DWT routines truncate the extra sample appropriately to deal with this.  This fixes a bug where this was not done appropriately in `waverec` when `axis != 0`.