### PR TITLE
TST: specify rtol and atol for assert_allclose calls in test_swt_decomposition

### DIFF
--- a/pywt/tests/test_swt.py
+++ b/pywt/tests/test_swt.py
@@ -31,28 +31,29 @@ tol_double = 1e-13
 def test_swt_decomposition():
     x = [3, 7, 1, 3, -2, 6, 4, 6]
     db1 = pywt.Wavelet('db1')
+    atol = tol_double
     (cA3, cD3), (cA2, cD2), (cA1, cD1) = pywt.swt(x, db1, level=3)
     expected_cA1 = [7.07106781, 5.65685425, 2.82842712, 0.70710678,
                     2.82842712, 7.07106781, 7.07106781, 6.36396103]
-    assert_allclose(cA1, expected_cA1)
+    assert_allclose(cA1, expected_cA1, rtol=1e-8, atol=atol)
     expected_cD1 = [-2.82842712, 4.24264069, -1.41421356, 3.53553391,
                     -5.65685425, 1.41421356, -1.41421356, 2.12132034]
-    assert_allclose(cD1, expected_cD1)
+    assert_allclose(cD1, expected_cD1, rtol=1e-8, atol=atol)
     expected_cA2 = [7, 4.5, 4, 5.5, 7, 9.5, 10, 8.5]
-    assert_allclose(cA2, expected_cA2, rtol=tol_double)
+    assert_allclose(cA2, expected_cA2, rtol=tol_double, atol=atol)
     expected_cD2 = [3, 3.5, 0, -4.5, -3, 0.5, 0, 0.5]
-    assert_allclose(cD2, expected_cD2, rtol=tol_double, atol=1e-14)
+    assert_allclose(cD2, expected_cD2, rtol=tol_double, atol=atol)
     expected_cA3 = [9.89949494, ] * 8
-    assert_allclose(cA3, expected_cA3)
+    assert_allclose(cA3, expected_cA3, rtol=1e-8, atol=atol)
     expected_cD3 = [0.00000000, -3.53553391, -4.24264069, -2.12132034,
                     0.00000000, 3.53553391, 4.24264069, 2.12132034]
-    assert_allclose(cD3, expected_cD3)
+    assert_allclose(cD3, expected_cD3, rtol=1e-8, atol=atol)
 
     # level=1, start_level=1 decomposition should match level=2
     res = pywt.swt(cA1, db1, level=1, start_level=1)
     cA2, cD2 = res[0]
-    assert_allclose(cA2, expected_cA2, rtol=tol_double)
-    assert_allclose(cD2, expected_cD2, rtol=tol_double, atol=1e-14)
+    assert_allclose(cA2, expected_cA2, rtol=tol_double, atol=atol)
+    assert_allclose(cD2, expected_cD2, rtol=tol_double, atol=atol)
 
     coeffs = pywt.swt(x, db1)
     assert_(len(coeffs) == 3)


### PR DESCRIPTION
This is an attempt to resolve #316 by allowing for a small absolute deviations in SWT tests that currently fail on some architectures.
