### PR TITLE
check for wrong number of dimensions in upcoef and downcoef

### DIFF
--- a/pywt/_dwt.py
+++ b/pywt/_dwt.py
@@ -314,6 +314,8 @@ def downcoef(part, data, wavelet, mode='symmetric', level=1):
     # accept array_like input; make a copy to ensure a contiguous array
     dt = _check_dtype(data)
     data = np.array(data, dtype=dt)
+    if data.ndim > 1:
+        raise ValueError("downcoef only supports 1d data.")
     if part not in 'ad':
         raise ValueError("Argument 1 must be 'a' or 'd', not '%s'." % part)
     mode = Modes.from_object(mode)
@@ -371,6 +373,8 @@ def upcoef(part, coeffs, wavelet, level=1, take=0):
     # accept array_like input; make a copy to ensure a contiguous array
     dt = _check_dtype(coeffs)
     coeffs = np.array(coeffs, dtype=dt)
+    if coeffs.ndim > 1:
+        raise ValueError("upcoef only supports 1d coeffs.")
     wavelet = _as_wavelet(wavelet)
     if part not in 'ad':
         raise ValueError("Argument 1 must be 'a' or 'd', not '%s'." % part)

--- a/pywt/_dwt.py
+++ b/pywt/_dwt.py
@@ -170,7 +170,7 @@ def dwt(data, wavelet, mode='symmetric', axis=-1):
 
     # accept array_like input; make a copy to ensure a contiguous array
     dt = _check_dtype(data)
-    data = np.array(data, dtype=dt)
+    data = np.asarray(data, dtype=dt, order='C')
     mode = Modes.from_object(mode)
     wavelet = _as_wavelet(wavelet)
 
@@ -238,10 +238,10 @@ def idwt(cA, cD, wavelet, mode='symmetric', axis=-1):
 
     if cA is not None:
         dt = _check_dtype(cA)
-        cA = np.array(cA, dtype=dt)
+        cA = np.asarray(cA, dtype=dt, order='C')
     if cD is not None:
         dt = _check_dtype(cD)
-        cD = np.array(cD, dtype=dt)
+        cD = np.asarray(cD, dtype=dt, order='C')
 
     if cA is not None and cD is not None:
         if cA.dtype != cD.dtype:
@@ -313,7 +313,7 @@ def downcoef(part, data, wavelet, mode='symmetric', level=1):
                 1j*downcoef(part, data.imag, wavelet, mode, level))
     # accept array_like input; make a copy to ensure a contiguous array
     dt = _check_dtype(data)
-    data = np.array(data, dtype=dt)
+    data = np.asarray(data, dtype=dt, order='C')
     if data.ndim > 1:
         raise ValueError("downcoef only supports 1d data.")
     if part not in 'ad':
@@ -372,7 +372,7 @@ def upcoef(part, coeffs, wavelet, level=1, take=0):
                 1j*upcoef(part, coeffs.imag, wavelet, level, take))
     # accept array_like input; make a copy to ensure a contiguous array
     dt = _check_dtype(coeffs)
-    coeffs = np.array(coeffs, dtype=dt)
+    coeffs = np.asarray(coeffs, dtype=dt, order='C')
     if coeffs.ndim > 1:
         raise ValueError("upcoef only supports 1d coeffs.")
     wavelet = _as_wavelet(wavelet)

--- a/pywt/tests/test__pywt.py
+++ b/pywt/tests/test__pywt.py
@@ -95,6 +95,14 @@ def test_upcoef_errs():
     assert_raises(ValueError, pywt.upcoef, 'f', np.ones(4), 'haar')
 
 
+def test_upcoef_and_downcoef_1d_only():
+    # upcoef and downcoef raise a ValueError if data.ndim > 1d
+    for ndim in [2, 3]:
+        data = np.ones((8, )*ndim)
+        assert_raises(ValueError, pywt.downcoef, 'a', data, 'haar')
+        assert_raises(ValueError, pywt.upcoef, 'a', data, 'haar')
+
+
 def test_wavelet_repr():
     from pywt._extensions import _pywt
     wavelet = _pywt.Wavelet('sym8')
@@ -157,6 +165,7 @@ def test_wavelet_errormsgs():
         pywt.Wavelet('gaus1')
     except ValueError as e:
         assert_(e.args[0].startswith('The `Wavelet` class'))
+
 
 if __name__ == '__main__':
     run_module_suite()


### PR DESCRIPTION
provide a helpful error message if n-dimensional (n != 1) data is provided to the 1D `upcoef` or `downcoef` 

closes #338
