### PR TITLE
user-friendly error messages about multilevel DWT format

### DIFF
--- a/pywt/_multilevel.py
+++ b/pywt/_multilevel.py
@@ -156,6 +156,12 @@ def waverec(coeffs, wavelet, mode='symmetric', axis=-1):
     a, ds = coeffs[0], coeffs[1:]
 
     for d in ds:
+        if d is not None and not isinstance(d, np.ndarray):
+            raise ValueError((
+                "Unexpected detail coefficient type: {}. Detail coefficients "
+                "must be arrays as returned by wavedec. If you are using "
+                "pywt.array_to_coeffs or pywt.unravel_coeffs, please specify "
+                "output_format='wavedec'").format(type(d)))
         if (a is not None) and (d is not None):
             try:
                 if a.shape[axis] == d.shape[axis] + 1:
@@ -310,6 +316,12 @@ def waverec2(coeffs, wavelet, mode='symmetric', axes=(-2, -1)):
     a = np.asarray(a)
 
     for d in ds:
+        if not isinstance(d, tuple) or len(d) != 3:
+            raise ValueError((
+                "Unexpected detail coefficient type: {}. Detail coefficients "
+                "must be a 3-tuple of arrays as returned by wavedec2. If you "
+                "are using pywt.array_to_coeffs or pywt.unravel_coeffs, "
+                "please specify output_format='wavedec2'").format(type(d)))
         d = tuple(np.asarray(coeff) if coeff is not None else None
                   for coeff in d)
         d_shapes = (coeff.shape for coeff in d if coeff is not None)
@@ -510,6 +522,14 @@ def waverecn(coeffs, wavelet, mode='symmetric', axes=None):
             "Coefficient list too short (minimum 1 array required).")
 
     a, ds = coeffs[0], coeffs[1:]
+
+    # this dictionary check must be prior to the call to _fix_coeffs
+    if len(ds) > 0 and not all([isinstance(d, dict) for d in ds]):
+        raise ValueError((
+            "Unexpected detail coefficient type: {}. Detail coefficients "
+            "must be a dicionary of arrays as returned by wavedecn. If "
+            "you are using pywt.array_to_coeffs or pywt.unravel_coeffs, "
+            "please specify output_format='wavedecn'").format(type(ds[0])))
 
     # Raise error for invalid key combinations
     ds = list(map(_fix_coeffs, ds))
@@ -827,7 +847,8 @@ def array_to_coeffs(arr, coeff_slices, output_format='wavedecn'):
     >>> cam = pywt.data.camera()
     >>> coeffs = pywt.wavedecn(cam, wavelet='db2', level=3)
     >>> arr, coeff_slices = pywt.coeffs_to_array(coeffs)
-    >>> coeffs_from_arr = pywt.array_to_coeffs(arr, coeff_slices)
+    >>> coeffs_from_arr = pywt.array_to_coeffs(arr, coeff_slices,
+    >>>                                        output_format='wavedecn')
     >>> cam_recon = pywt.waverecn(coeffs_from_arr, wavelet='db2')
     >>> assert_array_almost_equal(cam, cam_recon)
 

--- a/pywt/_multilevel.py
+++ b/pywt/_multilevel.py
@@ -1120,7 +1120,8 @@ def unravel_coeffs(arr, coeff_slices, coeff_shapes, output_format='wavedecn'):
     >>> cam = pywt.data.camera()
     >>> coeffs = pywt.wavedecn(cam, wavelet='db2', level=3)
     >>> arr, coeff_slices, coeff_shapes = pywt.ravel_coeffs(coeffs)
-    >>> coeffs_from_arr = pywt.unravel_coeffs(arr, coeff_slices, coeff_shapes)
+    >>> coeffs_from_arr = pywt.unravel_coeffs(arr, coeff_slices, coeff_shapes,
+    >>>                                       output_format='wavedecn')
     >>> cam_recon = pywt.waverecn(coeffs_from_arr, wavelet='db2')
     >>> assert_array_almost_equal(cam, cam_recon)
 

--- a/pywt/_multilevel.py
+++ b/pywt/_multilevel.py
@@ -844,7 +844,7 @@ def array_to_coeffs(arr, coeff_slices, output_format='wavedecn'):
     >>> coeffs = pywt.wavedecn(cam, wavelet='db2', level=3)
     >>> arr, coeff_slices = pywt.coeffs_to_array(coeffs)
     >>> coeffs_from_arr = pywt.array_to_coeffs(arr, coeff_slices,
-    >>>                                        output_format='wavedecn')
+    ...                                        output_format='wavedecn')
     >>> cam_recon = pywt.waverecn(coeffs_from_arr, wavelet='db2')
     >>> assert_array_almost_equal(cam, cam_recon)
 
