### PR TITLE
fix bug in iswtn for data of arbitrary shape when using user-specified axes

### DIFF
--- a/pywt/_swt.py
+++ b/pywt/_swt.py
@@ -516,16 +516,19 @@ def iswtn(coeffs, wavelet, axes=None):
             [dt, ] + [v.dtype for v in details.values()]))
         if output.dtype != common_dtype:
             output = output.astype(common_dtype)
+
         # We assume all coefficient arrays are of equal size
         shapes = [v.shape for k, v in details.items()]
-        dshape = shapes[0]
         if len(set(shapes)) != 1:
             raise RuntimeError(
                 "Mismatch in shape of intermediate coefficient arrays")
 
+        # shape of a single coefficient array, excluding non-transformed axes
+        coeff_trans_shape = tuple([shapes[0][ax] for ax in axes])
+
         # nested loop over all combinations of axis offsets at this level
         for firsts in product(*([range(last_index), ]*ndim_transform)):
-            for first, sh, ax in zip(firsts, dshape, axes):
+            for first, sh, ax in zip(firsts, coeff_trans_shape, axes):
                 indices[ax] = slice(first, sh, step_size)
                 even_indices[ax] = slice(first, sh, 2*step_size)
                 odd_indices[ax] = slice(first+step_size, sh, 2*step_size)


### PR DESCRIPTION
closes #460 

The issue was a variable that should have only contained the shape of the **transformed axes** and not all axes. This was missed by the current tests because these used the same size on each axis of the transformed array so it didn't matter if the shape from the wrong axis was selected.

A new test case with various permutations of shapes and non-transformed axis was added. Specifically the test case tests the following shape, axes permutations:
```
shape = (1, 48, 32), axes = [1, 2]
shape = (1, 32, 48), axes = [1, 2]
shape = (48, 1, 32), axes = [0, 2]
shape = (48, 32, 1), axes = [0, 1]
shape = (32, 1, 48), axes = [0, 2]
shape = (32, 48, 1), axes = [0, 1]
```
