### PR TITLE
fix segfault related to parallel SWT

### DIFF
--- a/pywt/_extensions/c/common.c
+++ b/pywt/_extensions/c/common.c
@@ -1,4 +1,4 @@
-/* Copyright (c) 2006-2012 Filip Wasilewski <http://en.ig.ma/> 
+/* Copyright (c) 2006-2012 Filip Wasilewski <http://en.ig.ma/>
  * Copyright (c) 2012-2016 The PyWavelets Developers
  *                         <https://github.com/PyWavelets/pywt>
  * See COPYING for license details.

--- a/pywt/_extensions/c/common.c
+++ b/pywt/_extensions/c/common.c
@@ -12,15 +12,6 @@
 #include <stdint.h> // for SIZE_MAX
 #endif /* _MSC_VER */
 
-#ifdef PY_EXTENSION
-void *wtcalloc(size_t len, size_t size){
-        void *p = wtmalloc(len*size);
-        if(p)
-            memset(p, 0, len*size);
-        return p;
-}
-#endif
-
 /* Returns the floor of the base-2 log of it's input
  *
  * Undefined for x = 0

--- a/pywt/_extensions/c/common.h
+++ b/pywt/_extensions/c/common.h
@@ -35,17 +35,14 @@
     /* on Solaris/SmartOS system, index_t is used in sys/types.h, so use pytw_index_t */
     typedef Py_ssize_t pywt_index_t;
 
-    /* using Python's memory manager */
-    #define wtmalloc(size)      PyMem_Malloc(size)
-    #define wtfree(ptr)         PyMem_Free(ptr)
-    void *wtcalloc(size_t, size_t);
 #else
     typedef int pywt_index_t;
-    /* standard c memory management */
-    #define wtmalloc(size)      malloc(size)
-    #define wtfree(ptr)         free(ptr)
-    #define wtcalloc(len, size) calloc(len, size)
 #endif
+
+/* standard c memory management */
+#define wtmalloc(size)      malloc(size)
+#define wtfree(ptr)         free(ptr)
+#define wtcalloc(len, size) calloc(len, size)
 
 #ifdef _MSC_VER
     #include <intrin.h>

--- a/pywt/_extensions/c/wt.template.c
+++ b/pywt/_extensions/c/wt.template.c
@@ -467,7 +467,8 @@ int CAT(TYPE, _swt_)(const TYPE * const restrict input, pywt_index_t input_len,
     if(level > 1){
         /* allocate filter first */
         e_filter_len = filter_len << (level-1);
-        e_filter = wtcalloc(e_filter_len, sizeof(TYPE));
+        if ((e_filter = wtcalloc(e_filter_len, sizeof(TYPE))) == NULL)
+            goto cleanup;
         if(e_filter == NULL)
             return -1;
         fstep = 1 << (level - 1);  // spacing between non-zero filter entries
@@ -487,6 +488,9 @@ int CAT(TYPE, _swt_)(const TYPE * const restrict input, pywt_index_t input_len,
                                                     filter_len, output, 1,
                                                     1);
     }
+ cleanup:
+    wtfree(e_filter);
+    return -3;
 }
 
 /*

--- a/pywt/tests/test_concurrent.py
+++ b/pywt/tests/test_concurrent.py
@@ -53,7 +53,7 @@ def test_concurrent_swt():
         warnings.simplefilter('ignore', FutureWarning)
         for swt_func, x in zip([pywt.swt, pywt.swt2, pywt.swtn],
                                [np.ones(8), np.eye(16), np.eye(16)]):
-            transform = partial(swt_func, wavelet='haar', level=1)
+            transform = partial(swt_func, wavelet='haar', level=3)
             for _ in range(10):
                 arrs = [x.copy() for _ in range(100)]
                 with futures.ThreadPoolExecutor(max_workers=max_workers) as ex:


### PR DESCRIPTION
For `swt2` or `swtn`, when the number of levels is >1, `wtcalloc` and `wtfree` are used.  The cython functions have been declared `nogil` to allow multi-threading, but `wtcalloc` calls `PyMem_Malloc` which requires the GIL.  This can lead to segfaults during parallel multidimensional SWT as raised in #363.

Using the standard C `malloc`, `free` and `calloc` seems to resolve the issue.

The only other place aside from axis-specific swt where `wtcalloc` and `wtfree` were being used is when allocating `wavelet` filter coefficients.