### PR TITLE
Revert "MAINT: 1.0.x Fix deprecated import for Iterable"

### DIFF
--- a/pywt/_utils.py
+++ b/pywt/_utils.py
@@ -3,7 +3,7 @@
 # See COPYING for license details.
 import inspect
 import sys
-from collections.abc import Iterable
+from collections import Iterable
 
 from ._extensions._pywt import (Wavelet, ContinuousWavelet,
                                 DiscreteContinuousWavelet, Modes)


### PR DESCRIPTION
Reverts PyWavelets/pywt#458