### PR TITLE
Fix spelling of continuous globally

### DIFF
--- a/doc/source/dev/testing.rst
+++ b/doc/source/dev/testing.rst
@@ -7,7 +7,7 @@ Continous integration with Travis-CI
 ------------------------------------
 
 The project is using `Travis-CI <https://travis-ci.org/PyWavelets/pywt>`_ service
-for continous integration and testing.
+for continuous integration and testing.
 
 Current build status is:
 

--- a/doc/source/ref/cwt.rst
+++ b/doc/source/ref/cwt.rst
@@ -6,7 +6,7 @@
 Continuous Wavelet Transform (CWT)
 =================================
 
-This section describes functions used to perform single continous wavelet
+This section describes functions used to perform single continuous wavelet
 transforms.
 
 Single level - ``cwt``

--- a/doc/source/ref/wavelets.rst
+++ b/doc/source/ref/wavelets.rst
@@ -256,7 +256,7 @@ from plain Python lists of filter coefficients and a *filter bank-like* object.
 
 .. class:: ContinuousWavelet(name)
 
-  Describes properties of a continous wavelet identified by the specified wavelet ``name``.
+  Describes properties of a continuous wavelet identified by the specified wavelet ``name``.
   In order to use a built-in wavelet the ``name`` parameter must be a valid
   wavelet name from the :func:`pywt.wavelist` list.
 

--- a/pywt/_cwt.py
+++ b/pywt/_cwt.py
@@ -27,7 +27,7 @@ def cwt(data, scales, wavelet, sampling_period=1.):
     Returns
     -------
     coefs : array_like
-        Continous wavelet transform of the input signal for the given scales
+        Continuous wavelet transform of the input signal for the given scales
         and wavelet
     frequencies : array_like
         if the unit of sampling period are seconds and given, than frequencies

