### PR TITLE
BLD: add missing import of textwrap

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,12 +4,12 @@
 import os
 import sys
 import subprocess
+import textwrap
 from functools import partial
 from distutils.sysconfig import get_python_inc
 
 import setuptools
 from setuptools import setup, Extension
-
 
 
 MAJOR = 1


### PR DESCRIPTION
Some build commands (e.g. ``python setup.py --help``) need `textwrap`, but it was not imported.