### PR TITLE
BLD: allow `pip install PyWavelets` to work in an empty venv.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,18 +9,7 @@ from distutils.sysconfig import get_python_inc
 
 import setuptools
 from setuptools import setup, Extension
-from numpy import get_include as get_numpy_include
 
-
-try:
-    from Cython.Build import cythonize
-    USE_CYTHON = True
-except ImportError:
-    USE_CYTHON = False
-    if not os.path.exists(os.path.join('pywt', '_extensions', '_pywt.c')):
-        msg = ("Cython must be installed when working with a development "
-               "version of PyWavelets")
-        raise RuntimeError(msg)
 
 
 MAJOR = 1
@@ -124,9 +113,13 @@ header_templates = ["c/convolution.template.h", "c/wt.template.h",
                     "c/wavelets_coeffs.template.h", "c/cwt.template.h"]
 header_templates = list(map(make_ext_path, header_templates))
 
-cython_modules = ['_pywt', '_dwt', '_swt', '_cwt']
-cython_sources = [('{0}.pyx' if USE_CYTHON else '{0}.c').format(module)
-                  for module in cython_modules]
+
+def get_cython_sources(use_cython):
+    cython_modules = ['_pywt', '_dwt', '_swt', '_cwt']
+    cython_sources = [('{0}.pyx' if use_cython else '{0}.c').format(module)
+                      for module in cython_modules]
+    return cython_modules, cython_sources
+
 
 c_macros = [("PY_EXTENSION", None), ]
 cython_macros = []
@@ -182,16 +175,20 @@ c_lib = ('c_wt', {'sources': sources,
                   'include_dirs': [make_ext_path("c"), get_python_inc()],
                   'macros': c_macros, })
 
-ext_modules = [
-    Extension('pywt._extensions.{0}'.format(module),
-              sources=[make_ext_path(source)],
-              # Doesn't automatically rebuild if library changes
-              depends=c_lib[1]['sources'] + c_lib[1]['depends'],
-              include_dirs=[make_ext_path("c"), get_numpy_include()],
-              define_macros=c_macros + cython_macros,
-              libraries=[c_lib[0]],)
-    for module, source, in zip(cython_modules, cython_sources)
-]
+def get_ext_modules(use_cython):
+    from numpy import get_include as get_numpy_include
+    cython_modules, cython_sources = get_cython_sources(use_cython)
+    ext_modules = [
+        Extension('pywt._extensions.{0}'.format(module),
+                  sources=[make_ext_path(source)],
+                  # Doesn't automatically rebuild if library changes
+                  depends=c_lib[1]['sources'] + c_lib[1]['depends'],
+                  include_dirs=[make_ext_path("c"), get_numpy_include()],
+                  define_macros=c_macros + cython_macros,
+                  libraries=[c_lib[0]],)
+        for module, source, in zip(cython_modules, cython_sources)
+    ]
+    return ext_modules
 
 
 from setuptools.command.develop import develop
@@ -240,14 +237,136 @@ class develop_build_clib(develop):
         self.process_distribution(None, self.dist, not self.no_deps)
 
 
