### PR TITLE
set language_level=3 for Cython

### DIFF
--- a/pywt/_extensions/_cwt.pyx
+++ b/pywt/_extensions/_cwt.pyx
@@ -1,4 +1,4 @@
-#cython: language_level=3, boundscheck=False, wraparound=False
+#cython: boundscheck=False, wraparound=False
 from . cimport common
 from . cimport c_wt
 from .common cimport pywt_index_t, MODE

--- a/pywt/_extensions/_cwt.pyx
+++ b/pywt/_extensions/_cwt.pyx
@@ -1,6 +1,7 @@
-#cython: boundscheck=False, wraparound=False
-cimport common, c_wt
-from common cimport pywt_index_t, MODE
+#cython: language_level=3, boundscheck=False, wraparound=False
+from . cimport common
+from . cimport c_wt
+from .common cimport pywt_index_t, MODE
 from ._pywt cimport _check_dtype
 
 cimport numpy as np

--- a/pywt/_extensions/_dwt.pyx
+++ b/pywt/_extensions/_dwt.pyx
@@ -1,4 +1,4 @@
-#cython: language_level=3, boundscheck=False, wraparound=False
+#cython: boundscheck=False, wraparound=False
 from . cimport common
 from . cimport c_wt
 from .common cimport pywt_index_t, MODE

--- a/pywt/_extensions/_dwt.pyx
+++ b/pywt/_extensions/_dwt.pyx
@@ -1,6 +1,7 @@
-#cython: boundscheck=False, wraparound=False
-cimport common, c_wt
-from common cimport pywt_index_t, MODE
+#cython: language_level=3, boundscheck=False, wraparound=False
+from . cimport common
+from . cimport c_wt
+from .common cimport pywt_index_t, MODE
 from ._pywt cimport _check_dtype
 
 cimport numpy as np

--- a/pywt/_extensions/_pywt.pxd
+++ b/pywt/_extensions/_pywt.pxd
@@ -1,4 +1,4 @@
-cimport wavelet
+from . cimport wavelet
 cimport numpy as np
 include "config.pxi"
 

--- a/pywt/_extensions/_pywt.pyx
+++ b/pywt/_extensions/_pywt.pyx
@@ -1,5 +1,6 @@
+#cython: language_level=3
 # Copyright (c) 2006-2012 Filip Wasilewski <http://en.ig.ma/>
-# Copyright (c) 2012-2016 The PyWavelets Developers
+# Copyright (c) 2012-2018 The PyWavelets Developers
 #                         <https://github.com/PyWavelets/pywt>
 # See COPYING for license details.
 
@@ -11,8 +12,8 @@ __all__ = ['MODES', 'Modes', 'DiscreteContinuousWavelet', 'Wavelet',
 import warnings
 import re
 
-cimport c_wt
-cimport common
+from . cimport c_wt
+from . cimport common
 from ._dwt cimport upcoef
 from ._cwt cimport cwt_psi_single
 
@@ -1044,7 +1045,7 @@ cpdef np.dtype _check_dtype(data):
 def keep(arr, keep_length):
     length = len(arr)
     if keep_length < length:
-        left_bound = (length - keep_length) / 2
+        left_bound = (length - keep_length) // 2
         return arr[left_bound:left_bound + keep_length]
     return arr
 

--- a/pywt/_extensions/_pywt.pyx
+++ b/pywt/_extensions/_pywt.pyx
@@ -1,4 +1,3 @@
-#cython: language_level=3
 # Copyright (c) 2006-2012 Filip Wasilewski <http://en.ig.ma/>
 # Copyright (c) 2012-2018 The PyWavelets Developers
 #                         <https://github.com/PyWavelets/pywt>

--- a/pywt/_extensions/_swt.pyx
+++ b/pywt/_extensions/_swt.pyx
@@ -1,12 +1,12 @@
-#cython: boundscheck=False, wraparound=False
-cimport common
-cimport c_wt
+#cython: language_level=3, boundscheck=False, wraparound=False
+from . cimport common
+from . cimport c_wt
 
 import warnings
 import numpy as np
 cimport numpy as np
 
-from common cimport pywt_index_t
+from .common cimport pywt_index_t
 from ._pywt cimport c_wavelet_from_object, cdata_t, Wavelet, _check_dtype
 
 include "config.pxi"

--- a/pywt/_extensions/_swt.pyx
+++ b/pywt/_extensions/_swt.pyx
@@ -1,4 +1,4 @@
-#cython: language_level=3, boundscheck=False, wraparound=False
+#cython: boundscheck=False, wraparound=False
 from . cimport common
 from . cimport c_wt
 

--- a/pywt/_extensions/c_wt.pxd
+++ b/pywt/_extensions/c_wt.pxd
@@ -3,9 +3,9 @@
 #                         <https://github.com/PyWavelets/pywt>
 # See COPYING for license details.
 
-from common cimport (MODE, pywt_index_t, ArrayInfo, Coefficient,
-                     DiscreteTransformType)
-from wavelet cimport DiscreteWavelet, ContinuousWavelet
+from .common cimport (MODE, pywt_index_t, ArrayInfo, Coefficient,
+                      DiscreteTransformType)
+from .wavelet cimport DiscreteWavelet, ContinuousWavelet
 
 include "config.pxi"
 

--- a/pywt/_extensions/wavelet.pxd
+++ b/pywt/_extensions/wavelet.pxd
@@ -1,4 +1,4 @@
-from common cimport pywt_index_t
+from .common cimport pywt_index_t
 
 cdef extern from "c/wavelets.h":
     ctypedef enum SYMMETRY:

--- a/setup.py
+++ b/setup.py
@@ -162,8 +162,7 @@ with open(defines_py, 'w') as fd:
     for k, v in py_defines.items():
         fd.write('%s = %d\n' % (k, int(v)))
 
-
-cythonize_opts = {}
+cythonize_opts = {'language_level': '3'}
 if os.environ.get("CYTHON_TRACE"):
     cythonize_opts['linetrace'] = True
     cython_macros.append(("CYTHON_TRACE_NOGIL", 1))


### PR DESCRIPTION
We do not currently specify the Cython `language_level`. This results in a warning from Cython 0.29 that the default is going to change from `language_level=2` to `language_level=3str` in the future.

As we are dropping Python 2 support in the next release, I thought we should just explicitly specify `language_level=3`. This PR adds the `language_level` directive at the top of each .pyx file.

There was one place where `/` needed to be `//` to maintain integer division.  The rest of the changes are to the import statements and were necessary to get the files to compile under this language level.

This is built on top of #434 so that the Python 2.7 test cases wouldn't be run. Only the c7c9c2f commit is new to this PR.
