### PR TITLE
better document the size requirements for swt/swt2/swtn

### DIFF
--- a/pywt/_extensions/_swt.pyx
+++ b/pywt/_extensions/_swt.pyx
@@ -31,8 +31,9 @@ def swt_max_level(size_t input_len):
     -----
     For the current implementation of the stationary wavelet transform, this
     corresponds to the number of times ``input_len`` is evenly divisible by
-    two.
-
+    two. In other words, for an n-level transform, the signal length must be a
+    multiple of ``2**n``. ``numpy.pad`` can be used to pad a signal up to an
+    appropriate length as needed.
     """
     return common.swt_max_level(input_len)
 

--- a/pywt/_extensions/_swt.pyx
+++ b/pywt/_extensions/_swt.pyx
@@ -2,6 +2,7 @@
 cimport common
 cimport c_wt
 
+import warnings
 import numpy as np
 cimport numpy as np
 
@@ -35,7 +36,13 @@ def swt_max_level(size_t input_len):
     multiple of ``2**n``. ``numpy.pad`` can be used to pad a signal up to an
     appropriate length as needed.
     """
-    return common.swt_max_level(input_len)
+    max_level = common.swt_max_level(input_len)
+    if max_level == 0:
+        warnings.warn(
+            "No levels of stationary wavelet decomposition are possible. The "
+            "signal to be transformed must have a size that is a multiple "
+            "of 2**n for an n-level decomposition.")
+    return max_level
 
 
 def swt(cdata_t[::1] data, Wavelet wavelet, size_t level, size_t start_level):
@@ -56,7 +63,8 @@ def swt(cdata_t[::1] data, Wavelet wavelet, size_t level, size_t start_level):
 
     if end_level > common.swt_max_level(data.size):
         msg = ("Level value too high (max level for current data size and "
-               "start_level is %d)." % (swt_max_level(data.size) - start_level))
+               "start_level is %d)." % (
+                common.swt_max_level(data.size) - start_level))
         raise ValueError(msg)
 
     output_len = common.swt_buffer_length(data.size)
@@ -156,7 +164,8 @@ cpdef swt_axis(np.ndarray data, Wavelet wavelet, size_t level,
 
     if end_level > common.swt_max_level(data.shape[axis]):
         msg = ("Level value too high (max level for current data size and "
-               "start_level is %d)." % (swt_max_level(data.shape[axis]) - start_level))
+               "start_level is %d)." % (
+                common.swt_max_level(data.shape[axis]) - start_level))
         raise ValueError(msg)
 
     data = data.astype(_check_dtype(data), copy=False)

--- a/pywt/_swt.py
+++ b/pywt/_swt.py
@@ -49,6 +49,12 @@ def swt(data, wavelet, level=None, start_level=0, axis=-1):
 
             [(cAm+n, cDm+n), ..., (cAm+1, cDm+1), (cAm, cDm)]
 
+    Notes
+    -----
+    The implementation here follows the "algorithm a-trous" and requires that
+    the signal length along the transformed axis be a multiple of ``2**level``.
+    If this is not the case, the user should pad up to an appropriate size
+    using a function such as ``numpy.pad``.
     """
     if not _have_c99_complex and np.iscomplexobj(data):
         data = np.asarray(data)
@@ -193,6 +199,12 @@ def swt2(data, wavelet, level, start_level=0, axes=(-2, -1)):
         where cA is approximation, cH is horizontal details, cV is
         vertical details, cD is diagonal details and m is ``start_level``.
 
+    Notes
+    -----
+    The implementation here follows the "algorithm a-trous" and requires that
+    the signal length along the transformed axes be a multiple of ``2**level``.
+    If this is not the case, the user should pad up to an appropriate size
+    using a function such as ``numpy.pad``.
     """
     axes = tuple(axes)
     data = np.asarray(data)
@@ -372,6 +384,12 @@ def swtn(data, wavelet, level, start_level=0, axes=None):
         For user-specified ``axes``, the order of the characters in the
         dictionary keys map to the specified ``axes``.
 
+    Notes
+    -----
+    The implementation here follows the "algorithm a-trous" and requires that
+    the signal length along the transformed axes be a multiple of ``2**level``.
+    If this is not the case, the user should pad up to an appropriate size
+    using a function such as ``numpy.pad``.
     """
     data = np.asarray(data)
     if not _have_c99_complex and np.iscomplexobj(data):

--- a/pywt/tests/test_swt.py
+++ b/pywt/tests/test_swt.py
@@ -7,7 +7,8 @@ from copy import deepcopy
 from itertools import combinations
 import numpy as np
 from numpy.testing import (run_module_suite, dec, assert_allclose, assert_,
-                           assert_equal, assert_raises, assert_array_equal)
+                           assert_equal, assert_raises, assert_array_equal,
+                           assert_warns)
 
 import pywt
 from pywt._extensions._swt import swt_axis
@@ -57,7 +58,21 @@ def test_swt_decomposition():
 
     coeffs = pywt.swt(x, db1)
     assert_(len(coeffs) == 3)
-    assert_(pywt.swt_max_level(len(x)) == 3)
+    assert_(pywt.swt_max_level(len(x)), 3)
+
+
+def test_swt_max_level():
+    # odd sized signal will warn about no levels of decomposition possible
+    assert_warns(UserWarning, pywt.swt_max_level, 11)
+    with warnings.catch_warnings():
+        warnings.simplefilter('ignore', UserWarning)
+        assert_equal(pywt.swt_max_level(11), 0)
+
+    # no warnings when >= 1 level of decomposition possible
+    assert_equal(pywt.swt_max_level(2), 1)     # divisible by 2**1
+    assert_equal(pywt.swt_max_level(4*3), 2)    # divisible by 2**2
+    assert_equal(pywt.swt_max_level(16), 4)    # divisible by 2**4
+    assert_equal(pywt.swt_max_level(16*3), 4)  # divisible by 2**4
 
 
 def test_swt_axis():


### PR DESCRIPTION
This is related to #324.  

Here I have only updated documentation rather than issue a warning in `swt_max_level` itself. I think too many warnings might become annoying, but perhaps in a specific case (maybe only when the number of levels is zero?) it could be appropriate?
