### PR TITLE
Fix deprecated import for Iterable

### DIFF
--- a/pywt/_utils.py
+++ b/pywt/_utils.py
@@ -3,7 +3,7 @@
 # See COPYING for license details.
 import inspect
 import sys
-from collections import Iterable
+from collections.abc import Iterable
 
 from ._extensions._pywt import (Wavelet, ContinuousWavelet,
                                 DiscreteContinuousWavelet, Modes)


### PR DESCRIPTION
This PR fixes the way `Iterable` is imported. With this change, it will import it from `collections.abc` rather than `collections` (which emitted a deprecation warning).

Explanation:
Importing abstract base classes from `collections` instead of from `collections.abc` was deprecated starting in Python 3.3+, and in 3.8 it will stop working.  The _"Astract Base Classes for Collections"_ module (`collections.abc`) was introduced in Python 3.3.  In previous Python versions, the ABC's were part of the `collections` module.

Note:
The deprecation warning was not displayed when running tests with `tox` because `nosetests` was swallowing the message.