### PR TITLE
parse CWT wavelet names for parameters

### DIFF
--- a/pywt/_extensions/_pywt.pyx
+++ b/pywt/_extensions/_pywt.pyx
@@ -709,7 +709,7 @@ cdef public class ContinuousWavelet [type ContinuousWaveletType, object Continuo
                         "representing the bandwidth frequency and center "
                         "frequency, respectively (example: {0}1.5-1.0)."
                         ).format(base_name)
-                warnings.warn(msg)
+                warnings.warn(msg, FutureWarning)
         else:
             base_name = self.name
         family_code, family_number = wname_to_code(base_name)

--- a/pywt/tests/test__pywt.py
+++ b/pywt/tests/test__pywt.py
@@ -53,6 +53,9 @@ def test_compare_downcoef_coeffs():
     # compare downcoef against wavedec outputs
     for nlevels in [1, 2, 3]:
         for wavelet in pywt.wavelist():
+            if wavelet in ['cmor', 'shan', 'fbsp']:
+                # skip these CWT families to avoid warnings
+                continue
             wavelet = pywt.DiscreteContinuousWavelet(wavelet)
             if isinstance(wavelet, pywt.Wavelet):
                 max_level = pywt.dwt_max_level(r.size, wavelet.dec_len)

--- a/pywt/tests/test_concurrent.py
+++ b/pywt/tests/test_concurrent.py
@@ -102,7 +102,7 @@ def test_concurrent_dwt():
 def test_concurrent_cwt():
     time, sst = pywt.data.nino()
     dt = time[1]-time[0]
