### PR TITLE
support soft thresholding of complex valued data

### DIFF
--- a/pywt/_thresholding.py
+++ b/pywt/_thresholding.py
@@ -22,8 +22,11 @@ def soft(data, value, substitute=0):
     sign = np.sign(data)
     thresholded = (magnitude - value).clip(0) * sign
 
-    cond = np.less(magnitude, value)
-    return np.where(cond, substitute, thresholded)
+    if substitute == 0:
+        return thresholded
+    else:
+        cond = np.less(magnitude, value)
+        return np.where(cond, substitute, thresholded)
 
 
 def hard(data, value, substitute=0):

--- a/pywt/_thresholding.py
+++ b/pywt/_thresholding.py
@@ -17,10 +17,13 @@ import numpy as np
 
 def soft(data, value, substitute=0):
     data = np.asarray(data)
-
     magnitude = np.absolute(data)
-    sign = np.sign(data)
-    thresholded = (magnitude - value).clip(0) * sign
+
+    with np.errstate(divide='ignore'):
+        # divide by zero okay as np.inf values get clipped, so ignore warning.
+        thresholded = (1 - value/magnitude)
+        thresholded.clip(min=0, max=None, out=thresholded)
+        thresholded = data * thresholded
 
     if substitute == 0:
         return thresholded

--- a/pywt/_thresholding.py
+++ b/pywt/_thresholding.py
@@ -40,11 +40,15 @@ def hard(data, value, substitute=0):
 
 def greater(data, value, substitute=0):
     data = np.asarray(data)
+    if np.iscomplexobj(data):
+        raise ValueError("greater thresholding only supports real data")
     return np.where(np.less(data, value), substitute, data)
 
 
 def less(data, value, substitute=0):
     data = np.asarray(data)
+    if np.iscomplexobj(data):
+        raise ValueError("less thresholding only supports real data")
     return np.where(np.greater(data, value), substitute, data)
 
 
@@ -58,20 +62,23 @@ def threshold(data, value, mode='soft', substitute=0):
     """
     Thresholds the input data depending on the mode argument.
 
-    In ``soft`` thresholding, the data values where their absolute value is
-    less than the value param are replaced with substitute. From the data
-    values with absolute value greater or equal to the thresholding value,
-    a quantity of ``(signum * value)`` is subtracted.
+    In ``soft`` thresholding, data values with absolute value less than
+    `param` are replaced with `substitute`. Data values with absolute value
+    greater or equal to the thresholding value are shrunk toward zero
+    by `value`.  In other words, the new value is
+    ``data/np.abs(data) * np.maximum(np.abs(data) - value, 0)``.
 
     In ``hard`` thresholding, the data values where their absolute value is
-    less than the value param are replaced with substitute. Data values with
+    less than the value param are replaced with `substitute`. Data values with
     absolute value greater or equal to the thresholding value stay untouched.
 
-    In ``greater`` thresholding, the data is replaced with substitute where
+    In ``greater`` thresholding, the data is replaced with `substitute` where
     data is below the thresholding value. Greater data values pass untouched.
 
-    In ``less`` thresholding, the data is replaced with substitute where data
-    is above the thresholding value. Less data values pass untouched.
+    In ``less`` thresholding, the data is replaced with `substitute` where data
+    is above the thresholding value. Lesser data values pass untouched.
+
+    Both ``hard`` and ``soft`` thresholding also support complex-valued data.
 
     Parameters
     ----------

--- a/pywt/tests/test_thresholding.py
+++ b/pywt/tests/test_thresholding.py
@@ -63,6 +63,10 @@ def test_threshold():
                     [[1, 2]] * 2, rtol=1e-12)
     assert_allclose(pywt.threshold([[1, 2]] * 2, 2, 'hard'),
                     [[0, 2]] * 2, rtol=1e-12)
+    assert_allclose(pywt.threshold([[1, 2]] * 2, 2, 'hard', substitute=s),
+                    [[s, 2]] * 2, rtol=1e-12)
+    assert_allclose(pywt.threshold([[1+1j, 2+2j]] * 2, 2, 'hard'),
+                    [[0, 2+2j]] * 2, rtol=1e-12)
 
     # greater
     greater_result = [0., 0., 2., 2.5, 3., 3.5, 4.]
@@ -72,14 +76,23 @@ def test_threshold():
                     [[1, 2]] * 2, rtol=1e-12)
     assert_allclose(pywt.threshold([[1, 2]] * 2, 2, 'greater'),
                     [[0, 2]] * 2, rtol=1e-12)
+    assert_allclose(pywt.threshold([[1, 2]] * 2, 2, 'greater', substitute=s),
+                    [[s, 2]] * 2, rtol=1e-12)
+    # greater doesn't allow complex-valued inputs
+    assert_raises(ValueError, pywt.threshold, [1j, 2j], 2, 'greater')
 
     # less
     assert_allclose(pywt.threshold(data, 2, 'less'),
                     np.array([1., 1.5, 2., 0., 0., 0., 0.]), rtol=1e-12)
     assert_allclose(pywt.threshold([[1, 2]] * 2, 1, 'less'),
                     [[1, 0]] * 2, rtol=1e-12)
+    assert_allclose(pywt.threshold([[1, 2]] * 2, 1, 'less', substitute=s),
+                    [[1, s]] * 2, rtol=1e-12)
     assert_allclose(pywt.threshold([[1, 2]] * 2, 2, 'less'),
                     [[1, 2]] * 2, rtol=1e-12)
+
+    # less doesn't allow complex-valued inputs
+    assert_raises(ValueError, pywt.threshold, [1j, 2j], 2, 'less')
 
     # invalid
     assert_raises(ValueError, pywt.threshold, data, 2, 'foo')


### PR DESCRIPTION
The current implementation of soft thresholding is incorrect for complex-valued data.  Fixing it is as simple as replacing `np.sign(x)`  with `x/np.abs(x)`.

The implementation here is equivalent to this, but deals properly with zeros in x.

The updated `soft` implementation is equivalent to the old one for real-valued data, but performance is better (~2.5 times faster for the default value of `substitute=0` on arrays with 5 million elements)

The existing `hard` thresholding was already correct for complex-valued data.  I didn't think the `less` or `greater` thresholdings make sense for complex-valued inputs, so set this to raise a ValueError if the input is complex.