### PR TITLE
adding Community guidelines

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -41,7 +41,7 @@ Coding guidelines
     within the interpreter, and are compiled into a reference guide in html and
     pdf format.  Higher-level documentation for key (areas of) functionality is
     provided in tutorial format and/or in module docstrings.  A guide on how to
-    write documentation is given in `numpydoc docstring guide`_.
+    write documentation is given in the `numpydoc docstring guide`_.
 
 3. Code style
     Uniformity of style in which code is written is important to others trying

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -41,7 +41,7 @@ Coding guidelines
     within the interpreter, and are compiled into a reference guide in html and
     pdf format.  Higher-level documentation for key (areas of) functionality is
     provided in tutorial format and/or in module docstrings.  A guide on how to
-    write documentation is given in `how to document`_.
+    write documentation is given in `numpydoc docstring guide`_.
 
 3. Code style
     Uniformity of style in which code is written is important to others trying
@@ -57,7 +57,7 @@ Coding guidelines
 
 .. _pep8 package: http://pypi.python.org/pypi/pep8
 
-.. _how to document: https://github.com/numpy/numpy/blob/master/doc/HOWTO_DOCUMENT.rst.txt
+.. _numpydoc docstring guide: https://numpydoc.readthedocs.io/en/latest/
 
 .. _doctest: http://www.doughellmann.com/PyMOTW/doctest/
 

--- a/community_guidelines.rst
+++ b/community_guidelines.rst
@@ -1,0 +1,22 @@
+Community Guidelines
+====================
+
+or How We Work (Together)
+-------------------------
+
+PyWavelets has adopted a set of community guidelines in common with the
+scikit-image project.
+
+We welcome each and every contributor to PyWavelets. Our aim is
+enthusiastic and productive collaboration, to build an excellent
+software library, and to have a ton of fun doing it. We encourage one
+another to be gentle in criticism of others' work, humble in
+acknowledging our own mistakes, and generous in our praise.
+
+If you ever feel like you are not being treated as well as you should, please
+get in touch with one of the project leads (our email addresses are available
+through our GitHub profiles). We are committed to making this community a
+safe and welcome space.
+
+You can learn more about contributing to PyWavelets at
+http://pywavelets.readthedocs.io/en/latest/#state-of-development-contributing

--- a/doc/source/common_refs.rst
+++ b/doc/source/common_refs.rst
@@ -11,3 +11,5 @@
 .. _PyWavelets discussions group: http://groups.google.com/group/pywavelets
 .. _Releases Page: https://github.com/PyWavelets/pywt/releases
 .. _Matplotlib: http://matplotlib.org
+.. _guidelines for pull requests: https://github.com/PyWavelets/pywt/tree/master/CONTRIBUTING.rst
+.. _community guildelines: https://github.com/PyWavelets/pywt/tree/master/community_guidelines.rst

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -110,7 +110,11 @@ where that was decided).
 
 All contributions including bug reports, bug fixes, new feature implementations
 and documentation improvements are welcome.  Moreover, developers with an
-interest in PyWavelets are very welcome to join the development team!
+interest in PyWavelets are very welcome to join the development team! Please
+see our `guidelines for pull requests`_ for more information.
+
+Contributors are expected to behave in a productive and respectful manner in
+accordance with our `community guidelines`_.
 
 Contact
 -------


### PR DESCRIPTION
As suggested in #267, this PR adds a set of community guidelines.  At the moment these have just been [copied from scikit-image](https://github.com/scikit-image/scikit-image-web/blob/master/community_guidelines.rst) with some acknowledgement of that fact added at the top. 

I am happy enough with that wording as is, but please suggest any desired changes.

I could also use suggestions on how to make this visible.  For now I have linked it in the top page of the documentation since we do not maintain another separate website like scikit-image does.  

closes #267
