### PR TITLE
TST: relax tolerance in test_wavelet_packet_dtypes

### DIFF
--- a/pywt/tests/test_wp.py
+++ b/pywt/tests/test_wp.py
@@ -163,7 +163,7 @@ def test_wavelet_packet_dtypes():
         # reconstruction from coefficients should preserve dtype
         r = wp.reconstruct(False)
         assert_equal(r.dtype, x.dtype)
-        assert_allclose(r, x, atol=1e-6, rtol=1e-6)
+        assert_allclose(r, x, atol=1e-5, rtol=1e-5)
 
     # first element of the tuple is the input dtype
     # second element of the tuple is the transform dtype

--- a/pywt/tests/test_wp2d.py
+++ b/pywt/tests/test_wp2d.py
@@ -165,7 +165,7 @@ def test_wavelet_packet_dtypes():
         # reconstruction from coefficients should preserve dtype
         r = wp.reconstruct(False)
         assert_equal(r.dtype, x.dtype)
-        assert_allclose(r, x, atol=1e-6, rtol=1e-6)
+        assert_allclose(r, x, atol=1e-5, rtol=1e-5)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
with 1e-6, these tests fail on a subset of builds at MacPython/pywavelets-wheels#5
Backing off to 1e-5 should resolve the problem.