### PR TITLE
backporting bug fixes from master to 0.5.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ matrix:
         - PYFLAKES=1
         - PEP8=1
         - NUMPYSPEC=numpy
+        - MPLSPEC=matplotlib
       before_install:
         - pip install pep8==1.5.1
         - pip install pyflakes
@@ -25,22 +26,27 @@ matrix:
     - python: 3.5
       env:
         - NUMPYSPEC=numpy
+        - MPLSPEC=matplotlib
         - USE_WHEEL=1
     - os: linux
       python: 3.4
       env:
         - NUMPYSPEC=numpy
+        - MPLSPEC=matplotlib
         - USE_SDIST=1
     - os: linux
       python: 2.6
       env:
         - NUMPYSPEC="numpy==1.9.3"
+        - MPLSPEC="matplotlib<2"
     - python: 2.7
       env:
         - NUMPYSPEC=numpy
+        - MPLSPEC=matplotlib
     - python: 3.5
       env:
         - NUMPYSPEC=numpy
+        - MPLSPEC=matplotlib
         - REFGUIDE_CHECK=1  # run doctests only
 
 cache: pip
@@ -55,7 +61,7 @@ before_install:
   - pip install --upgrade wheel
   # Set numpy version first, other packages link against it
   - pip install $NUMPYSPEC
-  - pip install Cython matplotlib nose coverage codecov futures
+  - pip install Cython $MPLSPEC nose coverage codecov futures
   - set -o pipefail
   - if [ "${USE_WHEEL}" == "1" ]; then pip install wheel; fi
   - |

--- a/.travis.yml
+++ b/.travis.yml
@@ -52,7 +52,7 @@ before_install:
   - pip install --upgrade wheel
   # Set numpy version first, other packages link against it
   - pip install $NUMPYSPEC
-  - pip install Cython matplotlib nose coverage codecov
+  - pip install Cython matplotlib nose coverage codecov futures
   - set -o pipefail
   - |
     if [ "${REFGUIDE_CHECK}" == "1" ]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,14 +22,17 @@ matrix:
       script:
         - PYFLAKES_NODOCTEST=1 pyflakes pywt demo | grep -E -v 'unable to detect undefined names|assigned to but never used|imported but unused|redefinition of unused' > test.out; cat test.out; test \! -s test.out
         - pep8 pywt demo
-
     - python: 3.5
       env:
         - NUMPYSPEC=numpy
-    - python: 3.4
+        - USE_WHEEL=1
+    - os: linux
+      python: 3.4
       env:
         - NUMPYSPEC=numpy
-    - python: 2.6
+        - USE_SDIST=1
+    - os: linux
+      python: 2.6
       env:
         - NUMPYSPEC="numpy==1.9.3"
     - python: 2.7
@@ -54,6 +57,7 @@ before_install:
   - pip install $NUMPYSPEC
   - pip install Cython matplotlib nose coverage codecov futures
   - set -o pipefail
+  - if [ "${USE_WHEEL}" == "1" ]; then pip install wheel; fi
   - |
     if [ "${REFGUIDE_CHECK}" == "1" ]; then
         pip install sphinx numpydoc
@@ -62,7 +66,21 @@ before_install:
 script:
   # Define a fixed build dir so next step works
   - |
-    if [ "${REFGUIDE_CHECK}" == "1" ]; then
+    if [ "${USE_WHEEL}" == "1" ]; then
+        # Need verbose output or TravisCI will terminate after 10 minutes
+        pip wheel . -v
+        pip install PyWavelets*.whl -v
+        pushd demo
+        nosetests pywt
+        popd
+    elif [ "${USE_SDIST}" == "1" ]; then
+        python setup.py sdist
+        # Move out of source directory to avoid finding local pywt
+        pushd dist
+        pip install PyWavelets* -v
+        nosetests pywt
+        popd
+    elif [ "${REFGUIDE_CHECK}" == "1" ]; then
         pip install -e . -v
         python util/refguide_check.py --doctests
     else

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -23,7 +23,7 @@ install:
   - "util\\appveyor\\build.cmd %PYTHON%\\python.exe -m pip install
      numpy --cache-dir c:\\tmp\\pip-cache"
   - "util\\appveyor\\build.cmd %PYTHON%\\python.exe -m pip install
