### PR TITLE
force legacy numpy repr for doctests

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -15,6 +15,15 @@ import re
 import datetime
 import jinja2.filters
 
+import numpy as np
+
+# FIXME: doctests need the str/repr formatting used in Numpy < 1.14.
+try:
+    np.set_printoptions(legacy='1.13')
+except TypeError:
+    pass
+
+
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.

--- a/pywt/__init__.py
+++ b/pywt/__init__.py
@@ -36,7 +36,7 @@ except NameError:
 from pywt.version import version as __version__
 
 import numpy as np
-if LooseVersion(np.__version__) >= LooseVersion("1.14"):
+if np.lib.NumpyVersion(np.__version__) >= '1.14.0':
     from ._utils import is_nose_running
     if is_nose_running():
         np.set_printoptions(legacy='1.13')

--- a/pywt/__init__.py
+++ b/pywt/__init__.py
@@ -11,7 +11,7 @@ wavelet packets signal decomposition and reconstruction module.
 """
 
 from __future__ import division, print_function, absolute_import
-
+from distutils.version import LooseVersion
 
 from ._extensions._pywt import *
 from ._functions import *
@@ -34,6 +34,12 @@ except NameError:
     pass
 
 from pywt.version import version as __version__
+
+import numpy as np
+if LooseVersion(np.__version__) >= LooseVersion("1.14"):
+    from ._utils import is_nose_running
+    if is_nose_running():
+        np.set_printoptions(legacy='1.13')
 
 from numpy.testing import Tester
 test = Tester().test

--- a/pywt/_utils.py
+++ b/pywt/_utils.py
@@ -104,7 +104,7 @@ def is_nose_running():
     """Returns whether we are running the nose test loader
     """
     if 'nose' not in sys.modules:
-        return
+        return False
     try:
         import nose
     except ImportError:

--- a/pywt/_utils.py
+++ b/pywt/_utils.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2017 The PyWavelets Developers
 #                    <https://github.com/PyWavelets/pywt>
 # See COPYING for license details.
+import inspect
 import sys
 from collections import Iterable
 
@@ -97,3 +98,23 @@ def _modes_per_axis(modes, axes):
     else:
         raise ValueError("modes must be a str, Mode enum or iterable")
     return modes
+
+
+def is_nose_running():
+    """Returns whether we are running the nose test loader
+    """
+    if 'nose' not in sys.modules:
+        return
+    try:
+        import nose
+    except ImportError:
+        return False
+    # Now check that we have the loader in the call stask
+    stack = inspect.stack()
+    loader_file_name = nose.loader.__file__
+    if loader_file_name.endswith('.pyc'):
+        loader_file_name = loader_file_name[:-1]
+    for _, file_name, _, _, _, _ in stack:
+        if file_name == loader_file_name:
+            return True
+    return False

--- a/util/refguide_check.py
+++ b/util/refguide_check.py
@@ -41,6 +41,12 @@ from doctest import NORMALIZE_WHITESPACE, ELLIPSIS, IGNORE_EXCEPTION_DETAIL
 from argparse import ArgumentParser
 import numpy as np
 
+# FIXME: doctests need the str/repr formatting used in Numpy < 1.14.
+try:
+    np.set_printoptions(legacy='1.13')
+except TypeError:
+    pass
+
 # sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'doc',
 #                 'sphinxext'))
 from numpydoc.docscrape_sphinx import get_doc_object


### PR DESCRIPTION
Many doctests rely on the numpy <=1.13 format array printing.  This PR forces this older representation to be used in the docstring examples when numpy >= 1.14.

In the future, once the minimum numpy version supported has been bumped to >=1.14, the doctests should be regenerated with the new representation and these lines can be removed.