### PR TITLE
do not force float64 dtype on assignment to Node, Node2D

### DIFF
--- a/doc/release/1.0.0-notes.rst
+++ b/doc/release/1.0.0-notes.rst
@@ -42,10 +42,12 @@ reversed so that the decomposition levels are now returned in descending rather
 than ascending order. This makes these 2D stationary wavelet functions
 consistent with all of the other multilevel discrete transforms in PyWavelets.
 
-
 Bugs Fixed
 ==========
 
+Assigning new data to the ``Node`` or ``Node2D`` no longer forces a cast to
+``float64`` when the data is one of the other dtypes supported by the dwt
+(``float32``, ``complex64``, ``complex128``).
 
 Other changes
 =============

--- a/pywt/_wavelet_packets.py
+++ b/pywt/_wavelet_packets.py
@@ -11,7 +11,7 @@ __all__ = ["BaseNode", "Node", "WaveletPacket", "Node2D", "WaveletPacket2D"]
 
 import numpy as np
 
-from ._extensions._pywt import Wavelet
+from ._extensions._pywt import Wavelet, _check_dtype
 from ._dwt import dwt, idwt, dwt_max_level
 from ._multidim import dwt2, idwt2
 
@@ -266,9 +266,13 @@ class BaseNode(object):
                 subnode[path[self.PART_LEN:]] = data
             else:
                 if isinstance(data, BaseNode):
-                    self.data = np.asarray(data.data, dtype=np.float64)
+                    self.data = np.asarray(data.data)
                 else:
-                    self.data = np.asarray(data, dtype=np.float64)
+                    self.data = np.asarray(data)
+                # convert data to nearest supported dtype
+                dtype = _check_dtype(data)
+                if self.data.dtype != dtype:
+                    self.data = self.data.astype(dtype)
         else:
             raise TypeError("Invalid path parameter type - expected string but"
                             " got %s." % type(path))
@@ -542,7 +546,7 @@ class WaveletPacket(Node):
         self.mode = mode
 
         if data is not None:
-            data = np.asarray(data, dtype=np.float64)
+            data = np.asarray(data)
             assert data.ndim == 1
             self.data_size = data.shape[0]
             if maxlevel is None:
@@ -644,7 +648,7 @@ class WaveletPacket2D(Node2D):
         self.mode = mode
 
         if data is not None:
-            data = np.asarray(data, dtype=np.float64)
+            data = np.asarray(data)
             assert data.ndim == 2
             self.data_size = data.shape
             if maxlevel is None:

--- a/pywt/_wavelet_packets.py
+++ b/pywt/_wavelet_packets.py
@@ -296,16 +296,16 @@ class BaseNode(object):
         if parent and node.node_name:
             parent._delete_node(node.node_name)
 
+    @property
     def is_empty(self):
         return self.data is None
-    is_empty = property(is_empty)
 
+    @property
     def has_any_subnode(self):
         for part in self.PARTS:
             if self._get_node(part) is not None:  # and not .is_empty
                 return True
         return False
-    has_any_subnode = property(has_any_subnode)
 
     def get_leaf_nodes(self, decompose=False):
         """

--- a/pywt/tests/test_wp.py
+++ b/pywt/tests/test_wp.py
@@ -153,6 +153,10 @@ def test_wavelet_packet_dtypes():
         # no unnecessary copy made
         assert_(wp.data is x)
 
+        # assiging to a node should not change supported dtypes
+        wp['d'] = wp['d'].data
+        assert_equal(wp['d'].data.dtype, x.dtype)
+
         # full decomposition
         wp.get_level(wp.maxlevel)
 

--- a/pywt/tests/test_wp2d.py
+++ b/pywt/tests/test_wp2d.py
@@ -155,6 +155,10 @@ def test_wavelet_packet_dtypes():
         # no unnecessary copy made
         assert_(wp.data is x)
 
+        # assiging to a node should not change supported dtypes
+        wp['d'] = wp['d'].data
+        assert_equal(wp['d'].data.dtype, x.dtype)
+
         # full decomposition
         wp.get_level(wp.maxlevel)
 

--- a/pywt/tests/test_wp2d.py
+++ b/pywt/tests/test_wp2d.py
@@ -4,7 +4,7 @@ from __future__ import division, print_function, absolute_import
 
 import numpy as np
 from numpy.testing import (run_module_suite, assert_allclose, assert_,
-                           assert_raises)
+                           assert_raises, assert_equal)
 
 import pywt
 
@@ -143,6 +143,25 @@ def test_lazy_evaluation_2D():
                     rtol=1e-12)
     assert_allclose(wp.a.data, np.array([[3., 7., 11., 15.]] * 4), rtol=1e-12)
     assert_allclose(wp.d.data, np.zeros((4, 4)), rtol=1e-12, atol=1e-12)
+
+
+def test_wavelet_packet_dtypes():
+    shape = (16, 16)
+    for dtype in [np.float32, np.float64, np.complex64, np.complex128]:
+        x = np.random.randn(*shape).astype(dtype)
+        if np.iscomplexobj(x):
+            x = x + 1j*np.random.randn(*shape).astype(x.real.dtype)
+        wp = pywt.WaveletPacket2D(data=x, wavelet='db1', mode='symmetric')
+        # no unnecessary copy made
+        assert_(wp.data is x)
+
+        # full decomposition
+        wp.get_level(wp.maxlevel)
+
+        # reconstruction from coefficients should preserve dtype
+        r = wp.reconstruct(False)
+        assert_equal(r.dtype, x.dtype)
+        assert_allclose(r, x, atol=1e-6, rtol=1e-6)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This PR removes the explicit casts to float64 from the wavelet packets code, enabling packets with the other dtypes supported by the DWT (float32, complex64 and complex128).
