### PR TITLE
Change ValueError to UserWarning when level is > dwt_max_level

### DIFF
--- a/doc/release/1.0.0-notes.rst
+++ b/doc/release/1.0.0-notes.rst
@@ -42,6 +42,11 @@ reversed so that the decomposition levels are now returned in descending rather
 than ascending order. This makes these 2D stationary wavelet functions
 consistent with all of the other multilevel discrete transforms in PyWavelets.
 
+For ``wavedec``, ``wavedec2`` and ``wavedecn``, the ability for the user to
+specify a ``level`` that is greater than the value returned by
+``dwt_max_level``  has been restored. A ``UserWarning`` is raised instead of a
+``ValueError`` in this case.
+
 Bugs Fixed
 ==========
 

--- a/pywt/_multilevel.py
+++ b/pywt/_multilevel.py
@@ -36,9 +36,9 @@ def _check_level(sizes, dec_lens, level):
         raise ValueError(
             "Level value of %d is too low . Minimum level is 0." % level)
     elif level > max_level:
-        raise ValueError(
-            "Level value of %d is too high.  Maximum allowed is %d." % (
-                level, max_level))
+        warnings.warn(
+            ("Level value of {} is too high: all coefficients will experience "
+            "boundary effects.").format(level))
     return level
 
 

--- a/pywt/tests/test_multilevel.py
+++ b/pywt/tests/test_multilevel.py
@@ -304,7 +304,22 @@ def test_wavedecn_invalid_inputs():
     # invalid number of levels
     data = np.ones(16)
     assert_raises(ValueError, pywt.wavedecn, data, 'haar', level=-1)
-    assert_raises(ValueError, pywt.wavedecn, data, 'haar', level=100)
+
+
+def test_wavedecn_many_levels():
+    # perfect reconstruction even when level > pywt.dwt_max_level
+    data = np.arange(64).reshape(8, 8)
+    tol = 1e-12
+    dec_funcs = [pywt.wavedec, pywt.wavedec2, pywt.wavedecn]
+    rec_funcs = [pywt.waverec, pywt.waverec2, pywt.waverecn]
+    with warnings.catch_warnings():
+        warnings.simplefilter('ignore', UserWarning)
+        for dec_func, rec_func in zip(dec_funcs, rec_funcs):
+            for mode in ['periodization', 'symmetric']:
+                    coeffs = dec_func(data, 'haar', mode=mode, level=20)
+                    r = rec_func(coeffs, 'haar', mode=mode)
+                    assert_allclose(data, r, atol=tol, rtol=tol)
+
 
 
 def test_waverecn_accuracies():

--- a/pywt/tests/test_multilevel.py
+++ b/pywt/tests/test_multilevel.py
@@ -321,7 +321,6 @@ def test_wavedecn_many_levels():
                     assert_allclose(data, r, atol=tol, rtol=tol)
 
 
-
 def test_waverecn_accuracies():
     # testing 3D only here
     rstate = np.random.RandomState(1234)


### PR DESCRIPTION
For consistency with Matlab and with old (~3 years prior) releases of PyWavelets, do not raise an error if the user sets `level` in `wavedec*` to a value greater than that returned by `dwt_max_level`.

At the moment, I have left a `UserWarning` if no coefficients will be unaffected by the signal boundaries to help guide users toward a reasonable number of levels in typical applications. 

closes #396 

