### PR TITLE
fix: enforce consistent coefficient order for ravel_coeffs

### DIFF
--- a/pywt/_multilevel.py
+++ b/pywt/_multilevel.py
@@ -1072,7 +1072,10 @@ def ravel_coeffs(coeffs, axes=None):
         if np.any([d is None for d in coeff_dict.values()]):
             raise ValueError("coeffs_to_array does not support missing "
                              "coefficients.")
-        for key, d in coeff_dict.items():
+        # sort to make sure key order is consistent across Python versions
+        keys = sorted(coeff_dict.keys())
+        for key in keys:
+            d = coeff_dict[key]
             sl = slice(offset, offset + d.size)
             offset += d.size
             coeff_arr[sl] = d.ravel()


### PR DESCRIPTION
The current implementation of ``ravel_coeffs`` depends on the order of the keys in the detail coefficient dictionaries returned by ``wavedecn``. This order can vary across python versions due to differences in whether the underlying Python dict respects insertion order. This PR just sorts the keys first to make sure that the wavelet subbands are stacked in the raveled array is identical across all Python versions.

A compact example of the key ordering issue:

```Python
c = pywt.wavedecn(np.ones((4, 4)), wavelet='db1', level=1)
print(c[1].keys())
```

The output of the print statement above in Python 3.6 is ``dict_keys(['ad', 'da', 'dd'])``, but on Python 2.7 is ``['dd', 'ad', 'da']``. Note the difference in order which ends up reflected in which order the coefficients are stacked by ``pywt.ravel_coeffs``.

print(sorted(c[1].keys())) whereas gives ``['ad', 'da', 'dd']`` on both versions for consistent order.

