### PR TITLE
provide a more helpful error message for wrong wavelet type

### DIFF
--- a/pywt/_dwt.py
+++ b/pywt/_dwt.py
@@ -7,7 +7,7 @@ from ._extensions._dwt import (dwt_single, dwt_axis, idwt_single, idwt_axis,
                                upcoef as _upcoef, downcoef as _downcoef,
                                dwt_max_level as _dwt_max_level,
                                dwt_coeff_len as _dwt_coeff_len)
-from ._utils import string_types
+from ._utils import string_types, _as_wavelet
 
 
 __all__ = ["dwt", "idwt", "downcoef", "upcoef", "dwt_max_level",
@@ -157,8 +157,7 @@ def dwt(data, wavelet, mode='symmetric', axis=-1):
     dt = _check_dtype(data)
     data = np.array(data, dtype=dt)
     mode = Modes.from_object(mode)
-    if not isinstance(wavelet, Wavelet):
-        wavelet = Wavelet(wavelet)
+    wavelet = _as_wavelet(wavelet)
 
     if axis < 0:
         axis = axis + data.ndim
@@ -243,8 +242,7 @@ def idwt(cA, cD, wavelet, mode='symmetric', axis=-1):
     ndim = cA.ndim
 
     mode = Modes.from_object(mode)
-    if not isinstance(wavelet, Wavelet):
-        wavelet = Wavelet(wavelet)
+    wavelet = _as_wavelet(wavelet)
 
     if axis < 0:
         axis = axis + ndim
@@ -304,8 +302,7 @@ def downcoef(part, data, wavelet, mode='symmetric', level=1):
     if part not in 'ad':
         raise ValueError("Argument 1 must be 'a' or 'd', not '%s'." % part)
     mode = Modes.from_object(mode)
-    if not isinstance(wavelet, Wavelet):
-        wavelet = Wavelet(wavelet)
+    wavelet = _as_wavelet(wavelet)
     return np.asarray(_downcoef(part == 'a', data, wavelet, mode, level))
 
 
@@ -359,8 +356,7 @@ def upcoef(part, coeffs, wavelet, level=1, take=0):
     # accept array_like input; make a copy to ensure a contiguous array
     dt = _check_dtype(coeffs)
     coeffs = np.array(coeffs, dtype=dt)
-    if not isinstance(wavelet, Wavelet):
-        wavelet = Wavelet(wavelet)
+    wavelet = _as_wavelet(wavelet)
     if part not in 'ad':
         raise ValueError("Argument 1 must be 'a' or 'd', not '%s'." % part)
     return np.asarray(_upcoef(part == 'a', coeffs, wavelet, level, take))

--- a/pywt/_multilevel.py
+++ b/pywt/_multilevel.py
@@ -18,7 +18,7 @@ from ._extensions._pywt import Wavelet
 from ._extensions._dwt import dwt_max_level
 from ._dwt import dwt, idwt
 from ._multidim import dwt2, idwt2, dwtn, idwtn, _fix_coeffs
-from ._utils import _wavelets_per_axis
+from ._utils import _as_wavelet, _wavelets_per_axis
 
 __all__ = ['wavedec', 'waverec', 'wavedec2', 'waverec2', 'wavedecn',
            'waverecn', 'coeffs_to_array', 'array_to_coeffs']
@@ -84,9 +84,7 @@ def wavedec(data, wavelet, mode='symmetric', level=None, axis=-1):
     """
     data = np.asarray(data)
 
-    if not isinstance(wavelet, Wavelet):
-        wavelet = Wavelet(wavelet)
-
+    wavelet = _as_wavelet(wavelet)
     try:
         axes_shape = data.shape[axis]
     except IndexError:

--- a/pywt/_swt.py
+++ b/pywt/_swt.py
@@ -5,9 +5,9 @@ import numpy as np
 
 from ._extensions._dwt import idwt_single
 from ._extensions._swt import swt_max_level, swt as _swt, swt_axis as _swt_axis
-from ._extensions._pywt import Wavelet, Modes, _check_dtype
+from ._extensions._pywt import Modes, _check_dtype
 from ._multidim import idwt2, idwtn
-from ._utils import _wavelets_per_axis
+from ._utils import _as_wavelet, _wavelets_per_axis
 
 
 __all__ = ["swt", "swt_max_level", 'iswt', 'swt2', 'iswt2', 'swtn', 'iswtn']
@@ -61,8 +61,9 @@ def swt(data, wavelet, level=None, start_level=0, axis=-1):
     # accept array_like input; make a copy to ensure a contiguous array
     dt = _check_dtype(data)
     data = np.array(data, dtype=dt)
-    if not isinstance(wavelet, Wavelet):
-        wavelet = Wavelet(wavelet)
+
+    wavelet = _as_wavelet(wavelet)
+
     if level is None:
         level = swt_max_level(len(data))
 
@@ -117,8 +118,7 @@ def iswt(coeffs, wavelet):
 
     # num_levels, equivalent to the decomposition level, n
     num_levels = len(coeffs)
-    if not isinstance(wavelet, Wavelet):
-        wavelet = Wavelet(wavelet)
+    wavelet = _as_wavelet(wavelet)
     mode = Modes.from_object('periodization')
     for j in range(num_levels, 0, -1):
         step_size = int(pow(2, j-1))

--- a/pywt/_utils.py
+++ b/pywt/_utils.py
@@ -4,7 +4,8 @@
 import sys
 from collections import Iterable
 
-from ._extensions._pywt import Wavelet, Modes
+from ._extensions._pywt import (Wavelet, ContinuousWavelet,
+                                DiscreteContinuousWavelet, Modes)
 
 
 # define string_types as in six for Python 2/3 compatibility
@@ -16,8 +17,14 @@ else:
 
 def _as_wavelet(wavelet):
     """Convert wavelet name to a Wavelet object"""
-    if not isinstance(wavelet, Wavelet):
-        wavelet = Wavelet(wavelet)
+    if not isinstance(wavelet, (ContinuousWavelet, Wavelet)):
+        wavelet = DiscreteContinuousWavelet(wavelet)
+    if isinstance(wavelet, ContinuousWavelet):
+        raise ValueError(
+            "A ContinuousWavelet object was provided, but only discrete "
+            "Wavelet objects are supported by this function.  A list of all "
+            "supported discrete wavelets can be obtained by running:\n"
+            "print(pywt.wavelist(kind='discrete'))")
     return wavelet
 
 

--- a/pywt/tests/test_dwt_idwt.py
+++ b/pywt/tests/test_dwt_idwt.py
@@ -193,5 +193,15 @@ def test_dwt_idwt_axis_excess():
                   pywt.idwt, [1, 2, 4], [4, 1, 3], 'db2', 'symmetric', axis=1)
 
 
+def test_error_on_continuous_wavelet():
+    # A ValueError is raised if a Continuous wavelet is selected
+    data = np.ones((32, ))
+    for cwave in ['morl', pywt.DiscreteContinuousWavelet('morl')]:
+        assert_raises(ValueError, pywt.dwt, data, cwave)
+
+        cA, cD = pywt.dwt(data, 'db1')
+        assert_raises(ValueError, pywt.idwt, cA, cD, cwave)
+
+
 if __name__ == '__main__':
     run_module_suite()

--- a/pywt/tests/test_multidim.py
+++ b/pywt/tests/test_multidim.py
@@ -406,5 +406,17 @@ def test_per_axis_wavelets_and_modes():
                     atol=1e-14)
 
 
+def test_error_on_continuous_wavelet():
+    # A ValueError is raised if a Continuous wavelet is selected
+    data = np.ones((16, 16))
+    for dec_fun, rec_fun in zip([pywt.dwt2, pywt.dwtn],
+                                [pywt.idwt2, pywt.idwtn]):
+        for cwave in ['morl', pywt.DiscreteContinuousWavelet('morl')]:
+            assert_raises(ValueError, dec_fun, data, wavelet=cwave)
+
+            c = dec_fun(data, 'db1')
+            assert_raises(ValueError, rec_fun, c, wavelet=cwave)
+
+
 if __name__ == '__main__':
     run_module_suite()

--- a/pywt/tests/test_multilevel.py
+++ b/pywt/tests/test_multilevel.py
@@ -627,5 +627,17 @@ def test_per_axis_wavelets_and_modes():
     assert_equal(min(max_levels[:2]), len(coefs2[1:]))
 
 
+def test_error_on_continuous_wavelet():
+    # A ValueError is raised if a Continuous wavelet is selected
+    data = np.ones((16, 16))
+    for dec_fun, rec_fun in zip([pywt.wavedec, pywt.wavedec2, pywt.wavedecn],
+                                [pywt.waverec, pywt.waverec2, pywt.waverecn]):
+        for cwave in ['morl', pywt.DiscreteContinuousWavelet('morl')]:
+            assert_raises(ValueError, dec_fun, data, wavelet=cwave)
+
+            c = dec_fun(data, 'db1')
+            assert_raises(ValueError, rec_fun, c, wavelet=cwave)
+
+
 if __name__ == '__main__':
     run_module_suite()

--- a/pywt/tests/test_swt.py
+++ b/pywt/tests/test_swt.py
@@ -386,5 +386,20 @@ def test_per_axis_wavelets():
     assert_allclose(pywt.iswt2(coefs2, wavelets[:2]), data2, atol=1e-14)
 
 
+def test_error_on_continuous_wavelet():
+    # A ValueError is raised if a Continuous wavelet is selected
+    data = np.ones((16, 16))
+    with warnings.catch_warnings():  # avoid FutureWarning in swt2
+        warnings.simplefilter('ignore', FutureWarning)
+        for dec_func, rec_func in zip([pywt.swt, pywt.swt2, pywt.swtn],
+                                      [pywt.iswt, pywt.iswt2, pywt.iswtn]):
+            for cwave in ['morl', pywt.DiscreteContinuousWavelet('morl')]:
+                assert_raises(ValueError, dec_func, data, wavelet=cwave,
+                              level=3)
+
+                c = dec_func(data, 'db1', level=3)
+                assert_raises(ValueError, rec_func, c, wavelet=cwave)
+
+
 if __name__ == '__main__':
     run_module_suite()


### PR DESCRIPTION
In current master, providing the name of a continuous wavelet to a discrete transform such as `wavedecn` results in the non-obvious `AttributeError` shown in #333

This PR provides a helpful error message when discrete transforms are called with either a
`ContinuousWavelet` object or a name corresponding to a `ContinuousWavelet`.  In all cases, the error message is provided either directly via `_as_wavelet` (or indirectly via `_wavelets_per_axis`). 

New tests verify that a `ValueError` rather than `AttributeError` is raised for each of the discrete transforms.

closes #333



