### PR TITLE
BLD: fix doc build on ReadTheDocs, need matplotlib for plots in examples

### DIFF
--- a/util/readthedocs/requirements.txt
+++ b/util/readthedocs/requirements.txt
@@ -13,3 +13,4 @@ Cython==0.20.2
 nose
 wheel
 numpydoc
+matplotlib


### PR DESCRIPTION
This change seems to be needed after gh-376.