-if __name__ == '__main__':
+def parse_setuppy_commands():
+    """Check the commands and respond appropriately.  Disable broken commands.
+
+    Return a boolean value for whether or not to run the build or not (avoid
+    import NumPy or parsing Cython and template files if False).
+    """
+    args = sys.argv[1:]
+
+    if not args:
+        # User forgot to give an argument probably, let setuptools handle that.
+        return True
+
+    info_commands = ['--help-commands', '--name', '--version', '-V',
+                     '--fullname', '--author', '--author-email',
+                     '--maintainer', '--maintainer-email', '--contact',
+                     '--contact-email', '--url', '--license', '--description',
+                     '--long-description', '--platforms', '--classifiers',
+                     '--keywords', '--provides', '--requires', '--obsoletes']
+
+    for command in info_commands:
+        if command in args:
+            return False
+
+    # Note that 'alias', 'saveopts' and 'setopt' commands also seem to work
+    # fine as they are, but are usually used together with one of the commands
+    # below and not standalone.  Hence they're not added to good_commands.
+    good_commands = ('develop', 'sdist', 'build', 'build_ext', 'build_py',
+                     'build_clib', 'build_scripts', 'bdist_wheel', 'bdist_rpm',
+                     'bdist_wininst', 'bdist_msi', 'bdist_mpkg',
+                     'build_sphinx')
+
+    for command in good_commands:
+        if command in args:
+            return True
+
+    # The following commands are supported, but we need to show more
+    # useful messages to the user
+    if 'install' in args:
+        print(textwrap.dedent("""
+            Note: if you need reliable uninstall behavior, then install
+            with pip instead of using `setup.py install`:
+
+              - `pip install .`       (from a git repo or downloaded source
+                                       release)
+              - `pip install PyWavelets`   (last PyWavelets release on PyPI)
+
+            """))
+        return True
+
+    if '--help' in args or '-h' in sys.argv[1]:
+        print(textwrap.dedent("""
+            PyWavelets-specific help
+            ------------------------
+
+            To install PyWavelets from here with reliable uninstall, we recommend
+            that you use `pip install .`. To install the latest PyWavelets release
+            from PyPI, use `pip install PyWavelets`.
+
+            For help with build/installation issues, please ask on the
+            PyWavelets mailing list.  If you are sure that you have run
+            into a bug, please report it at https://github.com/PyWavelets/pywt/issues.
+
+            Setuptools commands help
+            ------------------------
+            """))
+        return False
+
+
+    # The following commands aren't supported.  They can only be executed when
+    # the user explicitly adds a --force command-line argument.
+    bad_commands = dict(
+        test="""
+            `setup.py test` is not supported.  Use one of the following
+            instead:
+
+              - `>>> pywt.test()`           (run tests for installed PyWavelets
+                                             from within an interpreter)
+            """,
+        upload="""
+            `setup.py upload` is not supported, because it's insecure.
+            Instead, build what you want to upload and upload those files
+            with `twine upload -s <filenames>` instead.
+            """,
+        upload_docs="`setup.py upload_docs` is not supported",
+        easy_install="`setup.py easy_install` is not supported",
+        clean="""
+            `setup.py clean` is not supported, use one of the following instead:
+
+              - `git clean -xdf` (cleans all files)
+              - `git clean -Xdf` (cleans all versioned files, doesn't touch
+                                  files that aren't checked into the git repo)
+            """,
+        check="`setup.py check` is not supported",
+        register="`setup.py register` is not supported",
+        bdist_dumb="`setup.py bdist_dumb` is not supported",
+        bdist="`setup.py bdist` is not supported",
+        flake8="`setup.py flake8` is not supported, use flake8 standalone",
+        )
+    bad_commands['nosetests'] = bad_commands['test']
+    for command in ('upload_docs', 'easy_install', 'bdist', 'bdist_dumb',
+                     'register', 'check', 'install_data', 'install_headers',
+                     'install_lib', 'install_scripts', ):
+        bad_commands[command] = "`setup.py %s` is not supported" % command
+
+    for command in bad_commands.keys():
+        if command in args:
+            print(textwrap.dedent(bad_commands[command]) +
+                  "\nAdd `--force` to your command to use it anyway if you "
+                  "must (unsupported).\n")
+            sys.exit(1)
+
+    # Commands that do more than print info, but also don't need Cython and
+    # template parsing.
+    other_commands = ['egg_info', 'install_egg_info', 'rotate']
+    for command in other_commands:
+        if command in args:
+            return False
+
+    # If we got here, we didn't detect what setup.py command was given
+    warnings.warn("Unrecognized setuptools command, proceeding with "
+                  "generating Cython sources and expanding templates")
+    return True
+
+
+
+def setup_package():
     # Rewrite the version file everytime
     write_version_py()
 
-    if USE_CYTHON:
-        ext_modules = cythonize(ext_modules, compiler_directives=cythonize_opts)
-
-    setup(
+    metadata = dict(
         name="PyWavelets",
         maintainer="The PyWavelets Developers",
         maintainer_email="pywavelets@googlegroups.com",
@@ -292,11 +411,43 @@ if __name__ == '__main__':
         package_data={'pywt.data': ['*.npy', '*.npz'],
                       'pywt': ['tests/*.py', 'tests/data/*.npz',
                                'tests/data/*.py']},
-        ext_modules=ext_modules,
         libraries=[c_lib],
         cmdclass={'develop': develop_build_clib},
         test_suite='nose.collector',
 
-        # A function is imported in setup.py, so not really useful
         install_requires=["numpy>=1.9.1"],
+        setup_requires=["numpy>=1.9.1"],
     )
+
+    if "--force" in sys.argv:
+        run_build = True
+        sys.argv.remove('--force')
+    else:
+        # Raise errors for unsupported commands, improve help output, etc.
+        run_build = parse_setuppy_commands()
+
+    if run_build:
+        # This imports numpy and Cython, so only do that if we're actually
+        # building and not for, e.g., pip grabbing metadata.
+        # See gh-397 for details.
+        try:
+            from Cython.Build import cythonize
+            USE_CYTHON = True
+        except ImportError:
+            USE_CYTHON = False
+            if not os.path.exists(os.path.join('pywt', '_extensions', '_pywt.c')):
+                msg = ("Cython must be installed when working with a development "
+                       "version of PyWavelets")
+                raise RuntimeError(msg)
+
+        ext_modules = get_ext_modules(USE_CYTHON)
+        if USE_CYTHON:
+            ext_modules = cythonize(ext_modules, compiler_directives=cythonize_opts)
+
+        metadata['ext_modules'] = ext_modules
+
+    setup(**metadata)
+
+
+if __name__ == '__main__':
+    setup_package()


### PR DESCRIPTION
Closes gh-397.

The parse_setuppy_commands is taken over from numpy/scipy, so
well-tested.  The other changes are minor. I've tried to move only code that rely on `numpy` or `Cython` imports into functions so that can be delayed.