### PR TITLE
fix bug in FswavedecnResult.__setitem__ and improve docstrings

### DIFF
--- a/pywt/_multilevel.py
+++ b/pywt/_multilevel.py
@@ -1171,8 +1171,8 @@ class FswavedecnResult(object):
     ----------
     coeffs : ndarray
         The coefficient array.
-    coeff_slices : dict
-        Dictionary of slices corresponding to each detail or approximation
+    coeff_slices : list
+        List of slices corresponding to each detail or approximation
         coefficient array.
     wavelets : list of pywt.DiscreteWavelet objects
         The wavelets used.  Will be a list with length equal to
@@ -1212,7 +1212,7 @@ class FswavedecnResult(object):
 
     @property
     def coeff_slices(self):
-        """Dict: Dictionary of coeffficient slices."""
+        """List: List of coeffficient slices."""
         return self._coeff_slices
 
     @property
@@ -1374,6 +1374,16 @@ def fswavedecn(data, wavelet, mode='symmetric', levels=None, axes=None):
         Contains the wavelet coefficients, slice objects to allow obtaining
         the coefficients per detail or approximation level, and more.
         See `FswavedecnResult` for details.
+
+    Examples
+    --------
+    >>> from pywt import fswavedecn
+    >>> fs_result = fswavedecn(np.ones((32, 32)), 'sym2', levels=(1, 3))
+    >>> print(fs_result.detail_keys())
+    [(0, 1), (0, 2), (0, 3), (1, 0), (1, 1), (1, 2), (1, 3)]
+    >>> approx_coeffs = fs_result.approx
+    >>> detail_1_2 = fs_result[(1, 2)]
+
 
     Notes
     -----

--- a/pywt/_multilevel.py
+++ b/pywt/_multilevel.py
@@ -1212,7 +1212,7 @@ class FswavedecnResult(object):
 
     @property
     def coeff_slices(self):
-        """List: List of coeffficient slices."""
+        """List: List of coefficient slices."""
         return self._coeff_slices
 
     @property

--- a/pywt/_multilevel.py
+++ b/pywt/_multilevel.py
@@ -1319,12 +1319,13 @@ class FswavedecnResult(object):
         """
         self._validate_index(levels)
         sl = self._get_coef_sl(levels)
+        current_dtype = self._coeffs[sl].dtype
         if self._coeffs[sl].shape != x.shape:
             raise ValueError(
                 "x does not match the shape of the requested coefficient")
-        if x.dtype != sl.dtype:
+        if x.dtype != current_dtype:
             warnings.warn("dtype mismatch:  converting the provided array to"
-                          "dtype {}".format(sl.dtype))
+                          "dtype {}".format(current_dtype))
         self._coeffs[sl] = x
 
     def detail_keys(self):

--- a/pywt/_multilevel.py
+++ b/pywt/_multilevel.py
@@ -1256,7 +1256,7 @@ class FswavedecnResult(object):
         sl = [slice(None), ] * self.ndim
         for n, (ax, lev) in enumerate(zip(self.axes, levels)):
             sl[ax] = self.coeff_slices[n][lev]
-        return sl
+        return tuple(sl)
 
     @property
     def approx(self):

--- a/pywt/tests/test_multilevel.py
+++ b/pywt/tests/test_multilevel.py
@@ -914,6 +914,28 @@ def test_fswavedecn_fswaverecn_axes_subsets():
     assert_raises(ValueError, pywt.fswavedecn, data, 'haar', axes=(1, 5))
 
 
+def test_fswavedecnresult():
+    data = np.ones((32, 32))
+    levels = (1, 2)
+    result = pywt.fswavedecn(data, 'sym2', levels=levels)
+
+    # can access the lowpass band via .approx or via __getitem__
+    approx_key = (0, ) * data.ndim
+    assert_array_equal(result[approx_key], result.approx)
+
+    dkeys = result.detail_keys()
+    # the approximation key shouldn't be present in the detail_keys
+    assert_(approx_key not in dkeys)
+
+    # can access all detail coefficients and they have matching ndim
+    for k in dkeys:
+        d = result[k]
+        assert_equal(d.ndim, data.ndim)
+
+    # all coefficients are stacked into result.coeffs (same ndim)
+    assert_equal(result.coeffs.ndim, data.ndim)
+
+
 def test_error_on_continuous_wavelet():
     # A ValueError is raised if a Continuous wavelet is selected
     data = np.ones((16, 16))

--- a/pywt/tests/test_multilevel.py
+++ b/pywt/tests/test_multilevel.py
@@ -932,6 +932,17 @@ def test_fswavedecnresult():
         d = result[k]
         assert_equal(d.ndim, data.ndim)
 
+    # can assign modified coefficients
+    result[k] = np.zeros_like(d)
+
+    # assigning a differently sized array raises a ValueError
+    with assert_raises(ValueError):
+        result[k] = np.zeros(tuple([s + 1 for s in d.shape]))
+
+    # warns on assigning with a non-matching dtype
+    with assert_warns(UserWarning):
+        result[k] = np.zeros_like(d).astype(np.float32)
+
     # all coefficients are stacked into result.coeffs (same ndim)
     assert_equal(result.coeffs.ndim, data.ndim)
 

--- a/pywt/tests/test_multilevel.py
+++ b/pywt/tests/test_multilevel.py
@@ -936,12 +936,12 @@ def test_fswavedecnresult():
     result[k] = np.zeros_like(d)
 
     # assigning a differently sized array raises a ValueError
-    with assert_raises(ValueError):
-        result[k] = np.zeros(tuple([s + 1 for s in d.shape]))
+    assert_raises(ValueError, result.__setitem__,
+                  k, np.zeros(tuple([s + 1 for s in d.shape])))
 
     # warns on assigning with a non-matching dtype
-    with assert_warns(UserWarning):
-        result[k] = np.zeros_like(d).astype(np.float32)
+    assert_warns(UserWarning, result.__setitem__,
+                 k, np.zeros_like(d).astype(np.float32))
 
     # all coefficients are stacked into result.coeffs (same ndim)
     assert_equal(result.coeffs.ndim, data.ndim)


### PR DESCRIPTION
There was a bug in the dtype check in the __setitem__ method of FswavedecnResult that prevents assigning modified coefficients. I think this probably warrants a 1.0.1 release to address.

The issue is that the user is supposed to be able to do something like:
```Python
dkey = (1, 2)
result[dkey] = modified_coeffs
```
A workaround in 1.0.0 is to do:
```Python
result.coeffs[result._get_coef_sl(dkey)] = modified_coeffs
``` 

This PR also improves testing of the FswaverecnResult and makes a few docstring improvements.

