### PR TITLE
Fix corner case for small scales in CWT

### DIFF
--- a/pywt/_cwt.py
+++ b/pywt/_cwt.py
@@ -84,7 +84,13 @@ def cwt(data, scales, wavelet, sampling_period=1.):
             coef = - np.sqrt(scales[i]) * np.diff(
                 np.convolve(data, int_psi[j.astype(np.int)][::-1]))
             d = (coef.size - data.size) / 2.
-            out[i, :] = coef[int(np.floor(d)):int(-np.ceil(d))]
+            if d > 0:
+                out[i, :] = coef[int(np.floor(d)):int(-np.ceil(d))]
+            elif d == 0.:
+                out[i, :] = coef
+            else:
+                raise ValueError(
+                    "Selected scale of {} too small.".format(scales[i]))
         frequencies = scale2frequency(wavelet, scales, precision)
         if np.isscalar(frequencies):
             frequencies = np.array([frequencies])

--- a/pywt/_cwt.py
+++ b/pywt/_cwt.py
@@ -78,9 +78,9 @@ def cwt(data, scales, wavelet, sampling_period=1.):
             out = np.zeros((np.size(scales), data.size), dtype=complex)
         else:
             out = np.zeros((np.size(scales), data.size))
+        precision = 10
+        int_psi, x = integrate_wavelet(wavelet, precision=precision)
         for i in np.arange(np.size(scales)):
-            precision = 10
-            int_psi, x = integrate_wavelet(wavelet, precision=precision)
             step = x[1] - x[0]
             j = np.floor(
                 np.arange(scales[i] * (x[-1] - x[0]) + 1) / (scales[i] * step))

--- a/pywt/_cwt.py
+++ b/pywt/_cwt.py
@@ -18,9 +18,10 @@ def cwt(data, scales, wavelet, sampling_period=1.):
     data : array_like
         Input signal
     scales : array_like
-        The wavelet scales to use. Use the function ``scale2frequency`` to
-        determine what physical frequency (in Hz) a given scale corresponds to
-        for a particular wavelet.
+        The wavelet scales to use. One can use
+        ``f = scale2frequency(scale, wavelet)/sampling_period`` to determine
+        what physical frequency, ``f``. Here, ``f`` is in hertz when the
+        ``sampling_period`` is given in seconds.
     wavelet : Wavelet object or name
         Wavelet to use
     sampling_period : float

--- a/pywt/_cwt.py
+++ b/pywt/_cwt.py
@@ -18,11 +18,16 @@ def cwt(data, scales, wavelet, sampling_period=1.):
     data : array_like
         Input signal
     scales : array_like
-        scales to use
+        The wavelet scales to use. Use the function ``scale2frequency`` to
+        determine what physical frequency (in Hz) a given scale corresponds to
+        for a particular wavelet.
     wavelet : Wavelet object or name
         Wavelet to use
     sampling_period : float
-        Sampling period for frequencies output (optional)
+        Sampling period for the frequencies output (optional).
+        The values computed for ``coefs`` are independent of the choice of
+        ``sampling_period`` (i.e. ``scales`` is not scaled by the sampling
+        period).
 
     Returns
     -------
@@ -30,8 +35,8 @@ def cwt(data, scales, wavelet, sampling_period=1.):
         Continuous wavelet transform of the input signal for the given scales
         and wavelet
     frequencies : array_like
-        if the unit of sampling period are seconds and given, than frequencies
-        are in hertz. Otherwise Sampling period of 1 is assumed.
+        If the unit of sampling period are seconds and given, than frequencies
+        are in hertz. Otherwise, a sampling period of 1 is assumed.
 
     Notes
     -----

--- a/pywt/tests/test_cwt_wavelets.py
+++ b/pywt/tests/test_cwt_wavelets.py
@@ -2,7 +2,7 @@
 from __future__ import division, print_function, absolute_import
 
 from numpy.testing import (run_module_suite, assert_allclose, assert_warns,
-                           assert_almost_equal, assert_raises, assert_)
+                           assert_almost_equal, assert_raises)
 import numpy as np
 import pywt
 
@@ -367,7 +367,7 @@ def test_cwt_small_scales():
     # A scale of 0.1 was chosen specifically to give a filter of length 2 for
     # mexh.  This corner case should not raise an error.
     cfs, f = pywt.cwt(data, scales=0.1, wavelet='mexh')
-    assert_(np.all(cfs == 0))
+    assert_allclose(cfs, np.zeros_like(cfs))
 
     # extremely short scale factors raise a ValueError
     assert_raises(ValueError, pywt.cwt, data, scales=0.01, wavelet='mexh')

--- a/pywt/tests/test_cwt_wavelets.py
+++ b/pywt/tests/test_cwt_wavelets.py
@@ -2,7 +2,7 @@
 from __future__ import division, print_function, absolute_import
 
 from numpy.testing import (run_module_suite, assert_allclose, assert_warns,
-                           assert_almost_equal, assert_raises)
+                           assert_almost_equal, assert_raises, assert_)
 import numpy as np
 import pywt
 
@@ -360,6 +360,17 @@ def test_cwt_complex():
         [cfs_complex, f] = pywt.cwt(sst + 1j*sst, scales, wavelet, dt)
         assert_almost_equal(cfs + 1j*cfs, cfs_complex)
 
+
+def test_cwt_small_scales():
+    data = np.zeros(32)
+
+    # A scale of 0.1 was chosen specifically to give a filter of length 2 for
+    # mexh.  This corner case should not raise an error.
+    cfs, f = pywt.cwt(data, scales=0.1, wavelet='mexh')
+    assert_(np.all(cfs == 0))
+
+    # extremely short scale factors raise a ValueError
+    assert_raises(ValueError, pywt.cwt, data, scales=0.01, wavelet='mexh')
 
 if __name__ == '__main__':
     run_module_suite()


### PR DESCRIPTION
When scales is much smaller than one, indexing-related errors as reported in #379 can occur.  

The length of a convolution is `len(data) + len(filter) - 1` and there is also a `numpy.diff` operation in the CWT which shortens the output of the convolution by 1.  The combination of these effects mean that the CWT coefficients are only longer than the input for filters of at least length 3.  Shorter scales that lead to sampled filters of shorter length are not handled correctly.  This PR handles the filter length 2 case properly and raises a more informative error for the length 1 case.

Note: Matlab does something slightly different in the length 1 corner case.  It does not raise an error, but returns values extremely close to zero (e.g. on the order of 1e-14).  I don't know exactly what the underlying difference is in their implementation, but don't think it is of much practical consequence. 

I have tried to clarify the docstring to provide at least minimal guidance on choosing values for `scales`.

The final commit here is unrelated and just removes some unnecessary repeat calls to `integrate_wavelet`
