### PR TITLE
MAINT: 1.0.x Fix deprecated import for Iterable

### DIFF
--- a/pywt/_utils.py
+++ b/pywt/_utils.py
@@ -3,7 +3,7 @@
 # See COPYING for license details.
 import inspect
 import sys
-from collections import Iterable
+from collections.abc import Iterable
 
 from ._extensions._pywt import (Wavelet, ContinuousWavelet,
                                 DiscreteContinuousWavelet, Modes)


### PR DESCRIPTION
backport of #436