-    transform = partial(pywt.cwt, scales=np.arange(1, 4), wavelet='cmor',
+    transform = partial(pywt.cwt, scales=np.arange(1, 4), wavelet='cmor1.5-1',
                         sampling_period=dt)
     for _ in range(10):
         arrs = [sst.copy() for _ in range(50)]

--- a/pywt/tests/test_cwt_wavelets.py
+++ b/pywt/tests/test_cwt_wavelets.py
@@ -317,7 +317,7 @@ def test_cwt_parameters_in_names():
     for func in [pywt.ContinuousWavelet, pywt.DiscreteContinuousWavelet]:
         for name in ['fbsp', 'cmor', 'shan']:
             # additional parameters should be specified within the name
-            assert_warns(Warning, func, name)
+            assert_warns(FutureWarning, func, name)
 
         for name in ['cmor', 'shan']:
             # valid names

--- a/pywt/tests/test_cwt_wavelets.py
+++ b/pywt/tests/test_cwt_wavelets.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python
 from __future__ import division, print_function, absolute_import
 
-from numpy.testing import run_module_suite, assert_allclose
+from numpy.testing import (run_module_suite, assert_allclose, assert_warns,
+                           assert_almost_equal, assert_raises)
 import numpy as np
 import pywt
 
@@ -134,9 +135,9 @@ def test_shan():
     Fc = 1.5
 
     [psi, x] = ref_shan(LB, UB, N, Fb, Fc)
-    w = pywt.ContinuousWavelet("shan")
-    w.center_frequency = Fc
-    w.bandwidth_frequency = Fb
+    w = pywt.ContinuousWavelet("shan{}-{}".format(Fb, Fc))
+    assert_almost_equal(w.center_frequency, Fc)
+    assert_almost_equal(w.bandwidth_frequency, Fb)
     w.upper_bound = UB
     w.lower_bound = LB
     PSI, X = w.wavefun(length=N)
@@ -152,9 +153,9 @@ def test_shan():
     Fc = 1
 
     [psi, x] = ref_shan(LB, UB, N, Fb, Fc)
-    w = pywt.ContinuousWavelet("shan")
-    w.center_frequency = Fc
-    w.bandwidth_frequency = Fb
+    w = pywt.ContinuousWavelet("shan{}-{}".format(Fb, Fc))
+    assert_almost_equal(w.center_frequency, Fc)
+    assert_almost_equal(w.bandwidth_frequency, Fb)
     w.upper_bound = UB
     w.lower_bound = LB
     PSI, X = w.wavefun(length=N)
@@ -172,9 +173,9 @@ def test_cmor():
     Fc = 1.5
 
     [psi, x] = ref_cmor(LB, UB, N, Fb, Fc)
-    w = pywt.ContinuousWavelet("cmor")
-    w.center_frequency = Fc
-    w.bandwidth_frequency = Fb
+    w = pywt.ContinuousWavelet("cmor{}-{}".format(Fb, Fc))
+    assert_almost_equal(w.center_frequency, Fc)
+    assert_almost_equal(w.bandwidth_frequency, Fb)
     w.upper_bound = UB
     w.lower_bound = LB
     PSI, X = w.wavefun(length=N)
@@ -190,9 +191,9 @@ def test_cmor():
     Fc = 1
 
     [psi, x] = ref_cmor(LB, UB, N, Fb, Fc)
-    w = pywt.ContinuousWavelet("cmor")
-    w.center_frequency = Fc
-    w.bandwidth_frequency = Fb
+    w = pywt.ContinuousWavelet("cmor{}-{}".format(Fb, Fc))
+    assert_almost_equal(w.center_frequency, Fc)
+    assert_almost_equal(w.bandwidth_frequency, Fb)
     w.upper_bound = UB
     w.lower_bound = LB
     PSI, X = w.wavefun(length=N)
@@ -211,9 +212,10 @@ def test_fbsp():
     Fc = 1.5
 
     [psi, x] = ref_fbsp(LB, UB, N, M, Fb, Fc)
-    w = pywt.ContinuousWavelet("fbsp")
-    w.center_frequency = Fc
-    w.bandwidth_frequency = Fb
+
+    w = pywt.ContinuousWavelet("fbsp{}-{}-{}".format(M, Fb, Fc))
+    assert_almost_equal(w.center_frequency, Fc)
+    assert_almost_equal(w.bandwidth_frequency, Fb)
     w.fbsp_order = M
     w.upper_bound = UB
     w.lower_bound = LB
@@ -231,9 +233,9 @@ def test_fbsp():
     Fc = 1
 
     [psi, x] = ref_fbsp(LB, UB, N, M, Fb, Fc)
-    w = pywt.ContinuousWavelet("fbsp")
-    w.center_frequency = Fc
-    w.bandwidth_frequency = Fb
+    w = pywt.ContinuousWavelet("fbsp{}-{}-{}".format(M, Fb, Fc))
+    assert_almost_equal(w.center_frequency, Fc)
+    assert_almost_equal(w.bandwidth_frequency, Fb)
     w.fbsp_order = M
     w.upper_bound = UB
     w.lower_bound = LB
@@ -251,9 +253,9 @@ def test_fbsp():
     Fc = 1.2
 
     [psi, x] = ref_fbsp(LB, UB, N, M, Fb, Fc)
-    w = pywt.ContinuousWavelet("fbsp")
-    w.center_frequency = Fc
-    w.bandwidth_frequency = Fb
+    w = pywt.ContinuousWavelet("fbsp{}-{}-{}".format(M, Fb, Fc))
+    assert_almost_equal(w.center_frequency, Fc)
+    assert_almost_equal(w.bandwidth_frequency, Fb)
     w.fbsp_order = M
     w.upper_bound = UB
     w.lower_bound = LB
@@ -308,6 +310,38 @@ def test_mexh():
     assert_allclose(np.real(PSI), np.real(psi))
     assert_allclose(np.imag(PSI), np.imag(psi))
     assert_allclose(X, x)
+
+
+def test_cwt_parameters_in_names():
+
+    for func in [pywt.ContinuousWavelet, pywt.DiscreteContinuousWavelet]:
+        for name in ['fbsp', 'cmor', 'shan']:
+            # additional parameters should be specified within the name
+            assert_warns(Warning, func, name)
+
+        for name in ['cmor', 'shan']:
+            # valid names
+            func(name + '1.5-1.0')
+            func(name + '1-4')
+
+            # invalid names
+            assert_raises(ValueError, func, name + '1.0')
+            assert_raises(ValueError, func, name + 'B-C')
+            assert_raises(ValueError, func, name + '1.0-1.0-1.0')
+
+        # valid names
+        func('fbsp1-1.5-1.0')
+        func('fbsp1.0-1.5-1')
+        func('fbsp2-5-1')
+
+        # invalid name (non-integer order)
+        assert_raises(ValueError, func, 'fbsp1.5-1-1')
+        assert_raises(ValueError, func, 'fbspM-B-C')
+
+        # invalid name (too few or too many params)
+        assert_raises(ValueError, func, 'fbsp1.0')
+        assert_raises(ValueError, func, 'fbsp1.0-0.4')
+        assert_raises(ValueError, func, 'fbsp1-1-1-1')
 
 
 if __name__ == '__main__':

--- a/pywt/tests/test_matlab_compatibility_cwt.py
+++ b/pywt/tests/test_matlab_compatibility_cwt.py
@@ -5,6 +5,7 @@ accuracy against MathWorks Wavelet Toolbox.
 
 from __future__ import division, print_function, absolute_import
 
+import warnings
 import os
 import numpy as np
 from numpy.testing import assert_, dec, run_module_suite
@@ -68,7 +69,9 @@ def test_accuracy_pymatbridge_cwt():
     mlab.start()
     try:
         for wavelet in wavelets:
-            w = pywt.ContinuousWavelet(wavelet)
+            with warnings.catch_warnings():
+                warnings.simplefilter('ignore', FutureWarning)
+                w = pywt.ContinuousWavelet(wavelet)
             if np.any((wavelet == np.array(['shan', 'cmor'])),axis=0):
                 mlab.set_variable('wavelet', wavelet+str(w.bandwidth_frequency)+'-'+str(w.center_frequency))
             elif wavelet == 'fbsp':
@@ -100,8 +103,10 @@ def test_accuracy_precomputed_cwt():
     epsilon32 = 1e-5
     epsilon_psi = 1e-15
     for wavelet in wavelets:
-        w = pywt.ContinuousWavelet(wavelet)
-        w32 = pywt.ContinuousWavelet(wavelet,dtype=np.float32)
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore', FutureWarning)
+            w = pywt.ContinuousWavelet(wavelet)
+            w32 = pywt.ContinuousWavelet(wavelet,dtype=np.float32)
         psi = _load_matlab_result_psi(wavelet)
         yield _check_accuracy_psi, w, psi, wavelet, epsilon_psi
 
@@ -160,7 +165,7 @@ def _load_matlab_result_psi(wavelet):
 
 def _check_accuracy(data, w, scales, coefs, wavelet, epsilon):
     # PyWavelets result
-    coefs_pywt,freq = pywt.cwt(data, scales, w)
+    coefs_pywt, freq = pywt.cwt(data, scales, w)
 
     # calculate error measures
     rms = np.real(np.sqrt(np.mean((coefs_pywt - coefs) ** 2)))
@@ -172,7 +177,7 @@ def _check_accuracy(data, w, scales, coefs, wavelet, epsilon):
 
 def _check_accuracy_psi(w, psi, wavelet, epsilon):
     # PyWavelets result
-    psi_pywt,x = w.wavefun(length=1024)
+    psi_pywt, x = w.wavefun(length=1024)
 
     # calculate error measures
     rms = np.real(np.sqrt(np.mean((psi_pywt.flatten() - psi.flatten()) ** 2)))

--- a/pywt/tests/test_multidim.py
+++ b/pywt/tests/test_multidim.py
@@ -60,6 +60,9 @@ def test_dwdtn_idwtn_allwavelets():
     if 'dmey' in wavelist:
         wavelist.remove('dmey')
     for wavelet in wavelist:
+        if wavelet in ['cmor', 'shan', 'fbsp']:
+            # skip these CWT families to avoid warnings
+            continue
         if isinstance(pywt.DiscreteContinuousWavelet(wavelet), pywt.Wavelet):
             for mode in pywt.Modes.modes:
                 coeffs = pywt.dwtn(r, wavelet, mode=mode)

--- a/pywt/tests/test_multilevel.py
+++ b/pywt/tests/test_multilevel.py
@@ -2,6 +2,7 @@
 
 from __future__ import division, print_function, absolute_import
 
+import warnings
 from itertools import combinations
 import numpy as np
 from numpy.testing import (run_module_suite, assert_almost_equal,
@@ -38,11 +39,15 @@ wavelist = pywt.wavelist()
 if 'dmey' in wavelist:
     # accuracy is very low for dmey, so omit it
     wavelist.remove('dmey')
+
 # removing wavelets with dwt_possible == False
 del_list = []
 for wavelet in wavelist:
-    if not isinstance(pywt.DiscreteContinuousWavelet(wavelet), pywt.Wavelet):
-        del_list.append(wavelet)
+    with warnings.catch_warnings():
+        warnings.simplefilter('ignore', FutureWarning)
+        if not isinstance(pywt.DiscreteContinuousWavelet(wavelet),
+                          pywt.Wavelet):
+            del_list.append(wavelet)
 for del_ind in del_list:
     wavelist.remove(del_ind)
 


### PR DESCRIPTION
This PR implements wavelet name parsing for `cmor`, `shan`, and `fbsp` wavelets in the same manner as Matlab.  This was discussed in #308

`shan` and `cmor` have two float parameters (`center_frequency` and `bandwidth_frequency`) while `fbsp` also has an `fbsp_order` parameter.  Currently, these are silently assigned default values upon wavelet creation and the user can modify them via assigning to the wavelet attributes.  

This PR supports specifying these attributes within the wavelet name as in the Matlab toolbox.  e.g.
`cmorB-C` or `shanB-C` where B is the bandwidth and C is the center frequency.
`fbspM-B-C` where M is the spline order, B is the bandwidth and C is the center frequency.

I added a deprecation warning if no parameters are specified.