### PR TITLE
fix: default level in `wavedec2` and `wavedecn` can be too conservative

### DIFF
--- a/pywt/_multilevel.py
+++ b/pywt/_multilevel.py
@@ -24,21 +24,21 @@ __all__ = ['wavedec', 'waverec', 'wavedec2', 'waverec2', 'wavedecn',
            'waverecn', 'coeffs_to_array', 'array_to_coeffs']
 
 
-def _check_level(size, dec_len, level):
-    """
-    Set the default decomposition level or check if requested level is valid.
-    """
+def _check_level(sizes, dec_lens, level):
+    if np.isscalar(sizes):
+        sizes = (sizes, )
+    if np.isscalar(dec_lens):
+        dec_lens = (dec_lens, )
+    max_level = np.min([dwt_max_level(s, d) for s, d in zip(sizes, dec_lens)])
     if level is None:
-        level = dwt_max_level(size, dec_len)
+        level = max_level
     elif level < 0:
         raise ValueError(
             "Level value of %d is too low . Minimum level is 0." % level)
-    else:
-        max_level = dwt_max_level(size, dec_len)
-        if level > max_level:
-            raise ValueError(
-                "Level value of %d is too high.  Maximum allowed is %d." % (
-                    level, max_level))
+    elif level > max_level:
+        raise ValueError(
+            "Level value of %d is too high.  Maximum allowed is %d." % (
+                level, max_level))
     return level
 
 
@@ -226,7 +226,7 @@ def wavedec2(data, wavelet, mode='symmetric', level=None, axes=(-2, -1)):
     wavelets = _wavelets_per_axis(wavelet, axes)
     dec_lengths = [w.dec_len for w in wavelets]
 
-    level = _check_level(min(axes_sizes), max(dec_lengths), level)
+    level = _check_level(axes_sizes, dec_lengths, level)
 
     coeffs_list = []
 
@@ -406,7 +406,7 @@ def wavedecn(data, wavelet, mode='symmetric', level=None, axes=None):
     wavelets = _wavelets_per_axis(wavelet, axes)
     dec_lengths = [w.dec_len for w in wavelets]
 
-    level = _check_level(min(axes_shapes), max(dec_lengths), level)
+    level = _check_level(axes_shapes, dec_lengths, level)
 
     coeffs_list = []
 

--- a/pywt/tests/test_multilevel.py
+++ b/pywt/tests/test_multilevel.py
@@ -652,5 +652,22 @@ def test_error_on_continuous_wavelet():
             assert_raises(ValueError, rec_fun, c, wavelet=cwave)
 
 
+def test_default_level():
+    # default level is the maximum permissible for the transformed axes
+    data = np.ones((128, 32, 4))
+    wavelet = ('db8', 'db1')
+    for dec_func in [pywt.wavedec2, pywt.wavedecn]:
+        for axes in [(0, 1), (2, 1), (0, 2)]:
+            c = dec_func(data, wavelet, axes=axes)
+            max_lev = np.min([pywt.dwt_max_level(data.shape[ax], wav)
+                              for ax, wav in zip(axes, wavelet)])
+            assert_equal(len(c[1:]), max_lev)
+
+    for ax in [0, 1]:
+        c = pywt.wavedecn(data, wavelet[ax], axes=(ax, ))
+        assert_equal(len(c[1:]),
+                     pywt.dwt_max_level(data.shape[ax], wavelet[ax]))
+
+
 if __name__ == '__main__':
     run_module_suite()


### PR DESCRIPTION
The current default `level` setting in `wavedec2` or `wavedecn` can be too conservative if a per-axis `Wavelet` is provided.  It was using the longest wavelet filter and shortest transform axes to determine the number of levels.  This is too conservative when the longest wavelet is not applied along the shortest axis.  

Instead, `dwt_max_level` should be called on a per-axis basis and the minimum of the levels along the transformed axis returned.

A minimal example where the old behaviour would return a 0-level transform when in a multi-level transform is possible.
```python
data = np.ones((128, 32))
wavelet = ('db16', 'db1')
c = pywt.wavedec2(data, wavelet)
```
The new test cases are an expanded version of the above example.