-     Cython nose coverage matplotlib --cache-dir c:\\tmp\\pip-cache"
+     Cython nose coverage matplotlib futures --cache-dir c:\\tmp\\pip-cache"
 
 test_script:
   - "util\\appveyor\\build.cmd %PYTHON%\\python.exe setup.py build --build-lib build\\lib\\"

--- a/demo/wp_scalogram.py
+++ b/demo/wp_scalogram.py
@@ -40,7 +40,8 @@ ax.set_yticks(np.arange(0.5, len(labels) + 0.5), labels)
 # Show spectrogram and wavelet packet coefficients
 fig2 = plt.figure()
 ax2 = fig2.add_subplot(211)
-ax2.specgram(data, NFFT=64, noverlap=32, cmap=cmap)
+ax2.specgram(data, NFFT=64, noverlap=32, Fs=2, cmap=cmap,
+             interpolation='bilinear')
 ax2.set_title("Spectrogram of signal")
 ax3 = fig2.add_subplot(212)
 ax3.imshow(values, origin='upper', extent=[-1, 1, -1, 1],

--- a/pywt/_extensions/_swt.pyx
+++ b/pywt/_extensions/_swt.pyx
@@ -102,8 +102,7 @@ cpdef swt_axis(np.ndarray data, Wavelet wavelet, size_t level,
     # memory-views do not support n-dimensional arrays, use np.ndarray instead
     cdef common.ArrayInfo data_info, output_info
     cdef np.ndarray cD, cA
-    # Explicit input_shape necessary to prevent memory leak
-    cdef size_t[::1] input_shape, output_shape
+    cdef size_t[::1] output_shape
     cdef size_t end_level = start_level + level
     cdef int i, retval
 
@@ -122,28 +121,23 @@ cpdef swt_axis(np.ndarray data, Wavelet wavelet, size_t level,
         raise ValueError(msg)
 
     data = data.astype(_check_dtype(data), copy=False)
-
-    input_shape = <size_t [:data.ndim]> <size_t *> data.shape
-    output_shape = input_shape.copy()
-    output_shape[axis] = common.swt_buffer_length(data.shape[axis])
-    if output_shape[axis] != input_shape[axis]:
-        raise RuntimeError("swt_axis assumes output_shape is the same as "
-                           "input_shape")
+    # For SWT, the output matches the shape of the input
+    output_shape = <size_t [:data.ndim]> <size_t *> data.shape
 
     data_info.ndim = data.ndim
     data_info.strides = <pywt_index_t *> data.strides
     data_info.shape = <size_t *> data.shape
 
-    cA = np.empty(output_shape, data.dtype)
-    output_info.ndim = cA.ndim
-    output_info.strides = <pywt_index_t *> cA.strides
-    output_info.shape = <size_t *> cA.shape
+    output_info.ndim = data.ndim
 
     ret = []
     for i in range(start_level+1, end_level+1):
-
+        cA = np.empty(output_shape, dtype=data.dtype)
+        cD = np.empty(output_shape, dtype=data.dtype)
+        # strides won't match data_info.strides if data is not C-contiguous
+        output_info.strides = <pywt_index_t *> cA.strides
+        output_info.shape = <size_t *> cA.shape
         if data.dtype == np.float64:
-            cA = np.zeros(output_shape, dtype=np.float64)
             with nogil:
                 retval = c_wt.double_downcoef_axis(
                     <double *> data.data, data_info,
@@ -152,8 +146,8 @@ cpdef swt_axis(np.ndarray data, Wavelet wavelet, size_t level,
                     common.COEF_APPROX, common.MODE_PERIODIZATION,
                     i, common.SWT_TRANSFORM)
             if retval:
-                raise RuntimeError("C wavelet transform failed")
-            cD = np.zeros(output_shape, dtype=np.float64)
+                raise RuntimeError(
+                    "C wavelet transform failed with error code %d" % retval)
             with nogil:
                 retval = c_wt.double_downcoef_axis(
                     <double *> data.data, data_info,
@@ -162,9 +156,9 @@ cpdef swt_axis(np.ndarray data, Wavelet wavelet, size_t level,
                     common.COEF_DETAIL, common.MODE_PERIODIZATION,
                     i, common.SWT_TRANSFORM)
             if retval:
-                raise RuntimeError("C wavelet transform failed")
+                raise RuntimeError(
+                    "C wavelet transform failed with error code %d" % retval)
         elif data.dtype == np.float32:
-            cA = np.zeros(output_shape, dtype=np.float32)
             with nogil:
                 retval = c_wt.float_downcoef_axis(
                     <float *> data.data, data_info,
@@ -173,8 +167,8 @@ cpdef swt_axis(np.ndarray data, Wavelet wavelet, size_t level,
                     common.COEF_APPROX, common.MODE_PERIODIZATION,
                     i, common.SWT_TRANSFORM)
             if retval:
-                raise RuntimeError("C wavelet transform failed")
-            cD = np.zeros(output_shape, dtype=np.float32)
+                raise RuntimeError(
+                    "C wavelet transform failed with error code %d" % retval)
             with nogil:
                 retval = c_wt.float_downcoef_axis(
                     <float *> data.data, data_info,
@@ -183,7 +177,8 @@ cpdef swt_axis(np.ndarray data, Wavelet wavelet, size_t level,
                     common.COEF_DETAIL, common.MODE_PERIODIZATION,
                     i, common.SWT_TRANSFORM)
             if retval:
-                raise RuntimeError("C wavelet transform failed")
+                raise RuntimeError(
+                    "C wavelet transform failed with error code %d" % retval)
         else:
             raise TypeError("Array must be floating point, not {}"
                             .format(data.dtype))
@@ -191,7 +186,9 @@ cpdef swt_axis(np.ndarray data, Wavelet wavelet, size_t level,
 
         # previous approx coeffs are the data for the next level
         data = cA
-        data_info = output_info
+        # update data_info to match the new data array
+        data_info.strides = <pywt_index_t *> data.strides
+        data_info.shape = <size_t *> data.shape
 
     ret.reverse()
     return ret

--- a/pywt/_extensions/c/wt.template.c
+++ b/pywt/_extensions/c/wt.template.c
@@ -36,7 +36,7 @@ int CAT(TYPE, _downcoef_axis)(const TYPE * const restrict input, const ArrayInfo
     if (input_info.ndim != output_info.ndim)
         return 1;
     if (axis >= input_info.ndim)
-        return 1;
+        return 2;
 
     for (i = 0; i < input_info.ndim; ++i){
         if (i == axis){
@@ -44,17 +44,17 @@ int CAT(TYPE, _downcoef_axis)(const TYPE * const restrict input, const ArrayInfo
             case DWT_TRANSFORM:
                 if (dwt_buffer_length(input_info.shape[i], wavelet->dec_len,
                                       dwt_mode) != output_info.shape[i])
-                    return 1;
+                    return 3;
                 break;
             case SWT_TRANSFORM:
                 if (swt_buffer_length(input_info.shape[i])
                     != output_info.shape[i])
-                    return 1;
+                    return 4;
                 break;
             }
         } else {
             if (input_info.shape[i] != output_info.shape[i])
-                return 1;
+                return 5;
         }
     }
 
@@ -160,7 +160,7 @@ int CAT(TYPE, _downcoef_axis)(const TYPE * const restrict input, const ArrayInfo
  cleanup:
     free(temp_input);
     free(temp_output);
-    return 2;
+    return 6;
 }
 
 

--- a/pywt/_multidim.py
+++ b/pywt/_multidim.py
@@ -79,11 +79,14 @@ def idwt2(coeffs, wavelet, mode='symmetric', axes=(-2, -1)):
     ----------
     coeffs : tuple
         (cA, (cH, cV, cD)) A tuple with approximation coefficients and three
-        details coefficients 2D arrays like from `dwt2()`
+        details coefficients 2D arrays like from `dwt2`. If any of these
+        components are set to ``None``, it will be treated as zeros.
     wavelet : Wavelet object or name string
         Wavelet to use
     mode : str, optional
         Signal extension mode, see Modes (default: 'symmetric')
+        details coefficients 2D arrays like from `dwt2`.  If any of these
+        components are set to ``None``, it will be treated as zeros.
     axes : 2-tuple of ints, optional
         Axes over which to compute the IDWT. Repeated elements mean the IDWT
         will be performed multiple times along these axes.
@@ -211,8 +214,8 @@ def idwtn(coeffs, wavelet, mode='symmetric', axes=None):
     Parameters
     ----------
     coeffs: dict
-        Dictionary as in output of `dwtn`. Missing or None items
-        will be treated as zeroes.
+        Dictionary as in output of `dwtn`. Missing or ``None`` items
+        will be treated as zeros.
     wavelet : Wavelet object or name string
         Wavelet to use
     mode : str, optional

--- a/pywt/_multidim.py
+++ b/pywt/_multidim.py
@@ -85,8 +85,6 @@ def idwt2(coeffs, wavelet, mode='symmetric', axes=(-2, -1)):
         Wavelet to use
     mode : str, optional
         Signal extension mode, see Modes (default: 'symmetric')
-        details coefficients 2D arrays like from `dwt2`.  If any of these
-        components are set to ``None``, it will be treated as zeros.
     axes : 2-tuple of ints, optional
         Axes over which to compute the IDWT. Repeated elements mean the IDWT
         will be performed multiple times along these axes.

--- a/pywt/_multidim.py
+++ b/pywt/_multidim.py
@@ -106,10 +106,6 @@ def idwt2(coeffs, wavelet, mode='symmetric', axes=(-2, -1)):
         raise ValueError("Expected 2 axes")
 
     coeffs = {'aa': LL, 'da': HL, 'ad': LH, 'dd': HH}
-
-    # drop the keys corresponding to value = None
-    coeffs = dict((k, v) for k, v in coeffs.items() if v is not None)
-
     return idwtn(coeffs, wavelet, mode, axes)
 
 
@@ -239,6 +235,9 @@ def idwtn(coeffs, wavelet, mode='symmetric', axes=None):
     if not isinstance(wavelet, Wavelet):
         wavelet = Wavelet(wavelet)
     mode = Modes.from_object(mode)
+
+    # drop the keys corresponding to value = None
+    coeffs = dict((k, v) for k, v in coeffs.items() if v is not None)
 
     # Raise error for invalid key combinations
     coeffs = _fix_coeffs(coeffs)

--- a/pywt/_multilevel.py
+++ b/pywt/_multilevel.py
@@ -143,10 +143,13 @@ def waverec(coeffs, wavelet, mode='symmetric', axis=-1):
 
     for d in ds:
         if (a is not None) and (d is not None):
-            if a.shape[axis] == d.shape[axis] + 1:
-                a = a[[slice(s) for s in d.shape]]
-            elif a.shape[axis] != d.shape[axis]:
-                raise RuntimeError("coefficient shape mismatch")
+            try:
+                if a.shape[axis] == d.shape[axis] + 1:
+                    a = a[[slice(s) for s in d.shape]]
+                elif a.shape[axis] != d.shape[axis]:
+                    raise ValueError("coefficient shape mismatch")
+            except IndexError:
+                raise ValueError("Axis greater than coefficient dimensions")
         a = idwt(a, d, wavelet, mode, axis)
 
     return a

--- a/pywt/_multilevel.py
+++ b/pywt/_multilevel.py
@@ -142,8 +142,11 @@ def waverec(coeffs, wavelet, mode='symmetric', axis=-1):
     a, ds = coeffs[0], coeffs[1:]
 
     for d in ds:
-        if (a is not None) and (d is not None) and (len(a) == len(d) + 1):
-            a = a[:-1]
+        if (a is not None) and (d is not None):
+            if a.shape[axis] == d.shape[axis] + 1:
+                a = a[[slice(s) for s in d.shape]]
+            elif a.shape[axis] != d.shape[axis]:
+                raise RuntimeError("coefficient shape mismatch")
         a = idwt(a, d, wavelet, mode, axis)
 
     return a

--- a/pywt/data/_readers.py
+++ b/pywt/data/_readers.py
@@ -174,10 +174,10 @@ def nino():
     sst_csv = np.load(fname)['sst_csv']
     # sst_csv = pd.read_csv("http://www.cpc.ncep.noaa.gov/data/indices/ersst4.nino.mth.81-10.ascii", sep=' ', skipinitialspace=True)
     # take only full years
-    n = np.floor(sst_csv.shape[0]/12.)*12.
+    n = int(np.floor(sst_csv.shape[0]/12.)*12.)
     # Building the mean of three mounth
     # the 4. column is nino 3
-    sst = np.mean(np.reshape(np.array(sst_csv)[:n,4],(n/3,-1)),axis=1)
+    sst = np.mean(np.reshape(np.array(sst_csv)[:n, 4], (n//3, -1)), axis=1)
     sst = (sst - np.mean(sst)) / np.std(sst, ddof=1)
 
     dt = 0.25

--- a/pywt/tests/test_concurrent.py
+++ b/pywt/tests/test_concurrent.py
@@ -1,0 +1,117 @@
+"""
+Tests used to verify running PyWavelets transforms in parallel via
+concurrent.futures.ThreadPoolExecutor does not raise errors.
+"""
+
+from __future__ import division, print_function, absolute_import
+
+import sys
+import warnings
+import numpy as np
+from functools import partial
+from numpy.testing import dec, run_module_suite, assert_array_equal
+
+import pywt
+
+try:
+    if sys.version_info[0] == 2:
+        import futures
+    else:
+        from concurrent import futures
+    futures_available = True
+except ImportError:
+    futures_available = False
+
+
+def _assert_all_coeffs_equal(coefs1, coefs2):
+    # return True only if all coefficients of SWT or DWT match over all levels
+    if len(coefs1) != len(coefs2):
+        return False
+    for (c1, c2) in zip(coefs1, coefs2):
+        if isinstance(c1, tuple):
+            # for swt, swt2, dwt, dwt2, wavedec, wavedec2
+            for a1, a2 in zip(c1, c2):
+                assert_array_equal(a1, a2)
+        elif isinstance(c1, dict):
+            # for swtn, dwtn, wavedecn
+            for k, v in c1.items():
+                assert_array_equal(v, c2[k])
+        else:
+            return False
+    return True
+
+
+@dec.skipif(not futures_available)
+def test_concurrent_swt():
+    # tests error-free concurrent operation (see gh-288)
+    # swt on 1D data calls the Cython swt
+    # other cases call swt_axes
+    with warnings.catch_warnings():
+        # can remove catch_warnings once the swt2 FutureWarning is removed
+        warnings.simplefilter('ignore', FutureWarning)
+        for swt_func, x in zip([pywt.swt, pywt.swt2, pywt.swtn],
+                               [np.ones(8), np.eye(16), np.eye(16)]):
+            transform = partial(swt_func, wavelet='haar', level=1)
+            for _ in range(10):
+                arrs = [x.copy() for _ in range(100)]
+                with futures.ThreadPoolExecutor() as ex:
+                    results = list(ex.map(transform, arrs))
+
+        # validate result from  one of the concurrent runs
+        expected_result = transform(x)
+        _assert_all_coeffs_equal(expected_result, results[-1])
+
+
+@dec.skipif(not futures_available)
+def test_concurrent_wavedec():
+    # wavedec on 1D data calls the Cython dwt_single
+    # other cases call dwt_axes
+    for wavedec_func, x in zip([pywt.wavedec, pywt.wavedec2, pywt.wavedecn],
+                               [np.ones(8), np.eye(16), np.eye(16)]):
+        transform = partial(wavedec_func, wavelet='haar', level=1)
+        for _ in range(10):
+            arrs = [x.copy() for _ in range(100)]
+            with futures.ThreadPoolExecutor() as ex:
+                results = list(ex.map(transform, arrs))
+
+        # validate result from  one of the concurrent runs
+        expected_result = transform(x)
+        _assert_all_coeffs_equal(expected_result, results[-1])
+
+
+@dec.skipif(not futures_available)
+def test_concurrent_dwt():
+    # dwt on 1D data calls the Cython dwt_single
+    # other cases call dwt_axes
+    for dwt_func, x in zip([pywt.dwt, pywt.dwt2, pywt.dwtn],
+                           [np.ones(8), np.eye(16), np.eye(16)]):
+        transform = partial(dwt_func, wavelet='haar')
+        for _ in range(10):
+            arrs = [x.copy() for _ in range(100)]
+            with futures.ThreadPoolExecutor() as ex:
+                results = list(ex.map(transform, arrs))
+
+        # validate result from  one of the concurrent runs
+        expected_result = transform(x)
+        _assert_all_coeffs_equal([expected_result, ], [results[-1], ])
+
+
+@dec.skipif(not futures_available)
+def test_concurrent_cwt():
+    time, sst = pywt.data.nino()
+    dt = time[1]-time[0]
+    transform = partial(pywt.cwt, scales=np.arange(1, 4), wavelet='cmor',
+                        sampling_period=dt)
+    for _ in range(10):
+        arrs = [sst.copy() for _ in range(50)]
+        with futures.ThreadPoolExecutor() as ex:
+            results = list(ex.map(transform, arrs))
+
+    # validate result from  one of the concurrent runs
+    expected_result = transform(sst)
+    for a1, a2 in zip(expected_result, results[-1]):
+        assert_array_equal(a1, a2)
+
+
+if __name__ == '__main__':
+    run_module_suite()

--- a/pywt/tests/test_concurrent.py
+++ b/pywt/tests/test_concurrent.py
@@ -7,6 +7,7 @@ from __future__ import division, print_function, absolute_import
 
 import sys
 import warnings
+import multiprocessing
 import numpy as np
 from functools import partial
 from numpy.testing import dec, run_module_suite, assert_array_equal
@@ -18,6 +19,7 @@ try:
         import futures
     else:
         from concurrent import futures
+    max_workers = multiprocessing.cpu_count()
     futures_available = True
 except ImportError:
     futures_available = False
@@ -54,7 +56,7 @@ def test_concurrent_swt():
             transform = partial(swt_func, wavelet='haar', level=1)
             for _ in range(10):
                 arrs = [x.copy() for _ in range(100)]
-                with futures.ThreadPoolExecutor() as ex:
+                with futures.ThreadPoolExecutor(max_workers=max_workers) as ex:
                     results = list(ex.map(transform, arrs))
 
         # validate result from  one of the concurrent runs
@@ -65,13 +67,13 @@ def test_concurrent_swt():
 @dec.skipif(not futures_available)
 def test_concurrent_wavedec():
     # wavedec on 1D data calls the Cython dwt_single
-    # other cases call dwt_axes
+    # other cases call dwt_axis
     for wavedec_func, x in zip([pywt.wavedec, pywt.wavedec2, pywt.wavedecn],
                                [np.ones(8), np.eye(16), np.eye(16)]):
         transform = partial(wavedec_func, wavelet='haar', level=1)
         for _ in range(10):
             arrs = [x.copy() for _ in range(100)]
-            with futures.ThreadPoolExecutor() as ex:
+            with futures.ThreadPoolExecutor(max_workers=max_workers) as ex:
                 results = list(ex.map(transform, arrs))
 
         # validate result from  one of the concurrent runs
@@ -82,13 +84,13 @@ def test_concurrent_wavedec():
 @dec.skipif(not futures_available)
 def test_concurrent_dwt():
     # dwt on 1D data calls the Cython dwt_single
-    # other cases call dwt_axes
+    # other cases call dwt_axis
     for dwt_func, x in zip([pywt.dwt, pywt.dwt2, pywt.dwtn],
                            [np.ones(8), np.eye(16), np.eye(16)]):
         transform = partial(dwt_func, wavelet='haar')
         for _ in range(10):
             arrs = [x.copy() for _ in range(100)]
-            with futures.ThreadPoolExecutor() as ex:
+            with futures.ThreadPoolExecutor(max_workers=max_workers) as ex:
                 results = list(ex.map(transform, arrs))
 
         # validate result from  one of the concurrent runs
@@ -104,7 +106,7 @@ def test_concurrent_cwt():
                         sampling_period=dt)
     for _ in range(10):
         arrs = [sst.copy() for _ in range(50)]
-        with futures.ThreadPoolExecutor() as ex:
+        with futures.ThreadPoolExecutor(max_workers=max_workers) as ex:
             results = list(ex.map(transform, arrs))
 
     # validate result from  one of the concurrent runs

--- a/pywt/tests/test_deprecations.py
+++ b/pywt/tests/test_deprecations.py
@@ -53,11 +53,6 @@ def test_MODES_attributes_deprecation():
         assert_warns(DeprecationWarning, get_mode, pywt.Modes, mode)
 
 
-def test_MODES_attributes_usage_deprecation():
-    for mode in old_modes:
-        assert_warns(DeprecationWarning, pywt.dwt, range(10), 'db3', mode)
-
-
 def test_MODES_deprecation_new():
     def use_MODES_new():
         return pywt.MODES.symmetric

--- a/pywt/tests/test_multidim.py
+++ b/pywt/tests/test_multidim.py
@@ -262,6 +262,23 @@ def test_idwtn_axes():
     assert_allclose(pywt.idwtn(coefs, 'haar', axes=(1, 1)), data, atol=1e-14)
 
 
+def test_idwt2_none_coeffs():
+    data = np.array([[0, 1, 2, 3],
+                     [1, 1, 1, 1],
+                     [1, 4, 2, 8]])
+    data = data + 1j*data  # test with complex data
+    cA, (cH, cV, cD) = pywt.dwt2(data, 'haar', axes=(1, 1))
+
+    # verify setting coefficients to None is the same as zeroing them
+    cD = np.zeros_like(cD)
+    result_zeros = pywt.idwt2((cA, (cH, cV, cD)), 'haar', axes=(1, 1))
+
+    cD = None
+    result_none = pywt.idwt2((cA, (cH, cV, cD)), 'haar', axes=(1, 1))
+
+    assert_equal(result_zeros, result_none)
+
+
 def test_idwtn_none_coeffs():
     data = np.array([[0, 1, 2, 3],
                      [1, 1, 1, 1],

--- a/pywt/tests/test_multidim.py
+++ b/pywt/tests/test_multidim.py
@@ -194,10 +194,6 @@ def test_error_on_invalid_keys():
     d = {'aa': LL, 'da': HL, 'ad': LH, 'dd': HH, 'ff': LH}
     assert_raises(ValueError, pywt.idwtn, d, wavelet)
 
-    # a key whose value is None
-    d = {'aa': LL, 'da': HL, 'ad': LH, 'dd': None}
-    assert_raises(ValueError, pywt.idwtn, d, wavelet)
-
     # mismatched key lengths
     d = {'a': LL, 'da': HL, 'ad': LH, 'dd': HH}
     assert_raises(ValueError, pywt.idwtn, d, wavelet)
@@ -264,6 +260,23 @@ def test_idwtn_axes():
     data = data + 1j*data  # test with complex data
     coefs = pywt.dwtn(data, 'haar', axes=(1, 1))
     assert_allclose(pywt.idwtn(coefs, 'haar', axes=(1, 1)), data, atol=1e-14)
+
+
+def test_idwtn_none_coeffs():
+    data = np.array([[0, 1, 2, 3],
+                     [1, 1, 1, 1],
+                     [1, 4, 2, 8]])
+    data = data + 1j*data  # test with complex data
+    coefs = pywt.dwtn(data, 'haar', axes=(1, 1))
+
+    # verify setting coefficients to None is the same as zeroing them
+    coefs['dd'] = np.zeros_like(coefs['dd'])
+    result_zeros = pywt.idwtn(coefs, 'haar', axes=(1, 1))
+
+    coefs['dd'] = None
+    result_none = pywt.idwtn(coefs, 'haar', axes=(1, 1))
+
+    assert_equal(result_zeros, result_none)
 
 
 def test_idwt2_axes():

--- a/pywt/tests/test_multilevel.py
+++ b/pywt/tests/test_multilevel.py
@@ -538,6 +538,13 @@ def test_waverec_axis_error():
     assert_raises(ValueError, pywt.waverec, c, 'haar', axis=1)
 
 
+def test_waverec_shape_mismatch_error():
+    c = pywt.wavedec(np.ones(16), 'haar')
+    # truncate a detail coefficient to an incorrect shape
+    c[3] = c[3][:-1]
+    assert_raises(ValueError, pywt.waverec, c, 'haar', axis=1)
+
+
 def test_wavedec2_axes_errors():
     data = np.ones((4, 4))
     # integer axes not allowed

--- a/pywt/tests/test_multilevel.py
+++ b/pywt/tests/test_multilevel.py
@@ -487,7 +487,7 @@ def test_waverec_axes_subsets():
 
 
 def test_waverec_axis_db2():
-    """test for fix to issue gh-293"""
+    # test for fix to issue gh-293
     rstate = np.random.RandomState(0)
     data = rstate.standard_normal((16, 16))
     for axis in [0, 1]:

--- a/pywt/tests/test_multilevel.py
+++ b/pywt/tests/test_multilevel.py
@@ -486,6 +486,16 @@ def test_waverec_axes_subsets():
         assert_allclose(rec, data, atol=1e-14)
 
 
+def test_waverec_axis_db2():
+    """test for fix to issue gh-293"""
+    rstate = np.random.RandomState(0)
+    data = rstate.standard_normal((16, 16))
+    for axis in [0, 1]:
+        coefs = pywt.wavedec(data, 'db2', axis=axis)
+        rec = pywt.waverec(coefs, 'db2', axis=axis)
+        assert_allclose(rec, data, atol=1e-14)
+
+
 def test_waverec2_axes_subsets():
     rstate = np.random.RandomState(0)
     data = rstate.standard_normal((8, 8, 8))

--- a/setup.py
+++ b/setup.py
@@ -249,7 +249,9 @@ if __name__ == '__main__':
         version=get_version_info()[0],
 
         packages=['pywt', 'pywt._extensions', 'pywt.data'],
-        package_data={'pywt.data': ['*.npy', '*.npz']},
+        package_data={'pywt.data': ['*.npy', '*.npz'],
+                      'pywt': ['tests/*.py', 'tests/data/*.npz',
+                               'tests/data/*.py']},
         ext_modules=ext_modules,
         libraries=[c_lib],
         cmdclass={'develop': develop_build_clib},

--- a/setup.py
+++ b/setup.py
@@ -258,5 +258,5 @@ if __name__ == '__main__':
         test_suite='nose.collector',
 
         # A function is imported in setup.py, so not really useful
-        install_requires=["numpy"],
+        install_requires=["numpy>=1.9.1"],
     )

--- a/util/readthedocs/requirements.txt
+++ b/util/readthedocs/requirements.txt
@@ -8,7 +8,7 @@
 # fix the versions of numpy to force the use of numpy to use the whl
 # of the rackspace folder instead of trying to install from more recent
 # source tarball published on PyPI
-numpy==1.8.1
+numpy==1.9.1
 Cython==0.20.2
 nose
 wheel


### PR DESCRIPTION
incorporates: #273, #276, #289, #291, #292, #294, #295

@rgommers.  I wasn't sure of the best way to get the specific changes from the PRs above from master to 0.5.x.  Here I checked out a branch based on 0.5.x and did cherry-picks of the commits for each PR above.  There were only a few minor conflicts to resolve.

Should there instead be a separate PR for each of the issues above instead of putting them all together like this?

I can add release notes for 0.5.2 in a separate PR in the next day or so.


