### PR TITLE
improve CWT docs

### DIFF
--- a/doc/source/pyplots/cwt_scaling_demo.py
+++ b/doc/source/pyplots/cwt_scaling_demo.py
@@ -1,0 +1,61 @@
+import numpy as np
+import pywt
+import matplotlib.pyplot as plt
+
+wav = pywt.ContinuousWavelet('cmor1.5-1.0')
+
+# print the range over which the wavelet will be evaluated
+print("Continuous wavelet will be evaluated over the range [{}, {}]".format(
+    wav.lower_bound, wav.upper_bound))
+
+width = wav.upper_bound - wav.lower_bound
+
+scales = [1, 2, 3, 4, 10, 15]
+
+max_len = int(np.max(scales)*width + 1)
+t = np.arange(max_len)
+fig, axes = plt.subplots(len(scales), 2, figsize=(12, 6))
+for n, scale in enumerate(scales):
+
+    # The following code is adapted from the internals of cwt
+    int_psi, x = pywt.integrate_wavelet(wav, precision=10)
+    step = x[1] - x[0]
+    j = np.floor(
+        np.arange(scale * width + 1) / (scale * step))
+    if np.max(j) >= np.size(int_psi):
+        j = np.delete(j, np.where((j >= np.size(int_psi)))[0])
+    j = j.astype(np.int)
+
+    # normalize int_psi for easier plotting
+    int_psi /= np.abs(int_psi).max()
+
+    # discrete samples of the integrated wavelet
+    filt = int_psi[j][::-1]
+
+    # The CWT consists of convolution of filt with the signal at this scale
+    # Here we plot this discrete convolution kernel at each scale.
+
+    nt = len(filt)
+    t = np.linspace(-nt//2, nt//2, nt)
+    axes[n, 0].plot(t, filt.real, t, filt.imag)
+    axes[n, 0].set_xlim([-max_len//2, max_len//2])
+    axes[n, 0].set_ylim([-1, 1])
+    axes[n, 0].text(50, 0.35, 'scale = {}'.format(scale))
+
+    f = np.linspace(-np.pi, np.pi, max_len)
+    filt_fft = np.fft.fftshift(np.fft.fft(filt, n=max_len))
+    filt_fft /= np.abs(filt_fft).max()
+    axes[n, 1].plot(f, np.abs(filt_fft)**2)
+    axes[n, 1].set_xlim([-np.pi, np.pi])
+    axes[n, 1].set_ylim([0, 1])
+    axes[n, 1].set_xticks([-np.pi, 0, np.pi])
+    axes[n, 1].set_xticklabels([r'$-\pi$', '0', r'$\pi$'])
+    axes[n, 1].grid('on', axis='x')
+    axes[n, 1].text(np.pi/2, 0.5, 'scale = {}'.format(scale))
+
+axes[n, 0].set_xlabel('time (samples)')
+axes[n, 1].set_xlabel('frequency (radians)')
+axes[0, 0].legend(['real', 'imaginary'], loc='upper left')
+axes[0, 1].legend(['Power'], loc='upper left')
+axes[0, 0].set_title('filter')
+axes[0, 1].set_title(r'|FFT(filter)|$^2$')

--- a/doc/source/ref/cwt.rst
+++ b/doc/source/ref/cwt.rst
@@ -56,7 +56,7 @@ given by:
     \psi(t) = \frac{1}{\sqrt{\pi B}} \exp^{-\frac{t^2}{B}}
               \exp^{\mathrm{j} 2\pi C t}
 
-where :math:`B` is the bandwith and :math:`C` is the center frequency.
+where :math:`B` is the bandwidth and :math:`C` is the center frequency.
 
 
 Gaussian Derivative Wavelets
@@ -100,7 +100,7 @@ point B, C) correspond to the following wavelets:
               \left[\frac{\sin(\pi B \frac{t}{M})}{\pi B \frac{t}{M}}\right]^M
               \exp^{2\mathrm{j} \pi C t}
 
-where :math:`M` is the spline order, :math:`B` is the bandwith and :math:`C` is
+where :math:`M` is the spline order, :math:`B` is the bandwidth and :math:`C` is
 the center frequency.
 
 
@@ -111,10 +111,10 @@ For each of the wavelets described below, the implementation in PyWavelets
 evaluates the wavelet function for :math:`t` over the range
 ``[wavelet.lower_bound, wavelet.upper_bound]`` (with default range
 :math:`[-8, 8]`). ``scale = 1`` corresponds to the case where the extent of the
-wavelet is (wavelet.upper_bound - wavelet.lower_bound + 1) samples of the
+wavelet is ``(wavelet.upper_bound - wavelet.lower_bound + 1)`` samples of the
 digital signal being analyzed. Larger scales correspond to stretching of the
-wavelet. For example, at scale=10 the wavelet is stretched by a factor of 10,
-making it sensitive to lower frequencies in the signal.
+wavelet. For example, at ``scale=10`` the wavelet is stretched by a factor of
+10, making it sensitive to lower frequencies in the signal.
 
 To relate a given scale to a specific signal frequency, the sampling period
 of the signal must be known. :func:`pywt.scale2frequency` can be used to
@@ -126,8 +126,8 @@ For the ``cmor``, ``fbsp`` and ``shan`` wavelets, the user can specify a
 specific a normalized center frequency. A value of 1.0 corresponds to 1/dt
 where dt is the sampling period. In other words, when analyzing a signal
 sampled at 100 Hz, a center frequency of 1.0 corresponds to ~100 Hz at
-scale = 1. This is above the Nyquist rate of 50 Hz, so for this particular
-wavelet, one would analyze a signal using scales >= 2.
+``scale = 1``. This is above the Nyquist rate of 50 Hz, so for this
+particular wavelet, one would analyze a signal using ``scales >= 2``.
 
 .. sourcecode:: python
 

--- a/doc/source/ref/cwt.rst
+++ b/doc/source/ref/cwt.rst
@@ -103,3 +103,48 @@ point B, C) correspond to the following wavelets:
 where :math:`M` is the spline order, :math:`B` is the bandwith and :math:`C` is
 the center frequency.
 
+
+Choosing the scales for ``cwt``
+-------------------------------
+
+For each of the wavelets described below, the implementation in PyWavelets
+evaluates the wavelet function for :math:`t` over the range
+``[wavelet.lower_bound, wavelet.upper_bound]`` (with default range
+:math:`[-8, 8]`). ``scale = 1`` corresponds to the case where the extent of the
+wavelet is (wavelet.upper_bound - wavelet.lower_bound + 1) samples of the
+digital signal being analyzed. Larger scales correspond to stretching of the
+wavelet. For example, at scale=10 the wavelet is stretched by a factor of 10,
+making it sensitive to lower frequencies in the signal.
+
+To relate a given scale to a specific signal frequency, the sampling period
+of the signal must be known. :func:`pywt.scale2frequency` can be used to
+convert a list of scales to their corresponding frequencies. The proper choice
+of scales depends on the chosen wavelet, so :func:`pywt.scale2frequency` should
+be used to get an idea of an appropriate range for the signal of interest.
+
+For the ``cmor``, ``fbsp`` and ``shan`` wavelets, the user can specify a
+specific a normalized center frequency. A value of 1.0 corresponds to 1/dt
+where dt is the sampling period. In other words, when analyzing a signal
+sampled at 100 Hz, a center frequency of 1.0 corresponds to ~100 Hz at
+scale = 1. This is above the Nyquist rate of 50 Hz, so for this particular
+wavelet, one would analyze a signal using scales >= 2.
+
+.. sourcecode:: python
+
+    >>> import numpy as np
+    >>> import pywt
+    >>> dt = 0.01  # 100 Hz sampling
+    >>> frequencies = pywt.scale2frequency('cmor1.5-1.0', [1, 2, 3, 4]) / dt
+    >>> frequencies
+    array([ 100.        ,   50.        ,   33.33333333,   25.        ])
+
+The CWT in PyWavelets is applied to discrete data by convolution with samples
+of the integral of the wavelet. If ``scale`` is too low, this will result in
+a discrete filter that is inadequately sampled leading to aliasing as shown
+in the example below. Here the wavelet is ``'cmor1.5-1.0'``. The left column of
+the figure shows the discrete filters used in the convolution at various
+scales. The right column are the corresponding Fourier power spectra of each
+filter.. For scales 1 and 2 it can be seen that aliasing due to violation of
+the Nyquist limit occurs.
+
+.. plot:: pyplots/cwt_scaling_demo2.py

--- a/doc/source/ref/cwt.rst
+++ b/doc/source/ref/cwt.rst
@@ -2,9 +2,9 @@
 
 .. currentmodule:: pywt
 
-=================================
+==================================
 Continuous Wavelet Transform (CWT)
-=================================
+==================================
 
 This section describes functions used to perform single continuous wavelet
 transforms.
@@ -15,4 +15,91 @@ Single level - ``cwt``
 .. autofunction:: cwt
 
 
+Continuous Wavelet Families
+---------------------------
+
+A variety of continuous wavelets have been implemented. A list of the available
+wavelet names compatible with ``cwt`` can be obtained by:
+
+.. sourcecode:: python
+
+    wavlist = pywt.wavelist(kind='continuous')
+
+
+Mexican Hat Wavelet
+^^^^^^^^^^^^^^^^^^^
+The mexican hat wavelet ``"mexh"`` is given by:
+
+.. math::
+    \psi(t) = \frac{2}{\sqrt{3} \sqrt[4]{\pi}} \exp^{-\frac{t^2}{2}}
+              \left( 1 - t^2 \right)
+
+where the constant out front is a normalization factor so that the wavelet has
+unit energy.
+
+
+Morlet Wavelet
+^^^^^^^^^^^^^^
+The Morlet wavelet ``"morl"`` is given by:
+
+.. math::
+    \psi(t) = \exp^{-\frac{t^2}{2}} \cos(5t)
+
+
+Complex Morlet Wavelets
+^^^^^^^^^^^^^^^^^^^^^^^
+
+The complex Morlet wavelet (``"cmorB-C"`` with floating point values B, C) is
+given by:
+
+.. math::
+    \psi(t) = \frac{1}{\sqrt{\pi B}} \exp^{-\frac{t^2}{B}}
+              \exp^{\mathrm{j} 2\pi C t}
+
+where :math:`B` is the bandwith and :math:`C` is the center frequency.
+
+
+Gaussian Derivative Wavelets
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+The Gaussian wavelets (``"gausP"`` where P is an integer between 1 and and 8)
+correspond to the Pth order derivatives of the function:
+
+.. math::
+    \psi(t) = C \exp^{-t^2}
+
+where :math:`C` is an order-dependent normalization constant.
+
+Complex Gaussian Derivative Wavelets
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+The complex Gaussian wavelets (``"cgauP"`` where P is an integer between 1 and
+8) correspond to the Pth order derivatives of the function:
+
+.. math::
+    \psi(t) = C \exp^{-\mathrm{j} t}\exp^{-t^2}
+
+where :math:`C` is an order-dependent normalization constant.
+
+Shannon Wavelets
+^^^^^^^^^^^^^^^^
+The Shannon wavelets (``"shanB-C"`` with floating point values B and C)
+correspond to the following wavelets:
+
+.. math::
+    \psi(t) = \sqrt{B} \frac{\sin(\pi B t)}{\pi B t} \exp^{\mathrm{j}2 \pi C t}
+
+where :math:`B` is the bandwith and :math:`C` is the center frequency.
+
+
+Freuqency B-Spline Wavelets
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+The frequency B-spline wavelets (``"fpspM-B-C"`` with integer M and floating
+point B, C) correspond to the following wavelets:
+
+.. math::
+    \psi(t) = \sqrt{B}
+              \left[\frac{\sin(\pi B \frac{t}{M})}{\pi B \frac{t}{M}}\right]^M
+              \exp^{2\mathrm{j} \pi C t}
+
+where :math:`M` is the spline order, :math:`B` is the bandwith and :math:`C` is
+the center frequency.
 

--- a/doc/source/ref/wavelets.rst
+++ b/doc/source/ref/wavelets.rst
@@ -17,8 +17,8 @@ Built-in wavelets - ``wavelist()``
 
 .. autofunction:: wavelist
 
-  Custom user wavelets are also supported through the :class:`Wavelet` object
-  constructor as described below.
+  Custom discrete wavelets are also supported through the
+  :class:`Wavelet` object constructor as described below.
 
 
 ``Wavelet`` object
@@ -26,8 +26,9 @@ Built-in wavelets - ``wavelist()``
 
 .. class:: Wavelet(name[, filter_bank=None])
 
-  Describes properties of a wavelet identified by the specified wavelet
-  ``name``. In order to use a built-in wavelet the ``name`` parameter must be a
+  Describes properties of a discrete wavelet identified by the specified
+  wavelet ``name``. For continuous wavelets see :class:`pywt.ContinuousWavelet`
+  instead. In order to use a built-in wavelet the ``name`` parameter must be a
   valid wavelet name from the :func:`pywt.wavelist` list.
 
   Custom Wavelet objects can be created by passing a user-defined filters set

--- a/pywt/_extensions/_pywt.pyx
+++ b/pywt/_extensions/_pywt.pyx
@@ -876,6 +876,7 @@ cdef public class ContinuousWavelet [type ContinuousWaveletType, object Continuo
         The complex frequency B-spline wavelet (fbsp) has bandwidth_frequency, center_frequency and fbsp_order as additional parameter
         The complex Shannon wavelet (shan) has bandwidth_frequency and center_frequency as additional parameter
         The complex Morlet wavelet (cmor) has bandwidth_frequency and center_frequency as additional parameter
+
         Examples
         --------
         >>> import pywt

--- a/pywt/_extensions/_pywt.pyx
+++ b/pywt/_extensions/_pywt.pyx
@@ -848,19 +848,21 @@ cdef public class ContinuousWavelet [type ContinuousWaveletType, object Continuo
             else:
                 return "unknown"
 
-    def wavefun(self, int level=8, length = None):
+    def wavefun(self, int level=8, length=None):
         """
-        wavefun(self, level=8, length = None)
+        wavefun(self, level=8, length=None)
 
-        Calculates approximations of wavelet
-        function (`psi`) on xgrid (`x`) at a given level of refinement or length itself.
+        Calculates approximations of wavelet function (``psi``) on xgrid
+        (``x``) at a given level of refinement or length itself.
 
         Parameters
         ----------
         level : int, optional
-            Level of refinement (default: 8). Defines the length by 2**level if length is not set.
+            Level of refinement (default: 8). Defines the length by
+            ``2**level`` if length is not set.
         length : int, optional
-            number of samples. If set to None, the length is set to 2**level instead.
+            Number of samples. If set to None, the length is set to
+            ``2**level`` instead.
 
         Returns
         -------
@@ -871,11 +873,19 @@ cdef public class ContinuousWavelet [type ContinuousWaveletType, object Continuo
 
         Notes
         -----
-        The effective support are set with lower_bound and upper_bound
-        The wavelet function is complex for cmor, shan, fbsp and cgau.
-        The complex frequency B-spline wavelet (fbsp) has bandwidth_frequency, center_frequency and fbsp_order as additional parameter
-        The complex Shannon wavelet (shan) has bandwidth_frequency and center_frequency as additional parameter
-        The complex Morlet wavelet (cmor) has bandwidth_frequency and center_frequency as additional parameter
+        The effective support are set with ``lower_bound`` and ``upper_bound``.
+        The wavelet function is complex for ``'cmor'``, ``'shan'``, ``'fbsp'``
+        and ``'cgau'``.
+
+        The complex frequency B-spline wavelet (``'fbsp'``) has
+        ``bandwidth_frequency``, ``center_frequency`` and ``fbsp_order`` as
+        additional parameters.
+
+        The complex Shannon wavelet (``'shan'``) has ``bandwidth_frequency``
+        and ``center_frequency`` as additional parameters.
+
+        The complex Morlet wavelet (``'cmor'``) has ``bandwidth_frequency``
+        and ``center_frequency`` as additional parameters.
 
         Examples
         --------
@@ -893,7 +903,7 @@ cdef public class ContinuousWavelet [type ContinuousWaveletType, object Continuo
         >>> plt.title("Gaussian Wavelet of order 8") # doctest: +ELLIPSIS
         <matplotlib.text.Text object at ...>
         >>> plt.show() # doctest: +SKIP
-        ---------
+
         >>> import pywt
         >>> import matplotlib.pyplot as plt
         >>> lb = -5


### PR DESCRIPTION
Document the equations for the CWT wavelets.

see #386

mathjax renders the equations like:
![cwt_docs](https://user-images.githubusercontent.com/6528957/42910108-4191d61e-8ab4-11e8-89ca-ad31ebef7220.png)
