### PR TITLE
Drop Python 2.7 testing on CI and update docs for Python 3.5+ support.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,19 +12,6 @@ env:
 matrix:
   include:
     - os: linux
-      python: 2.7
-      env:
-        - PYFLAKES=1
-        - PEP8=1
-        - NUMPYSPEC=numpy
-        - MATPLOTLIBSPEC=matplotlib
-      before_install:
-        - pip install pep8==1.5.1
-        - pip install pyflakes
-      script:
-        - PYFLAKES_NODOCTEST=1 pyflakes pywt demo | grep -E -v 'unable to detect undefined names|assigned to but never used|imported but unused|redefinition of unused' > test.out; cat test.out; test \! -s test.out
-        - pep8 pywt demo
-    - os: linux
       python: 3.6
       env:
         - NUMPYSPEC=numpy
@@ -36,11 +23,6 @@ matrix:
         - NUMPYSPEC=numpy
         - MATPLOTLIBSPEC=matplotlib
         - USE_SDIST=1
-    - os: linux
-      python: 2.7
-      env:
-        - NUMPYSPEC="numpy==1.9.3"
-        - MATPLOTLIBSPEC="matplotlib<=2.2.2"  # 2.2.3 requires numpy >= 1.10
     - os: linux
       python: 3.5
       env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ matrix:
     - os: linux
       python: 3.5
       env:
-        - NUMPYSPEC=numpy
+        - NUMPYSPEC="numpy==1.13.3"
         - MATPLOTLIBSPEC=matplotlib
         - REFGUIDE_CHECK=1  # run doctests only
     - os: osx

--- a/README.rst
+++ b/README.rst
@@ -66,7 +66,7 @@ Installation
 ------------
 
 PyWavelets supports `Python`_ >=3.5, and is only dependent on `Numpy`_
-(supported versions are currently ``>= 1.9``). To pass all of the tests,
+(supported versions are currently ``>= 1.13.3``). To pass all of the tests,
 `Matplotlib`_ is also required.
 
 There are binary wheels for Intel Linux, Windows and macOS / OSX on PyPi.  If

--- a/README.rst
+++ b/README.rst
@@ -65,7 +65,7 @@ For more usage examples see the `demo`_ directory in the source package.
 Installation
 ------------
 
-PyWavelets supports `Python`_ 2.7 or >=3.4, and is only dependent on `Numpy`_
+PyWavelets supports `Python`_ >=3.5, and is only dependent on `Numpy`_
 (supported versions are currently ``>= 1.9``). To pass all of the tests,
 `Matplotlib`_ is also required.
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,8 +7,6 @@
 
 environment:
   matrix:
-    - PYTHON: "C:\\Python27"
-    - PYTHON: "C:\\Python27-x64"
     - PYTHON: "C:\\Python34"
     - PYTHON: "C:\\Python34-x64"
       DISTUTILS_USE_SDK: "1"

--- a/doc/source/dev/preparing_windows_build_environment.rst
+++ b/doc/source/dev/preparing_windows_build_environment.rst
@@ -14,8 +14,7 @@ Depending on your Python version, a different version of the Microsoft Visual
 C++ compiler will be required to build extensions. The same compiler that was
 used to build Python itself should be used.
 
-For official binary builds of Python 2.6 to 3.2, this will be VS 2008. Python
-3.3 and 3.4 were compiled with VS 2010, and for Python 3.5 it will be MSVC 2015.
+For Python 3.5, 3.6 and 3.7 it will be MSVC 2015.
 
 The MSVC version should be printed when starting a Python REPL, and can be
 checked against the note below:
@@ -31,9 +30,7 @@ checked against the note below:
 
      ::
 
-        Python 2.7.3 (default, Apr 10 2012, 23:31:26) [MSC v.1500 32 bit (Intel)] on win32
-        Python 3.2 (r32:88445, Feb 20 2011, 21:30:00) [MSC v.1500 64 bit (AMD64)] on win32
-
+        Python 3.5.5 (default, Feb 13 2018, 06:15:35) [MSC v.1900 64 bit (AMD64)] on win32
 
 To get started first download, extract and install *Microsoft Windows SDK for
 Windows 7 and .NET Framework 3.5 SP1* from

--- a/doc/source/dev/testing.rst
+++ b/doc/source/dev/testing.rst
@@ -36,9 +36,9 @@ Running tests with Tox
 ----------------------
 
 There's also a config file for running tests with `Tox`_ (``pip install tox``).
-To for example run tests for Python 2.7 and Python 3.4 use::
+To for example run tests for Python 3.5 and 3.6 use::
 
-  tox -e py27,py34
+  tox -e py35,py36
 
 For more information see the `Tox`_ documentation.
 

--- a/doc/source/install.rst
+++ b/doc/source/install.rst
@@ -39,7 +39,7 @@ PyWavelets source code directory (containing ``setup.py``) and type::
 The requirements needed to build from source are:
 
  - Python_ 2.7 or >=3.4
- - Numpy_ >= 1.9.1
+ - Numpy_ >= 1.13.3
  - Cython_ >= 0.20.2  (if installing from git, not from a PyPI source release)
 
 To run all the tests for PyWavelets, you will also need to install the

--- a/setup.py
+++ b/setup.py
@@ -398,7 +398,6 @@ def setup_package():
             "Programming Language :: C",
             "Programming Language :: Python",
             "Programming Language :: Python :: 3",
-            "Programming Language :: Python :: 2.7",
             "Programming Language :: Python :: 3.5",
             "Programming Language :: Python :: 3.6",
             "Programming Language :: Python :: 3.7",

--- a/setup.py
+++ b/setup.py
@@ -414,8 +414,8 @@ def setup_package():
         cmdclass={'develop': develop_build_clib},
         test_suite='nose.collector',
 
-        install_requires=["numpy>=1.9.1"],
-        setup_requires=["numpy>=1.9.1"],
+        install_requires=["numpy>=1.13.3"],
+        setup_requires=["numpy>=1.13.3"],
     )
 
     if "--force" in sys.argv:

--- a/tox.ini
+++ b/tox.ini
@@ -13,14 +13,14 @@
 #     - Use pip to install the pywt sdist into the virtualenv
 #     - Run the pywt tests
 # To run against a specific subset of Python versions, use:
-#   tox -e py26,py27
+#   tox -e py36,py37
 
 # Tox assumes that you have appropriate Python interpreters already
-# installed and that they can be run as 'python2.6', 'python2.7', etc.
+# installed and that they can be run as 'python3.6', 'python3.7', etc.
 
 [tox]
 toxworkdir = {homedir}/.tox/pywt/
-envlist = py26, py27, py33, py34, py35
+envlist = py35, py36, py37
 
 [testenv]
 deps =


### PR DESCRIPTION
The release notes for 1.0 mention that 1.0.x is the last version with Python 3 support. This PR removes a few mentions of Python 2.7 from the docs and removes the Python 2.7 test cases from the Travis and Appveyor configurations.

There is also some mention of Python 2.7/3.2 in a section on building with MinGW. I was not familiar enough with the current status of MinGW builds on Windows to update that section, so I have left it as is for now.