### PR TITLE
test case for CWT with complex input

### DIFF
--- a/demo/cwt_analysis.py
+++ b/demo/cwt_analysis.py
@@ -7,18 +7,18 @@ import matplotlib.pyplot as plt
 import pywt
 
 time, sst = pywt.data.nino()
-dt = time[1]-time[0]
+dt = time[1] - time[0]
 
 # Taken from http://nicolasfauchereau.github.io/climatecode/posts/wavelet-analysis-in-python/
 wavelet = 'cmor1.5-1.0'
-scales = np.arange(1,128)
+scales = np.arange(1, 128)
 
-[cfs,frequencies] = pywt.cwt(sst,scales,wavelet,dt)
+[cfs, frequencies] = pywt.cwt(sst, scales, wavelet, dt)
 power = (abs(cfs)) ** 2
 
 period = 1. / frequencies
 levels = [0.0625, 0.125, 0.25, 0.5, 1, 2, 4, 8]
-f, ax = plt.subplots(figsize=(15,10))
+f, ax = plt.subplots(figsize=(15, 10))
 ax.contourf(time, np.log2(period), np.log2(power), np.log2(levels),
             extend='both')
 

--- a/demo/cwt_analysis.py
+++ b/demo/cwt_analysis.py
@@ -10,7 +10,7 @@ time, sst = pywt.data.nino()
 dt = time[1]-time[0]
 
 # Taken from http://nicolasfauchereau.github.io/climatecode/posts/wavelet-analysis-in-python/
-wavelet = 'cmor'
+wavelet = 'cmor1.5-1.0'
 scales = np.arange(1,128)
 
 [cfs,frequencies] = pywt.cwt(sst,scales,wavelet,dt)

--- a/pywt/tests/test_cwt_wavelets.py
+++ b/pywt/tests/test_cwt_wavelets.py
@@ -344,5 +344,22 @@ def test_cwt_parameters_in_names():
         assert_raises(ValueError, func, 'fbsp1-1-1-1')
 
 
+def test_cwt_complex():
+    for dtype in [np.float32, np.float64]:
+        time, sst = pywt.data.nino()
+        sst = np.asarray(sst, dtype=dtype)
+        dt = time[1] - time[0]
+        wavelet = 'cmor1.5-1.0'
+        scales = np.arange(1, 32)
+
+        # real-valued tranfsorm
+        [cfs, f] = pywt.cwt(sst, scales, wavelet, dt)
+
+        # complex-valued tranfsorm equals sum of the transforms of the real and
+        # imaginary components
+        [cfs_complex, f] = pywt.cwt(sst + 1j*sst, scales, wavelet, dt)
+        assert_almost_equal(cfs + 1j*cfs, cfs_complex)
+
+
 if __name__ == '__main__':
     run_module_suite()


### PR DESCRIPTION
A side effect of the DWT-focused #300 was that it also resolved #326 by making `cwt` accept complex dtypes on the inputs.  This PR just adds a simple test case to make sure that this feature gets tested to avoid future breakage.  

I also updated the CWT to avoid a `FutureWarning` related to #310.
