### PR TITLE
DOC: better document how to handle omitted coefficients in multilevel DWT reconstructions

### DIFF
--- a/pywt/_multidim.py
+++ b/pywt/_multidim.py
@@ -192,12 +192,16 @@ def dwtn(data, wavelet, mode='symmetric', axes=None):
 
 
 def _fix_coeffs(coeffs):
-    missing_keys = [k for k, v in coeffs.items() if
-                    v is None]
+    missing_keys = [k for k, v in coeffs.items() if v is None]
     if missing_keys:
         raise ValueError(
-            "The following detail coefficients were set to None: "
-            "{}.".format(missing_keys))
+            "The following detail coefficients were set to None:\n"
+            "{0}\n"
+            "For multilevel transforms, rather than setting\n"
+            "\tcoeffs[key] = None\n"
+            "use\n"
+            "\tcoeffs[key] = np.zeros_like(coeffs[key])\n".format(
+                missing_keys))
 
     invalid_keys = [k for k, v in coeffs.items() if
                     not set(k) <= set('ad')]

--- a/pywt/_multilevel.py
+++ b/pywt/_multilevel.py
@@ -122,6 +122,17 @@ def waverec(coeffs, wavelet, mode='symmetric', axis=-1):
         Axis over which to compute the inverse DWT. If not given, the
         last axis is used.
 
+    Notes
+    -----
+    It may sometimes desired to run ``waverec`` with some sets of
+    coefficients omitted.  This can best be done by setting the corresponding
+    arrays to zero arrays of matching shape and dtype.  Explicitly removing
+    list entries or setting them to ``None`` is not supported.
+
+    Specifically, to ignore detail coefficients at level 2, one could do::
+
+        coeffs[-2] == numpy.zeros_like(coeffs[-2])
+
     Examples
     --------
     >>> import pywt
@@ -250,6 +261,17 @@ def waverec2(coeffs, wavelet, mode='symmetric', axes=(-2, -1)):
     Returns
     -------
     2D array of reconstructed data.
+
+    Notes
+    -----
+    It may sometimes desired to run ``waverec2`` with some sets of
+    coefficients omitted.  This can best be done by setting the corresponding
+    arrays to zero arrays of matching shape and dtype.  Explicitly removing
+    list or tuple entries or setting them to ``None`` is not supported.
+
+    Specifically, to ignore all detail coefficients at level 2, one could do::
+
+        coeffs[-2] == tuple([numpy.zeros_like(v) for v in coeffs[-2]])
 
     Examples
     --------
@@ -435,6 +457,17 @@ def waverecn(coeffs, wavelet, mode='symmetric', axes=None):
     Returns
     -------
     nD array of reconstructed data.
+
+    Notes
+    -----
+    It is sometimes desired to run ``waverecn`` with some sets of
+    coefficients omitted.  This can best be done by setting the corresponding
+    arrays to zero arrays of matching shape and dtype.  Explicitly removing
+    list or dictionary entries or setting them to ``None`` is not supported.
+
+    Specifically, to ignore all detail coefficients at level 2, one could do::
+
+        codffs[-2] == {k: numpy.zeros_like(v) for k, v in coeffs[-2].items()}
 
     Examples
     --------

--- a/pywt/_multilevel.py
+++ b/pywt/_multilevel.py
@@ -467,7 +467,7 @@ def waverecn(coeffs, wavelet, mode='symmetric', axes=None):
 
     Specifically, to ignore all detail coefficients at level 2, one could do::
 
-        codffs[-2] == {k: numpy.zeros_like(v) for k, v in coeffs[-2].items()}
+        codffs[-2] = {k: numpy.zeros_like(v) for k, v in coeffs[-2].items()}
 
     Examples
     --------

--- a/pywt/_multilevel.py
+++ b/pywt/_multilevel.py
@@ -124,14 +124,14 @@ def waverec(coeffs, wavelet, mode='symmetric', axis=-1):
 
     Notes
     -----
-    It may sometimes desired to run ``waverec`` with some sets of
+    It may sometimes be desired to run ``waverec`` with some sets of
     coefficients omitted.  This can best be done by setting the corresponding
     arrays to zero arrays of matching shape and dtype.  Explicitly removing
     list entries or setting them to ``None`` is not supported.
 
     Specifically, to ignore detail coefficients at level 2, one could do::
 
-        coeffs[-2] == numpy.zeros_like(coeffs[-2])
+        coeffs[-2] == np.zeros_like(coeffs[-2])
 
     Examples
     --------
@@ -264,14 +264,14 @@ def waverec2(coeffs, wavelet, mode='symmetric', axes=(-2, -1)):
 
     Notes
     -----
-    It may sometimes desired to run ``waverec2`` with some sets of
+    It may sometimes be desired to run ``waverec2`` with some sets of
     coefficients omitted.  This can best be done by setting the corresponding
     arrays to zero arrays of matching shape and dtype.  Explicitly removing
     list or tuple entries or setting them to ``None`` is not supported.
 
     Specifically, to ignore all detail coefficients at level 2, one could do::
 
-        coeffs[-2] == tuple([numpy.zeros_like(v) for v in coeffs[-2]])
+        coeffs[-2] == tuple([np.zeros_like(v) for v in coeffs[-2]])
 
     Examples
     --------
@@ -460,14 +460,14 @@ def waverecn(coeffs, wavelet, mode='symmetric', axes=None):
 
     Notes
     -----
-    It is sometimes desired to run ``waverecn`` with some sets of
+    It may sometimes be desired to run ``waverecn`` with some sets of
     coefficients omitted.  This can best be done by setting the corresponding
     arrays to zero arrays of matching shape and dtype.  Explicitly removing
     list or dictionary entries or setting them to ``None`` is not supported.
 
     Specifically, to ignore all detail coefficients at level 2, one could do::
 
-        codffs[-2] = {k: numpy.zeros_like(v) for k, v in coeffs[-2].items()}
+        coeffs[-2] = {k: np.zeros_like(v) for k, v in coeffs[-2].items()}
 
     Examples
     --------


### PR DESCRIPTION
Related to the discussion in #302, this PR is intended to clarify issues of running `waverecn` (as well as `waverec` and `waverec2`) with some coefficients omitted.  The only truly safe way to do this currently seems to be to replace the undesired coefficient arrays with corresponding arrays of zeros.  In general, `None` cannot be allowed (as it is for the single-level `idwtn`), as the shapes of the arrays are needed at various places to ensure any extra padding was removed properly:

https://github.com/PyWavelets/pywt/blob/dd7b79332f6afac345be8dae3e6dffe2edb5facc/pywt/_multilevel.py#L148-L149
https://github.com/PyWavelets/pywt/blob/dd7b79332f6afac345be8dae3e6dffe2edb5facc/pywt/_multilevel.py#L296-L297
https://github.com/PyWavelets/pywt/blob/dd7b79332f6afac345be8dae3e6dffe2edb5facc/pywt/_multilevel.py#L514

Here the error message on `None` coefficients is updated to suggest the appropriate workaround and some text is added to the Notes section of the function docstrings.

