### PR TITLE
MAINT: 1.0.x: handle mixed dtype cofficients correctly across inverse transforms

### DIFF
--- a/pywt/_dwt.py
+++ b/pywt/_dwt.py
@@ -264,8 +264,12 @@ def idwt(cA, cD, wavelet, mode='symmetric', axis=-1):
     if cA is not None and cD is not None:
         if cA.dtype != cD.dtype:
             # need to upcast to common type
-            cA = cA.astype(np.float64)
-            cD = cD.astype(np.float64)
+            if cA.dtype.kind == 'c' or cD.dtype.kind == 'c':
+                dtype = np.complex128
+            else:
+                dtype = np.float64
+            cA = cA.astype(dtype)
+            cD = cD.astype(dtype)
     elif cA is None:
         cA = np.zeros_like(cD)
     elif cD is None:

--- a/pywt/_multidim.py
+++ b/pywt/_multidim.py
@@ -296,7 +296,15 @@ def idwtn(coeffs, wavelet, mode='symmetric', axes=None):
         for key in new_keys:
             L = coeffs.get(key + 'a', None)
             H = coeffs.get(key + 'd', None)
-
+            if L is not None and H is not None:
+                if L.dtype != H.dtype:
+                    # upcast to a common dtype (float64 or complex128)
+                    if L.dtype.kind == 'c' or H.dtype.kind == 'c':
+                        dtype = np.complex128
+                    else:
+                        dtype = np.float64
+                    L = np.asarray(L, dtype=dtype)
+                    H = np.asarray(H, dtype=dtype)
             new_coeffs[key] = idwt_axis(L, H, wav, mode, axis)
         coeffs = new_coeffs
 

--- a/pywt/tests/test_dwt_idwt.py
+++ b/pywt/tests/test_dwt_idwt.py
@@ -39,7 +39,22 @@ def test_dwt_idwt_basic():
     x_roundtrip2 = pywt.idwt(cA.astype(np.float64), cD.astype(np.float32),
                              'db2')
     assert_allclose(x_roundtrip2, x, rtol=1e-7, atol=1e-7)
-    assert_(x_roundtrip.dtype == np.float64)
+    assert_(x_roundtrip2.dtype == np.float64)
+
+
+def test_idwt_mixed_complex_dtype():
+    x = np.arange(8).astype(float)
+    x = x + 1j*x[::-1]
+    cA, cD = pywt.dwt(x, 'db2')
+
+    x_roundtrip = pywt.idwt(cA, cD, 'db2')
+    assert_allclose(x_roundtrip, x, rtol=1e-10)
+
+    # mismatched dtypes OK
+    x_roundtrip2 = pywt.idwt(cA.astype(np.complex128), cD.astype(np.complex64),
+                             'db2')
+    assert_allclose(x_roundtrip2, x, rtol=1e-7, atol=1e-7)
+    assert_(x_roundtrip2.dtype == np.complex128)
 
 
 def test_dwt_idwt_dtypes():

--- a/pywt/tests/test_multidim.py
+++ b/pywt/tests/test_multidim.py
@@ -363,6 +363,22 @@ def test_dwtn_idwtn_dtypes():
         assert_(x_roundtrip.dtype == dt_out, "idwtn: " + errmsg)
 
 
+def test_idwtn_mixed_complex_dtype():
+    rstate = np.random.RandomState(0)
+    x = rstate.randn(8, 8, 8)
+    x = x + 1j*x
+    coeffs = pywt.dwtn(x, 'db2')
+
+    x_roundtrip = pywt.idwtn(coeffs, 'db2')
+    assert_allclose(x_roundtrip, x, rtol=1e-10)
+
+    # mismatched dtypes OK
+    coeffs['a' * x.ndim] = coeffs['a' * x.ndim].astype(np.complex64)
+    x_roundtrip2 = pywt.idwtn(coeffs, 'db2')
+    assert_allclose(x_roundtrip2, x, rtol=1e-7, atol=1e-7)
+    assert_(x_roundtrip2.dtype == np.complex128)
+
+
 def test_idwt2_size_mismatch_error():
     LL = np.zeros((6, 6))
     LH = HL = HH = np.zeros((5, 5))


### PR DESCRIPTION
This is a backport of #450 to the 1.0.x branch. There were no conflicts when cherry-picking the commits, so this should be good to go once CI passes.