### PR TITLE
BLD: 1.0.x pin cython language level to '2'

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -163,7 +163,7 @@ with open(defines_py, 'w') as fd:
         fd.write('%s = %d\n' % (k, int(v)))
 
 
-cythonize_opts = {}
+cythonize_opts = {'language_level': '2'}
 if os.environ.get("CYTHON_TRACE"):
     cythonize_opts['linetrace'] = True
     cython_macros.append(("CYTHON_TRACE_NOGIL", 1))


### PR DESCRIPTION
This PR applies #451 to the 1.0.x branch. 

I should backport a couple of the other bug fixes that were merged to master and then we can make a new release.