### PR TITLE
avoid FutureWarnings related to multiindexing in Numpy1.15

### DIFF
--- a/pywt/_multilevel.py
+++ b/pywt/_multilevel.py
@@ -679,7 +679,7 @@ def coeffs_to_array(coeffs, padding=0, axes=None):
     ndim = a_coeffs.ndim
     if len(coeffs) == 1:
         # only a single approximation coefficient array was found
-        return a_coeffs, [[slice(None)] * ndim]
+        return a_coeffs, [tuple([slice(None)] * ndim)]
 
     # Determine the number of dimensions that were transformed via key length
     ndim_transform = len(list(coeffs[1].keys())[0])
@@ -706,7 +706,7 @@ def coeffs_to_array(coeffs, padding=0, axes=None):
     else:
         coeff_arr = np.full(arr_shape, padding, dtype=a_coeffs.dtype)
 
-    a_slices = [slice(s) for s in a_shape]
+    a_slices = tuple([slice(s) for s in a_shape])
     coeff_arr[a_slices] = a_coeffs
 
     # initialize list of coefficient slices
@@ -733,6 +733,7 @@ def coeffs_to_array(coeffs, padding=0, axes=None):
                                               a_shape[ax_i] + d.shape[ax_i])
                 else:
                     raise ValueError("unexpected letter: {}".format(let))
+            slice_array = tuple(slice_array)
             coeff_arr[slice_array] = d
             coeff_slices[-1][key] = slice_array
         a_shape = [a_shape[n] + d_shape[n] for n in range(ndim)]

--- a/pywt/_swt.py
+++ b/pywt/_swt.py
@@ -517,7 +517,7 @@ def iswtn(coeffs, wavelet, axes=None):
 
             # nested loop over all combinations of odd/even inidices
             approx = output.copy()
-            output[indices] = 0
+            output[tuple(indices)] = 0
             ntransforms = 0
             for odds in product(*([(0, 1), ]*ndim_transform)):
                 for o, ax in zip(odds, axes):
@@ -528,8 +528,9 @@ def iswtn(coeffs, wavelet, axes=None):
                 # extract the odd/even indices for all detail coefficients
                 details_slice = {}
                 for key, value in details.items():
-                    details_slice[key] = value[odd_even_slices]
-                details_slice['a'*ndim_transform] = approx[odd_even_slices]
+                    details_slice[key] = value[tuple(odd_even_slices)]
+                details_slice['a'*ndim_transform] = approx[
+                    tuple(odd_even_slices)]
 
                 # perform the inverse dwt on the selected indices,
                 # making sure to use periodic boundary conditions
@@ -538,8 +539,8 @@ def iswtn(coeffs, wavelet, axes=None):
                     # circular shift along any odd indexed axis
                     if o:
                         x = np.roll(x, 1, axis=ax)
-                output[indices] += x
+                output[tuple(indices)] += x
                 ntransforms += 1
-            output[indices] /= ntransforms  # normalize
+            output[tuple(indices)] /= ntransforms  # normalize
         coeffs[j]['a'*ndim_transform] = a  # restore approx coeffs to dict
     return output

--- a/pywt/tests/test_multidim.py
+++ b/pywt/tests/test_multidim.py
@@ -123,7 +123,7 @@ def test_3D_reconstruct_complex():
     wavelet = pywt.Wavelet('haar')
     d = pywt.dwtn(data, wavelet)
     # idwtn creates even-length shapes (2x dwtn size)
-    original_shape = [slice(None, s) for s in data.shape]
+    original_shape = tuple([slice(None, s) for s in data.shape])
     assert_allclose(data, pywt.idwtn(d, wavelet)[original_shape],
                     rtol=1e-13, atol=1e-13)
 

--- a/pywt/tests/test_multilevel.py
+++ b/pywt/tests/test_multilevel.py
@@ -484,7 +484,7 @@ def test_waverecn_coeff_reshape_odd():
             coeffs2 = pywt.array_to_coeffs(coeff_arr, coeff_slices)
             x1r = pywt.waverecn(coeffs2, w, mode=mode)
             # truncate reconstructed values to original shape
-            x1r = x1r[[slice(s) for s in x1.shape]]
+            x1r = x1r[tuple([slice(s) for s in x1.shape])]
             assert_allclose(x1, x1r, rtol=1e-4, atol=1e-4)
 
 

--- a/pywt/tests/test_swt.py
+++ b/pywt/tests/test_swt.py
@@ -416,9 +416,11 @@ def test_per_axis_wavelets():
     assert_raises(ValueError, pywt.iswtn, coefs, wavelets[:2])
 
     # swt2/iswt2 also support per-axis wavelets/modes
-    data2 = data[..., 0]
-    coefs2 = pywt.swt2(data2, wavelets[:2], level)
-    assert_allclose(pywt.iswt2(coefs2, wavelets[:2]), data2, atol=1e-14)
+    with warnings.catch_warnings():
+        warnings.simplefilter('ignore', FutureWarning)
+        data2 = data[..., 0]
+        coefs2 = pywt.swt2(data2, wavelets[:2], level)
+        assert_allclose(pywt.iswt2(coefs2, wavelets[:2]), data2, atol=1e-14)
 
 
 def test_error_on_continuous_wavelet():


### PR DESCRIPTION
This PR fixes additional cases not previously addressed by #378.

Lists of slices have been converted to tuples of slices prior to use for multiindexing.  After this PR, the PyWavelets tests complete without any warnings being raised under Numpy 1.15.0rc1.


