### PR TITLE
Properly trim wavelet packet node coefficients during reconstruction

### DIFF
--- a/pywt/_wavelet_packets.py
+++ b/pywt/_wavelet_packets.py
@@ -71,9 +71,9 @@ class BaseNode(object):
         # Need to retain original data size/shape so we can trim any excess
         # boundary coefficients from the inverse transform.
         if self.data is None:
-            self.data_size = None
+            self.data_shape = None
         else:
-            self.data_size = np.asarray(data).shape
+            self.data_shape = np.asarray(data).shape
 
         self._init_subnodes()
 
@@ -442,8 +442,8 @@ class Node(BaseNode):
                              " from subnodes.")
         else:
             rec = idwt(data_a, data_d, self.wavelet, self.mode)
-            if self.data_size is not None and (rec.shape != self.data_size):
-                rec = rec[tuple([slice(sz) for sz in self.data_size])]
+            if self.data_shape is not None and (rec.shape != self.data_shape):
+                rec = rec[tuple([slice(sz) for sz in self.data_shape])]
             if update:
                 self.data = rec
             return rec
@@ -512,8 +512,8 @@ class Node2D(BaseNode):
         else:
             coeffs = data_ll, (data_hl, data_lh, data_hh)
             rec = idwt2(coeffs, self.wavelet, self.mode)
-            if self.data_size is not None and (rec.shape != self.data_size):
-                rec = rec[tuple([slice(sz) for sz in self.data_size])]
+            if self.data_shape is not None and (rec.shape != self.data_shape):
+                rec = rec[tuple([slice(sz) for sz in self.data_shape])]
             if update:
                 self.data = rec
             return rec
@@ -578,8 +578,6 @@ class WaveletPacket(Node):
         """
         if self.has_any_subnode:
             data = super(WaveletPacket, self).reconstruct(update)
-            if self.data_size is not None and len(data) > self.data_size:
-                data = data[:self.data_size]
             if update:
                 self.data = data
             return data
@@ -679,8 +677,6 @@ class WaveletPacket2D(Node2D):
         """
         if self.has_any_subnode:
             data = super(WaveletPacket2D, self).reconstruct(update)
-            if self.data_size is not None and (data.shape != self.data_size):
-                data = data[:self.data_size[0], :self.data_size[1]]
             if update:
                 self.data = data
             return data

--- a/pywt/_wavelet_packets.py
+++ b/pywt/_wavelet_packets.py
@@ -68,6 +68,12 @@ class BaseNode(object):
 
         # data - signal on level 0, coeffs on higher levels
         self.data = data
+        # Need to retain original data size/shape so we can trim any excess
+        # boundary coefficients from the inverse transform.
+        if self.data is None:
+            self.data_size = None
+        else:
+            self.data_size = np.asarray(data).shape
 
         self._init_subnodes()
 
@@ -436,6 +442,8 @@ class Node(BaseNode):
                              " from subnodes.")
         else:
             rec = idwt(data_a, data_d, self.wavelet, self.mode)
+            if self.data_size is not None and (rec.shape != self.data_size):
+                rec = rec[tuple([slice(sz) for sz in self.data_size])]
             if update:
                 self.data = rec
             return rec
@@ -504,6 +512,8 @@ class Node2D(BaseNode):
         else:
             coeffs = data_ll, (data_hl, data_lh, data_hh)
             rec = idwt2(coeffs, self.wavelet, self.mode)
+            if self.data_size is not None and (rec.shape != self.data_size):
+                rec = rec[tuple([slice(sz) for sz in self.data_size])]
             if update:
                 self.data = rec
             return rec

--- a/pywt/_wavelet_packets.py
+++ b/pywt/_wavelet_packets.py
@@ -71,9 +71,9 @@ class BaseNode(object):
         # Need to retain original data size/shape so we can trim any excess
         # boundary coefficients from the inverse transform.
         if self.data is None:
-            self.data_shape = None
+            self._data_shape = None
         else:
-            self.data_shape = np.asarray(data).shape
+            self._data_shape = np.asarray(data).shape
 
         self._init_subnodes()
 
@@ -442,8 +442,9 @@ class Node(BaseNode):
                              " from subnodes.")
         else:
             rec = idwt(data_a, data_d, self.wavelet, self.mode)
-            if self.data_shape is not None and (rec.shape != self.data_shape):
-                rec = rec[tuple([slice(sz) for sz in self.data_shape])]
+            if self._data_shape is not None and (
+                    rec.shape != self._data_shape):
+                rec = rec[tuple([slice(sz) for sz in self._data_shape])]
             if update:
                 self.data = rec
             return rec
@@ -512,8 +513,9 @@ class Node2D(BaseNode):
         else:
             coeffs = data_ll, (data_hl, data_lh, data_hh)
             rec = idwt2(coeffs, self.wavelet, self.mode)
-            if self.data_shape is not None and (rec.shape != self.data_shape):
-                rec = rec[tuple([slice(sz) for sz in self.data_shape])]
+            if self._data_shape is not None and (
+                    rec.shape != self._data_shape):
+                rec = rec[tuple([slice(sz) for sz in self._data_shape])]
             if update:
                 self.data = rec
             return rec

--- a/pywt/tests/test_wp.py
+++ b/pywt/tests/test_wp.py
@@ -189,5 +189,13 @@ def test_wavelet_packet_dtypes():
         assert_allclose(r, x.astype(transform_dtype), atol=1e-5, rtol=1e-5)
 
 
+def test_db3_roundtrip():
+    original = np.arange(512)
+    wp = pywt.WaveletPacket(data=original, wavelet='db3', mode='smooth',
+                            maxlevel=3)
+    r = wp.reconstruct()
+    assert_allclose(original, r, atol=1e-12, rtol=1e-12)
+
+
 if __name__ == '__main__':
     run_module_suite()

--- a/pywt/tests/test_wp2d.py
+++ b/pywt/tests/test_wp2d.py
@@ -168,5 +168,14 @@ def test_wavelet_packet_dtypes():
         assert_allclose(r, x, atol=1e-5, rtol=1e-5)
 
 
+def test_2d_roundtrip():
+    # test case corresponding to PyWavelets issue 447
+    original = pywt.data.camera()
+    wp = pywt.WaveletPacket2D(data=original, wavelet='db3', mode='smooth',
+                              maxlevel=3)
+    r = wp.reconstruct()
+    assert_allclose(original, r, atol=1e-12, rtol=1e-12)
+
+
 if __name__ == '__main__':
     run_module_suite()


### PR DESCRIPTION
For some boundary modes and data sizes, round-trip DWT/IDWT can results in an output that has an additional coefficient. Here is a simple 1D example where roundtrip transform of a length 17 signal gives a length 18 output:
pywt.waverec(pywt.wavedec(np.arange(17), 'db3', level=3), 'db3').shape

There is some existing logic that seems intended to trim the extra coefficients during wavelet packet transforms:
https://github.com/PyWavelets/pywt/blob/f0f4ee0a25bfee49cb50f7ab0c92126287a2cc73/pywt/_wavelet_packets.py#L570-L572

However, this really needs to be done at the `Node` rather than `WaveletPacket` level as indicated by the shape problem raised in #447.

closes #447