@@ -1138,7 +1138,7 @@ def unravel_coeffs(arr, coeff_slices, coeff_shapes, output_format='wavedecn'):
     >>> coeffs = pywt.wavedecn(cam, wavelet='db2', level=3)
     >>> arr, coeff_slices, coeff_shapes = pywt.ravel_coeffs(coeffs)
     >>> coeffs_from_arr = pywt.unravel_coeffs(arr, coeff_slices, coeff_shapes,
-    >>>                                       output_format='wavedecn')
+    ...                                       output_format='wavedecn')
     >>> cam_recon = pywt.waverecn(coeffs_from_arr, wavelet='db2')
     >>> assert_array_almost_equal(cam, cam_recon)
 

--- a/pywt/_multilevel.py
+++ b/pywt/_multilevel.py
@@ -170,10 +170,6 @@ def waverec(coeffs, wavelet, mode='symmetric', axis=-1):
                     raise ValueError("coefficient shape mismatch")
             except IndexError:
                 raise ValueError("Axis greater than coefficient dimensions")
-            except AttributeError:
-                raise AttributeError(
-                    "Wrong coefficient format, if using 'array_to_coeffs' "
-                    "please specify the 'output_format' parameter")
         a = idwt(a, d, wavelet, mode, axis)
 
     return a

--- a/pywt/_multilevel.py
+++ b/pywt/_multilevel.py
@@ -312,7 +312,7 @@ def waverec2(coeffs, wavelet, mode='symmetric', axes=(-2, -1)):
     a = np.asarray(a)
 
     for d in ds:
-        if not isinstance(d, tuple) or len(d) != 3:
+        if not isinstance(d, (list, tuple)) or len(d) != 3:
             raise ValueError((
                 "Unexpected detail coefficient type: {}. Detail coefficients "
                 "must be a 3-tuple of arrays as returned by wavedec2. If you "

--- a/pywt/tests/test_multilevel.py
+++ b/pywt/tests/test_multilevel.py
@@ -80,8 +80,9 @@ def test_waverec_invalid_inputs():
     coeffs = pywt.wavedec(x, 'db1')
     arr, coeff_slices = pywt.coeffs_to_array(coeffs)
     coeffs_from_arr = pywt.array_to_coeffs(arr, coeff_slices)
-    message = "Wrong coefficient format, if using 'array_to_coeffs' please specify the 'output_format' parameter"
-    assert_raises_regex(AttributeError, message, pywt.waverec, coeffs_from_arr, 'haar')
+    message = "Unexpected detail coefficient type"
+    assert_raises_regex(ValueError, message, pywt.waverec, coeffs_from_arr,
+                        'haar')
 
 
 def test_waverec_accuracies():
@@ -208,6 +209,13 @@ def test_waverec2_invalid_inputs():
     # input list cannot be empty
     assert_raises(ValueError, pywt.waverec2, [], 'haar')
 
+    # coefficients from a difference decomposition used as input
+    for dec_func in [pywt.wavedec, pywt.wavedecn]:
+        coeffs = dec_func(np.ones((8, 8)), 'haar')
+        message = "Unexpected detail coefficient type"
+        assert_raises_regex(ValueError, message, pywt.waverec2, coeffs,
+                            'haar')
+
 
 def test_waverec2_coeff_shape_mismatch():
     x = np.ones((8, 8))
@@ -283,6 +291,16 @@ def test_waverecn_invalid_coeffs():
 
     # input list cannot be empty
     assert_raises(ValueError, pywt.waverecn, [], 'haar')
+
+
+def test_waverecn_invalid_inputs():
+
+    # coefficients from a difference decomposition used as input
+    for dec_func in [pywt.wavedec, pywt.wavedec2]:
+        coeffs = dec_func(np.ones((8, 8)), 'haar')
+        message = "Unexpected detail coefficient type"
+        assert_raises_regex(ValueError, message, pywt.waverecn, coeffs,
+                            'haar')
 
 
 def test_waverecn_lists():


### PR DESCRIPTION
This PR introduces more informative error messages in the case the coefficients from the wrong multilevel DWT type are used as input to a multilevel reconstruction. This has resulted in user confusion in due to the output of `pywt.array_to_coeffs` and `pywt.unravel_coeffs` defaulting to compatibility with `wavedecn`:  see #470 and #357

This was previously done for 1D in #358, but this PR attempts to do thisconsistently across `waverec`, `waverec2` and `waverecn`.

In addition to the more informative error messages, I updated the docstring examples to explicitly specify `output_format` so that it is harder for users to overlook it.