### PR TITLE
remove iswt2's restriction on non-square inputs

### DIFF
--- a/pywt/_swt.py
+++ b/pywt/_swt.py
@@ -291,9 +291,8 @@ def iswt2(coeffs, wavelet):
         step_size = int(pow(2, j-1))
         last_index = step_size
         _, (cH, cV, cD) = coeffs[j-1]
-        # We are going to assume cH, cV, and cD are square and of equal size
-        if (cH.shape != cV.shape) or (cH.shape != cD.shape) or (
-                cH.shape[0] != cH.shape[1]):
+        # We are going to assume cH, cV, and cD are of equal size
+        if (cH.shape != cV.shape) or (cH.shape != cD.shape):
             raise RuntimeError(
                 "Mismatch in shape of intermediate coefficient arrays")
         for first_h in range(last_index):  # 0 to last_index - 1

--- a/pywt/tests/test_swt.py
+++ b/pywt/tests/test_swt.py
@@ -250,6 +250,17 @@ def test_swt2_iswt2_quick():
     test_swt2_iswt2_integration(wavelets=['db1', ])
 
 
+def test_swt2_iswt2_non_square(wavelets=None):
+    for nrows in [8, 16, 48]:
+        X = np.arange(nrows*32).reshape(nrows, 32)
+        current_wavelet = 'db1'
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore', FutureWarning)
+            coeffs = pywt.swt2(X, current_wavelet, level=2)
+            Y = pywt.iswt2(coeffs, current_wavelet)
+        assert_allclose(Y, X, rtol=tol_single, atol=tol_single)
+
+
 def test_swt2_axes():
     atol = 1e-14
     current_wavelet = pywt.Wavelet('db2')


### PR DESCRIPTION
`iswt2` enforces square shaped inputs (this is even documented in a comment), but that seems to be unnecessary.  This PR just removes the restriction and adds a basic test case with rectangular inputs.

closes #368 
