### PR TITLE
fix the phase of CWT when using complex mother wavelets

### DIFF
--- a/doc/release/1.1.0-notes.rst
+++ b/doc/release/1.1.0-notes.rst
@@ -19,6 +19,9 @@ Backwards incompatible changes
 
 Bugs Fixed
 ==========
+For the complex wavelet transforms, the tests were based on older implementation of Matlab CWT function that had an issue with the phase of the complex wavelet coefficients.
+Consequently, the complex wavelet coefficients were complex conjugates of the proper result.
+The tests were made using cmor1.0-1.0 and compared to the WT implementation proposed by Matlab R2017b and Lancaster University, Physics department Matlab function ``wt.m``.
 
 Other changes
 =============

--- a/doc/release/1.1.0-notes.rst
+++ b/doc/release/1.1.0-notes.rst
@@ -17,11 +17,24 @@ Deprecated features
 Backwards incompatible changes
 ==============================
 
+When using complex-valued wavelets with the ``cwt``, the output will now be
+the complex conjugate of the result that was produced by PyWavelets 1.0.x.
+This was done to account for a bug described below. The magnitude of the
+``cwt`` coefficients will still match those from previous releases.
+
 Bugs Fixed
 ==========
-For the complex wavelet transforms, the tests were based on older implementation of Matlab CWT function that had an issue with the phase of the complex wavelet coefficients.
-Consequently, the complex wavelet coefficients were complex conjugates of the proper result.
-The tests were made using cmor1.0-1.0 and compared to the WT implementation proposed by Matlab R2017b and Lancaster University, Physics department Matlab function ``wt.m``.
+
+For a ``cwt`` with complex wavelets, the results in PyWavelets 1.0.x releases
+matched the output of Matlab R2012a's ``cwt``. Howveer, older Matlab releases
+like R2012a had a phase that was of opposite sign to that given in textbook
+definitions of the CWT (Eq. 2 of Torrence and Compo's review article, "A
+Practical Guide to Wavelet Analysis"). Consequently, the wavelet coefficients
+were the complex conjugates of the expected result. This was validated by
+comparing the results of a transform using ``cmor1.0-1.0`` as compared to the
+``cwt`` implementation available in Matlab R2017b as well as the function
+``wt.m`` from the Lancaster University Physics department's
+`MODA toolbox <https://github.com/luphysics/MODA>`_
 
 Other changes
 =============

--- a/pywt/_cwt.py
+++ b/pywt/_cwt.py
@@ -75,12 +75,13 @@ def cwt(data, scales, wavelet, sampling_period=1.):
     if np.isscalar(scales):
         scales = np.array([scales])
     if data.ndim == 1:
-        if wavelet.complex_cwt:
-            out = np.zeros((np.size(scales), data.size), dtype=complex)
-        else:
-            out = np.zeros((np.size(scales), data.size))
         precision = 10
         int_psi, x = integrate_wavelet(wavelet, precision=precision)
+        if wavelet.complex_cwt:
+            out = np.zeros((np.size(scales), data.size), dtype=complex)
+            int_psi = np.conj(int_psi)
+        else:
+            out = np.zeros((np.size(scales), data.size))
         for i in np.arange(np.size(scales)):
             step = x[1] - x[0]
             j = np.floor(

--- a/pywt/tests/data/generate_matlab_data_cwt.py
+++ b/pywt/tests/data/generate_matlab_data_cwt.py
@@ -37,7 +37,7 @@ mlab.start()
 try:
     all_matlab_results = {}
     for wavelet in wavelets:
-        w = pywt.Wavelet(wavelet)
+        w = pywt.ContinuousWavelet(wavelet)
         if np.any((wavelet == np.array(['shan', 'cmor'])),axis=0):
             mlab.set_variable('wavelet', wavelet+str(w.bandwidth_frequency)+'-'+str(w.center_frequency))
         elif wavelet == 'fbsp':

--- a/pywt/tests/test_matlab_compatibility_cwt.py
+++ b/pywt/tests/test_matlab_compatibility_cwt.py
@@ -147,6 +147,11 @@ def _check_accuracy(data, w, scales, coefs, wavelet, epsilon):
     # PyWavelets result
     coefs_pywt, freq = pywt.cwt(data, scales, w)
 
+    # coefs from Matlab are from R2012a which is missing the complex conjugate
+    # as shown in Eq. 2 of Torrence and Compo. We take the complex conjugate of
+    # the precomputed Matlab result to account for this.
+    coefs = np.conj(coefs)
+
     # calculate error measures
     err = coefs_pywt - coefs
     rms = np.real(np.sqrt(np.mean(np.conj(err) * err)))

--- a/util/authors.py
+++ b/util/authors.py
@@ -30,6 +30,7 @@ NAME_MAP = {
     u('Helder'): u('Helder Oliveira'),
     u('Kai'): u('Kai Wohlfahrt'),
     u('asnt'): u('Alexandre Saint'),
+    u('pavleb'): u('Pavle Boškoski'),
 }
 
 


### PR DESCRIPTION
When performing CWT with complex wavelets, such as cmor the wavelet coefficients were conjugated. The equation for CWT includes conplex conjugate of the mother wavelet.

A simple example can show the problem. 
Let us have two sine waves simulating a simple linear system:
Uv = 0.3*np.sin(2*np.pi*80*t)
Iv = 5*np.sin(2*np.pi*80*t + np.pi/6)

The theoretical impedance of system with such input and output signals is
Z=Uv/Iv = 0.3/5.0 * exp(-j pi/6)

When using the master branch the result is just a complex conjugate thus leading to the bug. A simple test is below:
```Python
import pywt
import numpy as np

fb = 1.0
fc = 1.0
dec_factor = 1
num_cycle = 1
fmin = 70
fmax = 90

sampling_frequency = 5000.0
t = np.arange(0,1,1.0/sampling_frequency)
Uv = 0.3*np.sin(2*np.pi*80*t)
Iv = 5*np.sin(2*np.pi*80*t + np.pi/6)

dt = 1.0/sampling_frequency
wname = 'cmor{}-{}'.format(fb,fc)

scales = np.divide(sampling_frequency,np.linspace(fmax,fmin,30))
scales=scales*fc
coefI, freqsI = pywt.cwt(Iv,scales,wname,sampling_period=dt)
coefU, freqsU = pywt.cwt(Uv,scales,wname,sampling_period=dt)


ind_coi = 100 # Remove COI ad-hoc. Ignore the first and last N samples due to COI
Zv = np.divide(coefU,coefI)
print(np.mean(Zv))
Ztheory = 0.3/5.0*np.exp(-1j*np.pi/6)
print('Tehoretical Z=%f+1j%f' % (np.real(Ztheory), np.imag(Ztheory) ))
```



