### PR TITLE
Document how max levels are determined for multilevel DWT and SWT routines.

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -25,7 +25,7 @@ import jinja2.filters
 # Add any Sphinx extension module names here, as strings. They can be extensions
 # coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
 extensions = ['sphinx.ext.doctest', 'sphinx.ext.autodoc', 'sphinx.ext.todo',
-              'sphinx.ext.extlinks', 'numpydoc']
+              'sphinx.ext.extlinks', 'sphinx.ext.mathjax', 'numpydoc']
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']

--- a/pywt/_dwt.py
+++ b/pywt/_dwt.py
@@ -15,7 +15,7 @@ __all__ = ["dwt", "idwt", "downcoef", "upcoef", "dwt_max_level",
 
 
 def dwt_max_level(data_len, filter_len):
-    """
+    r"""
     dwt_max_level(data_len, filter_len)
 
     Compute the maximum useful level of decomposition.
@@ -32,6 +32,20 @@ def dwt_max_level(data_len, filter_len):
     -------
     max_level : int
         Maximum level.
+
+    Notes
+    -----
+    The rational for the choice of levels is the maximum level where at least
+    one coefficient in the output is uncorrupted by edge effects caused by
+    signal extension.  Put another way, decomposition stops when the signal
+    becomes shorter than the FIR filter length for a given wavelet.  This
+    corresponds to:
+
+    .. max_level = floor(log2(data_len/(filter_len - 1)))
+
+    .. math::
+        \mathtt{max\_level} = \left\lfloor\log_2\left(\mathtt{
+            \frac{data\_len}{filter\_len - 1}}\right)\right\rfloor
 
     Examples
     --------

--- a/pywt/_extensions/_swt.pyx
+++ b/pywt/_extensions/_swt.pyx
@@ -26,6 +26,12 @@ def swt_max_level(size_t input_len):
     max_level : int
         Maximum level of Stationary Wavelet Transform for data of given length.
 
+    Notes
+    -----
+    For the current implementation of the stationary wavelet transform, this
+    corresponds to the number of times ``input_len`` is evenly divisible by
+    two.
+
     """
     return common.swt_max_level(input_len)
 


### PR DESCRIPTION
This PR improves the `dwt_max_levels` docstring as discussed in #306

Thanks to @JohnLunzer for the suggested improvement to the phrasing used here.

I opted to enable the MathJax extension in Sphinx to get a LaTeX rendering for the docs (and IPython interactive help):
![maxleveqn](https://cloud.githubusercontent.com/assets/6528957/24876622/5e39c420-1dfa-11e7-8390-faa9dbe0073f.png)

A  drawback, is that the LaTeX code for the above is pretty illegible when perusing a plain text docstring, so I left a more legable plain text rendering as a comment ( https://github.com/grlee77/pywt/blob/2a7ef8857046355e6a7f969a16df8295ead596e7/pywt/_dwt.py#L44) .  Is this a reasonable compromise?

closes #306