--- a/pywt/_extensions/_pywt.pyx
+++ b/pywt/_extensions/_pywt.pyx
@@ -713,7 +713,7 @@ cdef public class ContinuousWavelet [type ContinuousWaveletType, object Continuo
         else:
             base_name = self.name
         family_code, family_number = wname_to_code(base_name)
-        self.w = <wavelet.ContinuousWavelet*> wavelet.continous_wavelet(
+        self.w = <wavelet.ContinuousWavelet*> wavelet.continuous_wavelet(
             family_code, family_number)
 
         if self.w is NULL:
@@ -755,7 +755,7 @@ cdef public class ContinuousWavelet [type ContinuousWaveletType, object Continuo
 
     def __dealloc__(self):
         if self.w is not NULL:
-            wavelet.free_continous_wavelet(self.w)
+            wavelet.free_continuous_wavelet(self.w)
             self.w = NULL
 
     property family_number:

--- a/pywt/_extensions/c/wavelets.c
+++ b/pywt/_extensions/c/wavelets.c
@@ -352,7 +352,7 @@ DiscreteWavelet* discrete_wavelet(WAVELET_NAME name, unsigned int order)
     return w;
 }
 
-ContinuousWavelet* continous_wavelet(WAVELET_NAME name, unsigned int order)
+ContinuousWavelet* continuous_wavelet(WAVELET_NAME name, unsigned int order)
 {
     ContinuousWavelet *w;
     switch(name){
@@ -360,7 +360,7 @@ ContinuousWavelet* continous_wavelet(WAVELET_NAME name, unsigned int order)
         case GAUS:
             if (order > 8)
                 return NULL;
-            w = blank_continous_wavelet();
+            w = blank_continuous_wavelet();
             if(w == NULL) return NULL;
 
             w->base.support_width = -1;
@@ -381,7 +381,7 @@ ContinuousWavelet* continous_wavelet(WAVELET_NAME name, unsigned int order)
             w->fbsp_order = 0;
             break;
         case MEXH:
-            w = blank_continous_wavelet();
+            w = blank_continuous_wavelet();
             if(w == NULL) return NULL;
 
             w->base.support_width = -1;
@@ -399,7 +399,7 @@ ContinuousWavelet* continous_wavelet(WAVELET_NAME name, unsigned int order)
             w->fbsp_order = 0;
             break;
         case MORL:
-            w = blank_continous_wavelet();
+            w = blank_continuous_wavelet();
             if(w == NULL) return NULL;
 
             w->base.support_width = -1;
@@ -419,7 +419,7 @@ ContinuousWavelet* continous_wavelet(WAVELET_NAME name, unsigned int order)
         case CGAU:
             if (order > 8)
                 return NULL;
-            w = blank_continous_wavelet();
+            w = blank_continuous_wavelet();
             if(w == NULL) return NULL;
 
             w->base.support_width = -1;
@@ -441,7 +441,7 @@ ContinuousWavelet* continous_wavelet(WAVELET_NAME name, unsigned int order)
             break;
         case SHAN:
 
-            w = blank_continous_wavelet();
+            w = blank_continuous_wavelet();
             if(w == NULL) return NULL;
 
             w->base.support_width = -1;
@@ -460,7 +460,7 @@ ContinuousWavelet* continous_wavelet(WAVELET_NAME name, unsigned int order)
             break;
         case FBSP:
 
-            w = blank_continous_wavelet();
+            w = blank_continuous_wavelet();
             if(w == NULL) return NULL;
 
             w->base.support_width = -1;
@@ -479,7 +479,7 @@ ContinuousWavelet* continous_wavelet(WAVELET_NAME name, unsigned int order)
             break;
         case CMOR:
 
-            w = blank_continous_wavelet();
+            w = blank_continuous_wavelet();
             if(w == NULL) return NULL;
 
             w->base.support_width = -1;
@@ -561,7 +561,7 @@ DiscreteWavelet* blank_discrete_wavelet(size_t filters_length)
     return w;
 }
 
-ContinuousWavelet* blank_continous_wavelet(void)
+ContinuousWavelet* blank_continuous_wavelet(void)
 {
     ContinuousWavelet* w;
 
@@ -669,7 +669,7 @@ void free_discrete_wavelet(DiscreteWavelet *w){
     wtfree(w);
 }
 
-void free_continous_wavelet(ContinuousWavelet *w){
+void free_continuous_wavelet(ContinuousWavelet *w){
 
     /* finally free struct */
     wtfree(w);

--- a/pywt/_extensions/c/wavelets.h
+++ b/pywt/_extensions/c/wavelets.h
@@ -95,13 +95,13 @@ int is_discrete_wavelet(WAVELET_NAME name);
  * order - order of the wavelet (ie. coif3 has order 3)
  */
 DiscreteWavelet* discrete_wavelet(WAVELET_NAME name, unsigned int order);
-ContinuousWavelet* continous_wavelet(WAVELET_NAME name, unsigned int order);
+ContinuousWavelet* continuous_wavelet(WAVELET_NAME name, unsigned int order);
 /*
  * Allocate blank Discrete Wavelet with zero-filled filters of given length
  */
 DiscreteWavelet* blank_discrete_wavelet(size_t filters_length);
 
-ContinuousWavelet* blank_continous_wavelet(void);
+ContinuousWavelet* blank_continuous_wavelet(void);
 
 /* Deep copy Discrete Wavelet */
 DiscreteWavelet* copy_discrete_wavelet(DiscreteWavelet* base);
@@ -112,4 +112,4 @@ DiscreteWavelet* copy_discrete_wavelet(DiscreteWavelet* base);
  */
 void free_discrete_wavelet(DiscreteWavelet *wavelet);
 
-void free_continous_wavelet(ContinuousWavelet *wavelet);
+void free_continuous_wavelet(ContinuousWavelet *wavelet);

--- a/pywt/_extensions/wavelet.pxd
+++ b/pywt/_extensions/wavelet.pxd
@@ -6,8 +6,8 @@ cdef extern from "c/wavelets.h":
         NEAR_SYMMETRIC
         SYMMETRIC
         ANTI_SYMMETRIC
-        
-        
+
+
     ctypedef enum WAVELET_NAME:
         HAAR
         RBIO
@@ -23,17 +23,17 @@ cdef extern from "c/wavelets.h":
         SHAN
         FBSP
         CMOR
-        
+
     ctypedef struct BaseWavelet:
         pywt_index_t support_width
 
         unsigned int orthogonal
         unsigned int biorthogonal
         unsigned int compact_support
-        
+
         SYMMETRY symmetry
 
-        
+
         int _builtin
         char* family_name
         char* short_name
@@ -50,12 +50,12 @@ cdef extern from "c/wavelets.h":
         float* rec_lo_float
         size_t dec_len         # length of decomposition filter
         size_t rec_len         # length of reconstruction filter
-        
+
         int vanishing_moments_psi
         int vanishing_moments_phi
         BaseWavelet base
 
-        
+
     ctypedef struct ContinuousWavelet:
 
         BaseWavelet base
@@ -65,16 +65,16 @@ cdef extern from "c/wavelets.h":
         float bandwidth_frequency
         unsigned int fbsp_order
         int complex_cwt
-    
+
 
     cdef int is_discrete_wavelet(WAVELET_NAME name)
     cdef DiscreteWavelet* discrete_wavelet(WAVELET_NAME name, int type)
     cdef DiscreteWavelet* blank_discrete_wavelet(size_t filter_length)
     cdef void free_discrete_wavelet(DiscreteWavelet* wavelet)
-    
-    cdef ContinuousWavelet* continous_wavelet(WAVELET_NAME name, int type)
-    cdef ContinuousWavelet* blank_continous_wavelet()
-    cdef void free_continous_wavelet(ContinuousWavelet* wavelet)
-    
-    
+
+    cdef ContinuousWavelet* continuous_wavelet(WAVELET_NAME name, int type)
+    cdef ContinuousWavelet* blank_continuous_wavelet()
+    cdef void free_continuous_wavelet(ContinuousWavelet* wavelet)
+
+
 

--- a/pywt/tests/test_matlab_compatibility_cwt.py
+++ b/pywt/tests/test_matlab_compatibility_cwt.py
@@ -1,5 +1,5 @@
 """
-Test used to verify PyWavelets Continous Wavelet Transform computation
+Test used to verify PyWavelets Continuous Wavelet Transform computation
 accuracy against MathWorks Wavelet Toolbox.
 """
 


### PR DESCRIPTION
@tayebzaidi pointed out another misspelling of continuous than the one recently resolved in #360.  A quick grep of the codebase revealed several other instances.

Fortunately, none of these are in function names in the Python API, so there should not be a backwards compatibility concern for PyWavelets itself.  Some function names in the underlying C/Cython code were modified, but I don't believe we make any guarantees regarding backward compatibility of the code in the private `_extensions` folder?
