### PR TITLE
DOC: add 'garotte' to the list of mode options in threshold docstring

### DIFF
--- a/pywt/_thresholding.py
+++ b/pywt/_thresholding.py
@@ -109,7 +109,7 @@ def threshold(data, value, mode='soft', substitute=0):
         Numeric data.
     value : scalar
         Thresholding value.
-    mode : {'soft', 'hard', 'greater', 'less'}
+    mode : {'soft', 'hard', 'garotte', 'greater', 'less'}
         Decides the type of thresholding to be applied on input data. Default
         is 'soft'.
     substitute : float, optional


### PR DESCRIPTION
'garotte' was missing from the list of options for mode in `threshold`
