### PR TITLE
swt(): inference of level=None to depend on axis

### DIFF
--- a/pywt/_swt.py
+++ b/pywt/_swt.py
@@ -78,7 +78,7 @@ def swt(data, wavelet, level=None, start_level=0, axis=-1):
 
     if level is None:
         level = swt_max_level(data.shape[axis])
-        
+
     if data.ndim == 1:
         ret = _swt(data, wavelet, level, start_level)
     else:

--- a/pywt/_swt.py
+++ b/pywt/_swt.py
@@ -71,14 +71,14 @@ def swt(data, wavelet, level=None, start_level=0, axis=-1):
 
     wavelet = _as_wavelet(wavelet)
 
-    if level is None:
-        level = swt_max_level(len(data))
-
     if axis < 0:
         axis = axis + data.ndim
     if not 0 <= axis < data.ndim:
         raise ValueError("Axis greater than data dimensions")
 
+    if level is None:
+        level = swt_max_level(data.shape[axis])
+        
     if data.ndim == 1:
         ret = _swt(data, wavelet, level, start_level)
     else:

--- a/pywt/tests/test_swt.py
+++ b/pywt/tests/test_swt.py
@@ -198,6 +198,15 @@ def test_swt_roundtrip_dtypes():
             assert_allclose(x, xr, rtol=1e-6, atol=1e-7)
 
 
+def test_swt_default_level_by_axis():
+    # make sure default number of levels matches the max level along the axis
+    wav = 'db2'
+    x = np.ones((2**3, 2**4, 2**5))
+    for axis in (0, 1, 2):
+        sdec = pywt.swt(x, wav, level=None, start_level=0, axis=axis)
+        assert_equal(len(sdec), pywt.swt_max_level(x.shape[axis]))
+
+
 def test_swt2_ndim_error():
     x = np.ones(8)
     with warnings.catch_warnings():


### PR DESCRIPTION
Did not check in other functions, but here when level=None, level was infered based on len(data) which is data.shape[0], leading to confusion when using axis~=0