### PR TITLE
bump minimum supported Cython version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,18 +16,21 @@ matrix:
       env:
         - NUMPYSPEC=numpy
         - MATPLOTLIBSPEC=matplotlib
+        - CYTHONSPEC=cython
         - USE_WHEEL=1
     - os: linux
       python: 3.7-dev
       env:
         - NUMPYSPEC=numpy
         - MATPLOTLIBSPEC=matplotlib
+        - CYTHONSPEC=cython
         - USE_SDIST=1
     - os: linux
       python: 3.5
       env:
         - NUMPYSPEC="numpy==1.13.3"
         - MATPLOTLIBSPEC=matplotlib
+        - CYTHONSPEC="cython==0.23.5"
         - REFGUIDE_CHECK=1  # run doctests only
     - os: osx
       osx_image: xcode7.3
@@ -35,6 +38,7 @@ matrix:
       env:
         - NUMPYSPEC=numpy
         - MATPLOTLIBSPEC=matplotlib
+        - CYTHONSPEC=cython
         - TRAVIS_PYTHON_VERSION=3.5
 
 cache: pip
@@ -51,7 +55,8 @@ before_install:
   # Set numpy version first, other packages link against it
   - pip install $NUMPYSPEC
   - pip install $MATPLOTLIBSPEC
-  - pip install Cython nose coverage codecov futures
+  - pip install $CYTHONSPEC
+  - pip install nose coverage codecov futures
   - set -o pipefail
   - if [ "${USE_WHEEL}" == "1" ]; then pip install wheel; fi
   - |

--- a/doc/source/install.rst
+++ b/doc/source/install.rst
@@ -40,7 +40,7 @@ The requirements needed to build from source are:
 
  - Python_ 2.7 or >=3.4
  - Numpy_ >= 1.13.3
- - Cython_ >= 0.20.2  (if installing from git, not from a PyPI source release)
+ - Cython_ >= 0.23.5  (if installing from git, not from a PyPI source release)
 
 To run all the tests for PyWavelets, you will also need to install the
 Matplotlib_ package.

--- a/util/readthedocs/requirements.txt
+++ b/util/readthedocs/requirements.txt
@@ -1,5 +1,5 @@
 numpy
-Cython==0.20.2
+cython
 nose
 wheel
 numpydoc


### PR DESCRIPTION
Readthedocs was pinned to Cython 0.20 which is too old to build the changes merged in #435.  I am trying to bump to 0.23.5 here to see if that is new enough.

I added a test case on Travis with the minimum Cython version since it seems the CI test cases all just used the most recent release..