### PR TITLE
MAINT/TST: update tests to use pytest

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -5,6 +5,7 @@ include = */pywt/*
 omit =
     */version.py
     */pywt/tests/*
+    */pywt/_doc_utils.py*
     */pywt/data/create_dat.py
     *.pxd
     stringsource

--- a/.travis.yml
+++ b/.travis.yml
@@ -56,7 +56,7 @@ before_install:
   - pip install $NUMPYSPEC
   - pip install $MATPLOTLIBSPEC
   - pip install $CYTHONSPEC
-  - pip install nose coverage codecov futures
+  - pip install pytest pytest-cov coverage codecov futures
   - set -o pipefail
   - if [ "${USE_WHEEL}" == "1" ]; then pip install wheel; fi
   - |
@@ -72,7 +72,7 @@ script:
         pip wheel . -v
         pip install PyWavelets*.whl -v
         pushd demo
-        nosetests pywt
+        pytest --pyargs pywt
         python ../pywt/tests/test_doc.py
         popd
     elif [ "${USE_SDIST}" == "1" ]; then
@@ -80,7 +80,7 @@ script:
         # Move out of source directory to avoid finding local pywt
         pushd dist
         pip install PyWavelets* -v
-        nosetests pywt
+        pytest --pyargs pywt
         python ../pywt/tests/test_doc.py
         popd
     elif [ "${REFGUIDE_CHECK}" == "1" ]; then
@@ -88,7 +88,7 @@ script:
         python util/refguide_check.py --doctests
     else
         CFLAGS="--coverage" python setup.py build --build-lib build/lib/ --build-temp build/tmp/
-        nosetests build/lib/ --tests pywt/tests
+        pytest --cov=pywt build/lib/pywt/tests/
     fi
 
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -88,7 +88,10 @@ script:
         python util/refguide_check.py --doctests
     else
         CFLAGS="--coverage" python setup.py build --build-lib build/lib/ --build-temp build/tmp/
-        pytest --cov=pywt build/lib/pywt/tests/
+        CFLAGS="--coverage" pip install -e . -v
+        pushd demo
+        pytest --pyargs pywt --cov=pywt
+        popd
     fi
 
 after_success:

--- a/LICENSE
+++ b/LICENSE
@@ -1,5 +1,5 @@
 Copyright (c) 2006-2012 Filip Wasilewski <http://en.ig.ma/>
-Copyright (c) 2012-2017 The PyWavelets Developers <https://github.com/PyWavelets/pywt>
+Copyright (c) 2012-2019 The PyWavelets Developers <https://github.com/PyWavelets/pywt>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in
@@ -18,3 +18,15 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
+
+
+The PyWavelets repository and source distributions bundle some code that is
+adapted from compatibly licensed projects. We list these here.
+
+Name: NumPy
+Files:  pywt/_pytesttester.py
+License: 3-clause BSD
+
+Name: SciPy
+Files:  setup.py, util/*
+License: 3-clause BSD

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -26,8 +26,10 @@ install:
      Cython pytest coverage matplotlib futures --cache-dir c:\\tmp\\pip-cache"
 
 test_script:
-  - "util\\appveyor\\build.cmd %PYTHON%\\python.exe setup.py build --build-lib build\\lib\\"
-  - "%PYTHON%\\Scripts\\pytest build\\lib\\pywt\\tests"
+  - "util\\appveyor\\build.cmd %PYTHON%\\python.exe -m pip install -e . -v"
+  - "cd demo"
+  - "%PYTHON%\\Scripts\\pytest --pyargs pywt"
+  - "cd .."
 
 after_test:
   - "util\\appveyor\\build.cmd %PYTHON%\\python.exe setup.py bdist_wheel"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -23,11 +23,11 @@ install:
   - "util\\appveyor\\build.cmd %PYTHON%\\python.exe -m pip install
      numpy --cache-dir c:\\tmp\\pip-cache"
   - "util\\appveyor\\build.cmd %PYTHON%\\python.exe -m pip install
-     Cython nose coverage matplotlib futures --cache-dir c:\\tmp\\pip-cache"
+     Cython pytest coverage matplotlib futures --cache-dir c:\\tmp\\pip-cache"
 
 test_script:
   - "util\\appveyor\\build.cmd %PYTHON%\\python.exe setup.py build --build-lib build\\lib\\"
-  - "%PYTHON%\\Scripts\\nosetests build\\lib --tests pywt\\tests"
+  - "%PYTHON%\\Scripts\\pytest build\\lib\\pywt\\tests"
 
 after_test:
   - "util\\appveyor\\build.cmd %PYTHON%\\python.exe setup.py bdist_wheel"

--- a/doc/source/dev/testing.rst
+++ b/doc/source/dev/testing.rst
@@ -23,13 +23,22 @@ does not break the build.
 Running tests locally
 ---------------------
 
-Tests are implemented with `nose`_, so use one of:
+Tests are implemented with `pytest`_, so use one of:
 
-    $ nosetests pywt
+    $ pytest --pyargs pywt -v
 
-    >>> pywt.test()  # doctest: +SKIP
+There are also older doctests that can be run by performing the following from
+the root of the project source.
 
-Note doctests require `Matplotlib`_ in addition to the usual dependencies.
+    $ python pywt/tests/test_doc.py
+    $ cd doc
+    $ make doctest
+
+Additionally the examples in the demo subfolder can be checked by running:
+
+    $ python util/refguide_check.py
+
+Note: doctests require `Matplotlib`_ in addition to the usual dependencies.
 
 
 Running tests with Tox
@@ -43,6 +52,6 @@ To for example run tests for Python 3.5 and 3.6 use::
 For more information see the `Tox`_ documentation.
 
 
-.. _nose: http://nose.readthedocs.org/en/latest/
-.. _Tox: http://tox.testrun.org/
-.. _Matplotlib: http://matplotlib.org
+.. _pytest: https://pytest.org
+.. _Tox: https://tox.readthedocs.io/en/latest/
+.. _Matplotlib: https://matplotlib.org

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,15 @@
+[pytest]
+addopts = -l
+norecursedirs = doc tools pywt/_extensions
+doctest_optionflags = NORMALIZE_WHITESPACE ELLIPSIS ALLOW_UNICODE ALLOW_BYTES
+
+filterwarnings =
+    error
+# Filter out annoying import messages.
+    ignore:Not importing directory
+    ignore:numpy.dtype size changed
+    ignore:numpy.ufunc size changed
+    ignore::UserWarning:cpuinfo,
+
+env =
+    PYTHONHASHSEED=0

--- a/pywt/__init__.py
+++ b/pywt/__init__.py
@@ -35,11 +35,5 @@ except NameError:
 
 from pywt.version import version as __version__
 
-import numpy as np
-if np.lib.NumpyVersion(np.__version__) >= '1.14.0':
-    from ._utils import is_nose_running
-    if is_nose_running():
-        np.set_printoptions(legacy='1.13')
-
 from numpy.testing import Tester
 test = Tester().test

--- a/pywt/__init__.py
+++ b/pywt/__init__.py
@@ -35,5 +35,6 @@ except NameError:
 
 from pywt.version import version as __version__
 
-from numpy.testing import Tester
-test = Tester().test
+from ._pytesttester import PytestTester
+test = PytestTester(__name__)
+del PytestTester

--- a/pywt/_pytest.py
+++ b/pywt/_pytest.py
@@ -1,0 +1,68 @@
+"""common test-related code."""
+import os
+import sys
+import multiprocessing
+import numpy as np
+import pytest
+
+
+__all__ = ['uses_matlab',   # skip if pymatbridge and Matlab unavailable
+           'uses_futures',  # skip if futures unavailable
+           'uses_pymatbridge',  # skip if no PYWT_XSLOW environment variable
+           'uses_precomputed',  # skip if PYWT_XSLOW environment variable found
+           'matlab_result_dict_cwt',   # dict with precomputed Matlab dwt data
+           'matlab_result_dict_dwt',   # dict with precomputed Matlab cwt data
+           'futures',      # the futures module or None
+           'max_workers',  # the number of workers available to futures
+           'size_set',     # the set of Matlab tests to run
+           ]
+
+try:
+    if sys.version_info[0] == 2:
+        import futures
+    else:
+        from concurrent import futures
+    max_workers = multiprocessing.cpu_count()
+    futures_available = True
+except ImportError:
+    futures_available = False
+    futures = None
+
+# check if pymatbridge + MATLAB tests should be run
+matlab_result_dict_dwt = None
+matlab_result_dict_cwt = None
+matlab_missing = True
+use_precomputed = True
+size_set = 'reduced'
+if 'PYWT_XSLOW' in os.environ:
+    try:
+        from pymatbridge import Matlab
+        mlab = Matlab()
+        matlab_missing = False
+        use_precomputed = False
+        size_set = 'full'
+    except ImportError:
+        print("To run Matlab compatibility tests you need to have MathWorks "
+              "MATLAB, MathWorks Wavelet Toolbox and the pymatbridge Python "
+              "package installed.")
+if use_precomputed:
+    # load dictionaries of precomputed results
+    data_dir = os.path.join(os.path.dirname(__file__), 'tests', 'data')
+    matlab_data_file_cwt = os.path.join(
+        data_dir, 'cwt_matlabR2015b_result.npz')
+    matlab_result_dict_cwt = np.load(matlab_data_file_cwt)
+
+    matlab_data_file_dwt = os.path.join(
+        data_dir, 'dwt_matlabR2012a_result.npz')
+    matlab_result_dict_dwt = np.load(matlab_data_file_dwt)
+
+uses_futures = pytest.mark.skipif(
+    not futures_available, reason='futures not available')
+uses_matlab = pytest.mark.skipif(
+    matlab_missing, reason='pymatbridge and/or Matlab not available')
+uses_pymatbridge = pytest.mark.skipif(
+    use_precomputed,
+    reason='PYWT_XSLOW set: skipping tests against precomputed Matlab results')
+uses_precomputed = pytest.mark.skipif(
+    not use_precomputed,
+    reason='PYWT_XSLOW not set: test against precomputed matlab tests')

--- a/pywt/_pytesttester.py
+++ b/pywt/_pytesttester.py
@@ -1,0 +1,209 @@
+"""
+Pytest test running.
+
+This module implements the ``test()`` function for NumPy modules. The usual
+boiler plate for doing that is to put the following in the module
+``__init__.py`` file::
+
+    from numpy._pytesttester import PytestTester
+    test = PytestTester(__name__).test
+    del PytestTester
+
+
+Warnings filtering and other runtime settings should be dealt with in the
+``pytest.ini`` file in the numpy repo root. The behavior of the test depends on
+whether or not that file is found as follows:
+
+* ``pytest.ini`` is present (develop mode)
+    All warnings except those explicily filtered out are raised as error.
+* ``pytest.ini`` is absent (release mode)
+    DeprecationWarnings and PendingDeprecationWarnings are ignored, other
+    warnings are passed through.
+
+In practice, tests run from the numpy repo are run in develop mode. That
+includes the standard ``python runtests.py`` invocation.
+
+This module is imported by every numpy subpackage, so lies at the top level to
+simplify circular import issues. For the same reason, it contains no numpy
+imports at module scope, instead importing numpy within function calls.
+"""
+from __future__ import division, absolute_import, print_function
+
+import sys
+import os
+
+__all__ = ['PytestTester']
+
+
+
+def _show_numpy_info():
+    import numpy as np
+
+    print("NumPy version %s" % np.__version__)
+    relaxed_strides = np.ones((10, 1), order="C").flags.f_contiguous
+    print("NumPy relaxed strides checking option:", relaxed_strides)
+
+
+class PytestTester(object):
+    """
+    Pytest test runner.
+
+    This class is made available in ``numpy.testing``, and a test function
+    is typically added to a package's __init__.py like so::
+
+      from numpy.testing import PytestTester
+      test = PytestTester(__name__).test
+      del PytestTester
+
+    Calling this test function finds and runs all tests associated with the
+    module and all its sub-modules.
+
+    Attributes
+    ----------
+    module_name : str
+        Full path to the package to test.
+
+    Parameters
+    ----------
+    module_name : module name
+        The name of the module to test.
+
+    """
+    def __init__(self, module_name):
+        self.module_name = module_name
+
+    def __call__(self, label='fast', verbose=1, extra_argv=None,
+                 doctests=False, coverage=False, durations=-1, tests=None):
+        """
+        Run tests for module using pytest.
+
+        Parameters
+        ----------
+        label : {'fast', 'full'}, optional
+            Identifies the tests to run. When set to 'fast', tests decorated
+            with `pytest.mark.slow` are skipped, when 'full', the slow marker
+            is ignored.
+        verbose : int, optional
+            Verbosity value for test outputs, in the range 1-3. Default is 1.
+        extra_argv : list, optional
+            List with any extra arguments to pass to pytests.
+        doctests : bool, optional
+            .. note:: Not supported
+        coverage : bool, optional
+            If True, report coverage of NumPy code. Default is False.
+            Requires installation of (pip) pytest-cov.
+        durations : int, optional
+            If < 0, do nothing, If 0, report time of all tests, if > 0,
+            report the time of the slowest `timer` tests. Default is -1.
+        tests : test or list of tests
+            Tests to be executed with pytest '--pyargs'
+
+        Returns
+        -------
+        result : bool
+            Return True on success, false otherwise.
+
+        Notes
+        -----
+        Each NumPy module exposes `test` in its namespace to run all tests for
+        it. For example, to run all tests for numpy.lib:
+
+        >>> np.lib.test() #doctest: +SKIP
+
+        Examples
+        --------
+        >>> result = np.lib.test() #doctest: +SKIP
+        ...
+        1023 passed, 2 skipped, 6 deselected, 1 xfailed in 10.39 seconds
+        >>> result
+        True
+
+        """
+        import pytest
+        import warnings
+
+        #FIXME This is no longer needed? Assume it was for use in tests.
+        # cap verbosity at 3, which is equivalent to the pytest '-vv' option
+        #from . import utils
+        #verbose = min(int(verbose), 3)
+        #utils.verbose = verbose
+        #
+
+        module = sys.modules[self.module_name]
+        module_path = os.path.abspath(module.__path__[0])
+
+        # setup the pytest arguments
+        pytest_args = ["-l"]
+
+        # offset verbosity. The "-q" cancels a "-v".
+        pytest_args += ["-q"]
+
+        # Filter out distutils cpu warnings (could be localized to
+        # distutils tests). ASV has problems with top level import,
+        # so fetch module for suppression here.
+        with warnings.catch_warnings():
+            warnings.simplefilter("always")
+            from numpy.distutils import cpuinfo
+
+        # Filter out annoying import messages. Want these in both develop and
+        # release mode.
+        pytest_args += [
+            "-W ignore:Not importing directory",
+            "-W ignore:numpy.dtype size changed",
+            "-W ignore:numpy.ufunc size changed",
+            "-W ignore::UserWarning:cpuinfo",
+            ]
+
+        # When testing matrices, ignore their PendingDeprecationWarnings
+        pytest_args += [
+            "-W ignore:the matrix subclass is not",
+            ]
+
+        # Ignore python2.7 -3 warnings
+        pytest_args += [
+            r"-W ignore:sys\.exc_clear\(\) not supported in 3\.x:DeprecationWarning",
+            r"-W ignore:in 3\.x, __setslice__:DeprecationWarning",
+            r"-W ignore:in 3\.x, __getslice__:DeprecationWarning",
+            r"-W ignore:buffer\(\) not supported in 3\.x:DeprecationWarning",
+            r"-W ignore:CObject type is not supported in 3\.x:DeprecationWarning",
+            r"-W ignore:comparing unequal types not supported in 3\.x:DeprecationWarning",
+            r"-W ignore:the commands module has been removed in Python 3\.0:DeprecationWarning",
+            r"-W ignore:The 'new' module has been removed in Python 3\.0:DeprecationWarning",
+            ]
+
+
+        if doctests:
+            raise ValueError("Doctests not supported")
+
+        if extra_argv:
+            pytest_args += list(extra_argv)
+
+        if verbose > 1:
+            pytest_args += ["-" + "v"*(verbose - 1)]
+
+        if coverage:
+            pytest_args += ["--cov=" + module_path]
+
+        if label == "fast":
+            pytest_args += ["-m", "not slow"]
+        elif label != "full":
+            pytest_args += ["-m", label]
+
+        if durations >= 0:
+            pytest_args += ["--durations=%s" % durations]
+
+        if tests is None:
+            tests = [self.module_name]
+
+        pytest_args += ["--pyargs"] + list(tests)
+
+
+        # run tests.
+        _show_numpy_info()
+
+        try:
+            code = pytest.main(pytest_args)
+        except SystemExit as exc:
+            code = exc.code
+
+        return code == 0

--- a/pywt/_utils.py
+++ b/pywt/_utils.py
@@ -98,23 +98,3 @@ def _modes_per_axis(modes, axes):
     else:
         raise ValueError("modes must be a str, Mode enum or iterable")
     return modes
-
-
-def is_nose_running():
-    """Returns whether we are running the nose test loader
-    """
-    if 'nose' not in sys.modules:
-        return False
-    try:
-        import nose
-    except ImportError:
-        return False
-    # Now check that we have the loader in the call stask
-    stack = inspect.stack()
-    loader_file_name = nose.loader.__file__
-    if loader_file_name.endswith('.pyc'):
-        loader_file_name = loader_file_name[:-1]
-    for _, file_name, _, _, _, _ in stack:
-        if file_name == loader_file_name:
-            return True
-    return False

--- a/pywt/tests/test__pywt.py
+++ b/pywt/tests/test__pywt.py
@@ -168,7 +168,3 @@ def test_wavelet_errormsgs():
         pywt.Wavelet('cmord')
     except ValueError as e:
         assert_(e.args[0] == "Invalid wavelet name 'cmord'.")
-
-
-if __name__ == '__main__':
-    run_module_suite()

--- a/pywt/tests/test__pywt.py
+++ b/pywt/tests/test__pywt.py
@@ -3,8 +3,7 @@
 from __future__ import division, print_function, absolute_import
 
 import numpy as np
-from numpy.testing import (run_module_suite, assert_allclose, assert_,
-                           assert_raises)
+from numpy.testing import assert_allclose, assert_, assert_raises
 
 import pywt
 

--- a/pywt/tests/test_concurrent.py
+++ b/pywt/tests/test_concurrent.py
@@ -5,25 +5,13 @@ concurrent.futures.ThreadPoolExecutor does not raise errors.
 
 from __future__ import division, print_function, absolute_import
 
-import sys
 import warnings
-import multiprocessing
 import numpy as np
 from functools import partial
-from numpy.testing import (dec, run_module_suite, assert_array_equal,
-                           assert_allclose)
+from numpy.testing import assert_array_equal, assert_allclose
+from pywt._pytest import uses_futures, futures, max_workers
 
 import pywt
-
-try:
-    if sys.version_info[0] == 2:
-        import futures
-    else:
-        from concurrent import futures
-    max_workers = multiprocessing.cpu_count()
-    futures_available = True
-except ImportError:
-    futures_available = False
 
 
 def _assert_all_coeffs_equal(coefs1, coefs2):
@@ -44,7 +32,7 @@ def _assert_all_coeffs_equal(coefs1, coefs2):
     return True
 
 
-@dec.skipif(not futures_available)
+@uses_futures
 def test_concurrent_swt():
     # tests error-free concurrent operation (see gh-288)
     # swt on 1D data calls the Cython swt
@@ -65,7 +53,7 @@ def test_concurrent_swt():
         _assert_all_coeffs_equal(expected_result, results[-1])
 
 
-@dec.skipif(not futures_available)
+@uses_futures
 def test_concurrent_wavedec():
     # wavedec on 1D data calls the Cython dwt_single
     # other cases call dwt_axis
@@ -82,7 +70,7 @@ def test_concurrent_wavedec():
         _assert_all_coeffs_equal(expected_result, results[-1])
 
 
-@dec.skipif(not futures_available)
+@uses_futures
 def test_concurrent_dwt():
     # dwt on 1D data calls the Cython dwt_single
     # other cases call dwt_axis
@@ -99,7 +87,7 @@ def test_concurrent_dwt():
         _assert_all_coeffs_equal([expected_result, ], [results[-1], ])
 
 
-@dec.skipif(not futures_available)
+@uses_futures
 def test_concurrent_cwt():
     atol = rtol = 1e-14
     time, sst = pywt.data.nino()
@@ -115,7 +103,3 @@ def test_concurrent_cwt():
     expected_result = transform(sst)
     for a1, a2 in zip(expected_result, results[-1]):
         assert_allclose(a1, a2, atol=atol, rtol=rtol)
-
-
-if __name__ == '__main__':
-    run_module_suite()

--- a/pywt/tests/test_cwt_wavelets.py
+++ b/pywt/tests/test_cwt_wavelets.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python
 from __future__ import division, print_function, absolute_import
 
-from numpy.testing import (run_module_suite, assert_allclose, assert_warns,
-                           assert_almost_equal, assert_raises)
+from numpy.testing import (assert_allclose, assert_warns, assert_almost_equal,
+                           assert_raises)
 import numpy as np
 import pywt
 
@@ -371,6 +371,3 @@ def test_cwt_small_scales():
 
     # extremely short scale factors raise a ValueError
     assert_raises(ValueError, pywt.cwt, data, scales=0.01, wavelet='mexh')
-
-if __name__ == '__main__':
-    run_module_suite()

--- a/pywt/tests/test_data.py
+++ b/pywt/tests/test_data.py
@@ -1,7 +1,6 @@
 import os
 import numpy as np
-from numpy.testing import (assert_allclose, assert_raises, assert_,
-                           run_module_suite)
+from numpy.testing import assert_allclose, assert_raises, assert_
 
 import pywt.data
 
@@ -76,7 +75,3 @@ def test_wavelab_signals():
 
     # ValueError on invalid length
     assert_raises(ValueError, pywt.data.demo_signal, 'Doppler', 0)
-
-
-if __name__ == '__main__':
-    run_module_suite()

--- a/pywt/tests/test_deprecations.py
+++ b/pywt/tests/test_deprecations.py
@@ -1,7 +1,7 @@
 import warnings
 
 import numpy as np
-from numpy.testing import assert_warns, run_module_suite, assert_array_equal
+from numpy.testing import assert_warns, assert_array_equal
 
 import pywt
 
@@ -87,7 +87,3 @@ def test_mode_equivalence():
         for old, new in old_new:
             assert_array_equal(pywt.dwt(x, 'db2', mode=old),
                                pywt.dwt(x, 'db2', mode=new))
-
-
-if __name__ == '__main__':
-    run_module_suite()

--- a/pywt/tests/test_dwt_idwt.py
+++ b/pywt/tests/test_dwt_idwt.py
@@ -2,8 +2,7 @@
 from __future__ import division, print_function, absolute_import
 
 import numpy as np
-from numpy.testing import (run_module_suite, assert_allclose, assert_,
-                           assert_raises)
+from numpy.testing import assert_allclose, assert_, assert_raises
 
 import pywt
 
@@ -224,7 +223,3 @@ def test_error_on_continuous_wavelet():
 
         cA, cD = pywt.dwt(data, 'db1')
         assert_raises(ValueError, pywt.idwt, cA, cD, cwave)
-
-
-if __name__ == '__main__':
-    run_module_suite()

--- a/pywt/tests/test_functions.py
+++ b/pywt/tests/test_functions.py
@@ -1,8 +1,7 @@
 #!/usr/bin/env python
 from __future__ import division, print_function, absolute_import
 
-from numpy.testing import (run_module_suite, assert_almost_equal,
-                           assert_allclose)
+from numpy.testing import assert_almost_equal, assert_allclose
 
 import pywt
 
@@ -37,7 +36,3 @@ def test_intwave_orthogonal():
     # For x > 0.5, the integral is equal to (1 - x)
     # Ignore last point here, there x > 1 and something goes wrong
     assert_allclose(int_psi[~ix][:-1], 1 - x[~ix][:-1], atol=1e-10)
-
-
-if __name__ == '__main__':
-    run_module_suite()

--- a/pywt/tests/test_matlab_compatibility.py
+++ b/pywt/tests/test_matlab_compatibility.py
@@ -5,35 +5,13 @@ accuracy against MathWorks Wavelet Toolbox.
 
 from __future__ import division, print_function, absolute_import
 
-import os
 import numpy as np
-from numpy.testing import assert_, dec, run_module_suite
+import pytest
+from numpy.testing import assert_
 
 import pywt
-
-if 'PYWT_XSLOW' in os.environ:
-    # Run a more comprehensive set of problem sizes.  This could take more than
-    # an hour to complete.
-    size_set = 'full'
-    use_precomputed = False
-else:
-    size_set = 'reduced'
-    use_precomputed = True
-
-if use_precomputed:
-    data_dir = os.path.join(os.path.dirname(__file__), 'data')
-    matlab_data_file = os.path.join(data_dir, 'dwt_matlabR2012a_result.npz')
-    matlab_result_dict = np.load(matlab_data_file)
-else:
-    try:
-        from pymatbridge import Matlab
-        mlab = Matlab()
-        _matlab_missing = False
-    except ImportError:
-        print("To run Matlab compatibility tests you need to have MathWorks "
-              "MATLAB, MathWorks Wavelet Toolbox and the pymatbridge Python "
-              "package installed.")
-        _matlab_missing = True
+from pywt._pytest import (uses_pymatbridge, uses_precomputed, size_set)
+from pywt._pytest import matlab_result_dict_dwt as matlab_result_dict
 
 # list of mode names in pywt and matlab
 modes = [('zero', 'zpd'),
@@ -63,9 +41,12 @@ def _get_data_sizes(w):
     return data_sizes
 
 
-@dec.skipif(use_precomputed or _matlab_missing)
-@dec.slow
+@uses_pymatbridge
+@pytest.mark.slow
 def test_accuracy_pymatbridge():
+    Matlab = pytest.importorskip("pymatbridge.Matlab")
+    mlab = Matlab()
+
     rstate = np.random.RandomState(1234)
     # max RMSE (was 1.0e-10, is reduced to 5.0e-5 due to different coefficents)
     epsilon = 5.0e-5
@@ -88,8 +69,8 @@ def test_accuracy_pymatbridge():
         mlab.stop()
 
 
-@dec.skipif(not use_precomputed)
-@dec.slow
+@uses_precomputed
+@pytest.mark.slow
 def test_accuracy_precomputed():
     # Keep this specific random seed to match the precomputed Matlab result.
     rstate = np.random.RandomState(1234)
@@ -177,7 +158,3 @@ def _check_accuracy(data, w, pmode, ma, md, wavelet, epsilon):
     msg = ('[RMS_D > EPSILON] for Mode: %s, Wavelet: %s, '
            'Length: %d, rms=%.3g' % (pmode, wavelet, len(data), rms_d))
     assert_(rms_d < epsilon, msg=msg)
-
-
-if __name__ == '__main__':
-    run_module_suite()

--- a/pywt/tests/test_matlab_compatibility.py
+++ b/pywt/tests/test_matlab_compatibility.py
@@ -60,10 +60,10 @@ def test_accuracy_pymatbridge():
                 data = rstate.randn(N)
                 mlab.set_variable('data', data)
                 for pmode, mmode in modes:
-                    ma, md = _compute_matlab_result(data, wavelet, mmode)
-                    yield _check_accuracy, data, w, pmode, ma, md, wavelet, epsilon
+                    ma, md = _compute_matlab_result(data, wavelet, mmode, mlab)
+                    _check_accuracy(data, w, pmode, ma, md, wavelet, epsilon)
                     ma, md = _load_matlab_result_pywt_coeffs(data, wavelet, mmode)
-                    yield _check_accuracy, data, w, pmode, ma, md, wavelet, epsilon_pywt_coeffs
+                    _check_accuracy(data, w, pmode, ma, md, wavelet, epsilon_pywt_coeffs)
 
     finally:
         mlab.stop()
@@ -83,12 +83,12 @@ def test_accuracy_precomputed():
             data = rstate.randn(N)
             for pmode, mmode in modes:
                 ma, md = _load_matlab_result(data, wavelet, mmode)
-                yield _check_accuracy, data, w, pmode, ma, md, wavelet, epsilon
+                _check_accuracy(data, w, pmode, ma, md, wavelet, epsilon)
                 ma, md = _load_matlab_result_pywt_coeffs(data, wavelet, mmode)
-                yield _check_accuracy, data, w, pmode, ma, md, wavelet, epsilon_pywt_coeffs
+                _check_accuracy(data, w, pmode, ma, md, wavelet, epsilon_pywt_coeffs)
 
 
-def _compute_matlab_result(data, wavelet, mmode):
+def _compute_matlab_result(data, wavelet, mmode, mlab):
     """ Compute the result using MATLAB.
 
     This function assumes that the Matlab variables `wavelet` and `data` have

--- a/pywt/tests/test_matlab_compatibility_cwt.py
+++ b/pywt/tests/test_matlab_compatibility_cwt.py
@@ -6,35 +6,13 @@ accuracy against MathWorks Wavelet Toolbox.
 from __future__ import division, print_function, absolute_import
 
 import warnings
-import os
 import numpy as np
-from numpy.testing import assert_, dec, run_module_suite
+import pytest
+from numpy.testing import assert_
 
 import pywt
-
-if 'PYWT_XSLOW' in os.environ:
-    # Run a more comprehensive set of problem sizes.  This could take more than
-    # an hour to complete.
-    size_set = 'full'
-    use_precomputed = False
-else:
-    size_set = 'reduced'
-    use_precomputed = True
-
-if use_precomputed:
-    data_dir = os.path.join(os.path.dirname(__file__), 'data')
-    matlab_data_file = os.path.join(data_dir, 'cwt_matlabR2015b_result.npz')
-    matlab_result_dict = np.load(matlab_data_file)
-else:
-    try:
-        from pymatbridge import Matlab
-        mlab = Matlab()
-        _matlab_missing = False
-    except ImportError:
-        print("To run Matlab compatibility tests you need to have MathWorks "
-              "MATLAB, MathWorks Wavelet Toolbox and the pymatbridge Python "
-              "package installed.")
-        _matlab_missing = True
+from pywt._pytest import (uses_pymatbridge, uses_precomputed, size_set,
+                          matlab_result_dict_cwt)
 
 families = ('gaus', 'mexh', 'morl', 'cgau', 'shan', 'fbsp', 'cmor')
 wavelets = sum([pywt.wavelist(name) for name in families], [])
@@ -53,15 +31,16 @@ def _get_data_sizes(w):
 def _get_scales(w):
     """ Return the scales to test for wavelet w. """
     if size_set == 'full':
-        Scales = (1,np.arange(1,3),np.arange(1,4),np.arange(1,5))
+        scales = (1, np.arange(1, 3), np.arange(1, 4), np.arange(1, 5))
     else:
-        Scales = (1,np.arange(1,3))
-    return Scales
+        scales = (1, np.arange(1, 3))
+    return scales
 
 
-@dec.skipif(use_precomputed or _matlab_missing)
-@dec.slow
+@uses_pymatbridge  # skip this case if precomputed results are used instead
+@pytest.mark.slow
 def test_accuracy_pymatbridge_cwt():
+    mlab = pytest.importorskip("pymatbridge.Matlab")
     rstate = np.random.RandomState(1234)
     # max RMSE (was 1.0e-10, is reduced to 5.0e-5 due to different coefficents)
     epsilon = 1e-15
@@ -93,8 +72,8 @@ def test_accuracy_pymatbridge_cwt():
         mlab.stop()
 
 
-@dec.skipif(not use_precomputed)
-@dec.slow
+@uses_precomputed  # skip this case if pymatbridge + Matlab are being used
+@pytest.mark.slow
 def test_accuracy_precomputed_cwt():
     # Keep this specific random seed to match the precomputed Matlab result.
     rstate = np.random.RandomState(1234)
@@ -143,11 +122,11 @@ def _load_matlab_result(data, wavelet, scales):
     """
     N = len(data)
     coefs_key = '_'.join([str(scales), wavelet, str(N), 'coefs'])
-    if (coefs_key not in matlab_result_dict):
+    if (coefs_key not in matlab_result_dict_cwt):
         raise KeyError(
             "Precompted Matlab result not found for wavelet: "
             "{0}, mode: {1}, size: {2}".format(wavelet, scales, N))
-    coefs = matlab_result_dict[coefs_key]
+    coefs = matlab_result_dict_cwt[coefs_key]
     return coefs
 
 
@@ -155,11 +134,11 @@ def _load_matlab_result_psi(wavelet):
     """ Load the precomputed result.
     """
     psi_key = '_'.join([wavelet, 'psi'])
-    if (psi_key not in matlab_result_dict):
+    if (psi_key not in matlab_result_dict_cwt):
         raise KeyError(
             "Precompted Matlab psi result not found for wavelet: "
             "{0}}".format(wavelet))
-    psi = matlab_result_dict[psi_key]
+    psi = matlab_result_dict_cwt[psi_key]
     return psi
 
 
@@ -187,6 +166,3 @@ def _check_accuracy_psi(w, psi, wavelet, epsilon):
     msg = ('[RMS > EPSILON] for  Wavelet: %s, '
            'rms=%.3g' % (wavelet, rms))
     assert_(rms < epsilon, msg=msg)
-
-if __name__ == '__main__':
-    run_module_suite()

--- a/pywt/tests/test_modes.py
+++ b/pywt/tests/test_modes.py
@@ -2,8 +2,7 @@
 from __future__ import division, print_function, absolute_import
 
 import numpy as np
-from numpy.testing import (assert_raises, run_module_suite,
-                           assert_equal, assert_allclose)
+from numpy.testing import assert_raises, assert_equal, assert_allclose
 
 import pywt
 
@@ -108,7 +107,3 @@ def test_default_mode():
     assert_allclose(cA, cA2)
     assert_allclose(cD, cD2)
     assert_allclose(pywt.idwt(cA, cD, 'db2'), x)
-
-
-if __name__ == '__main__':
-    run_module_suite()

--- a/pywt/tests/test_multidim.py
+++ b/pywt/tests/test_multidim.py
@@ -4,8 +4,7 @@ from __future__ import division, print_function, absolute_import
 
 import numpy as np
 from itertools import combinations
-from numpy.testing import (run_module_suite, assert_allclose, assert_,
-                           assert_raises, assert_equal)
+from numpy.testing import assert_allclose, assert_, assert_raises, assert_equal
 
 import pywt
 # Check that float32, float64, complex64, complex128 are preserved.
@@ -442,7 +441,3 @@ def test_error_on_continuous_wavelet():
 
             c = dec_fun(data, 'db1')
             assert_raises(ValueError, rec_fun, c, wavelet=cwave)
-
-
-if __name__ == '__main__':
-    run_module_suite()

--- a/pywt/tests/test_multilevel.py
+++ b/pywt/tests/test_multilevel.py
@@ -5,9 +5,9 @@ from __future__ import division, print_function, absolute_import
 import warnings
 from itertools import combinations
 import numpy as np
-from numpy.testing import (run_module_suite, assert_almost_equal,
-                           assert_allclose, assert_, assert_equal,
-                           assert_raises, assert_raises_regex, dec,
+import pytest
+from numpy.testing import (assert_almost_equal, assert_allclose, assert_,
+                           assert_equal, assert_raises, assert_raises_regex,
                            assert_array_equal, assert_warns)
 import pywt
 # Check that float32, float64, complex64, complex128 are preserved.
@@ -176,7 +176,7 @@ def test_multilevel_dtypes_2d():
         assert_(x_roundtrip.dtype == dt_out, "waverec2: " + errmsg)
 
 
-@dec.slow
+@pytest.mark.slow
 def test_waverec2_all_wavelets_modes():
     # test 2D case using all wavelets and modes
     rstate = np.random.RandomState(1234)
@@ -363,7 +363,7 @@ def test_waverecn_dtypes():
         assert_allclose(pywt.waverecn(coeffs, 'db1'), x, atol=tol, rtol=tol)
 
 
-@dec.slow
+@pytest.mark.slow
 def test_waverecn_all_wavelets_modes():
     # test 2D case using all wavelets and modes
     rstate = np.random.RandomState(1234)
@@ -1013,7 +1013,3 @@ def test_waverec_mixed_precision():
         r = ifunc(coeffs, 'db1')
         assert_allclose(r, x, rtol=1e-7, atol=1e-7)
         assert_equal(r.dtype, np.complex128)
-
-
-if __name__ == '__main__':
-    run_module_suite()

--- a/pywt/tests/test_perfect_reconstruction.py
+++ b/pywt/tests/test_perfect_reconstruction.py
@@ -28,7 +28,7 @@ def test_perfect_reconstruction():
     for wavelet in wavelets:
         for pmode, mmode in modes:
             for dt in dtypes:
-                yield check_reconstruction, pmode, mmode, wavelet, dt
+                check_reconstruction(pmode, mmode, wavelet, dt)
 
 
 def check_reconstruction(pmode, mmode, wavelet, dtype):

--- a/pywt/tests/test_perfect_reconstruction.py
+++ b/pywt/tests/test_perfect_reconstruction.py
@@ -7,7 +7,7 @@ Verify DWT perfect reconstruction.
 from __future__ import division, print_function, absolute_import
 
 import numpy as np
-from numpy.testing import assert_, run_module_suite
+from numpy.testing import assert_
 
 import pywt
 
@@ -59,7 +59,3 @@ def check_reconstruction(pmode, mmode, wavelet, dtype):
         msg = ('[RMS_REC > EPSILON] for Mode: %s, Wavelet: %s, '
                'Length: %d, rms=%.3g' % (pmode, wavelet, len(data), rms_rec))
         assert_(rms_rec < epsilon, msg=msg)
-
-
-if __name__ == '__main__':
-    run_module_suite()

--- a/pywt/tests/test_swt.py
+++ b/pywt/tests/test_swt.py
@@ -6,9 +6,9 @@ import warnings
 from copy import deepcopy
 from itertools import combinations, permutations
 import numpy as np
-from numpy.testing import (run_module_suite, dec, assert_allclose, assert_,
-                           assert_equal, assert_raises, assert_array_equal,
-                           assert_warns)
+import pytest
+from numpy.testing import (assert_allclose, assert_, assert_equal,
+                           assert_raises, assert_array_equal, assert_warns)
 
 import pywt
 from pywt._extensions._swt import swt_axis
@@ -210,7 +210,7 @@ def test_swt2_ndim_error():
         assert_raises(ValueError, pywt.swt2, x, 'haar', level=1)
 
 
-@dec.slow
+@pytest.mark.slow
 def test_swt2_iswt2_integration(wavelets=None):
     # This function performs a round-trip swt2/iswt2 transform test on
     # all available types of wavelets in PyWavelets - except the
@@ -325,7 +325,7 @@ def test_swtn_axes():
                   start_level=0, axis=0)
 
 
-@dec.slow
+@pytest.mark.slow
 def test_swtn_iswtn_integration(wavelets=None):
     # This function performs a round-trip swtn/iswtn transform for various
     # possible combinations of:
@@ -525,7 +525,3 @@ def test_iswtn_mixed_dtypes():
         y = pywt.iswtn(coeffs, wav)
         assert_equal(output_dtype, y.dtype)
         assert_allclose(y, x, rtol=1e-3, atol=1e-3)
-
-
-if __name__ == '__main__':
-    run_module_suite()

--- a/pywt/tests/test_thresholding.py
+++ b/pywt/tests/test_thresholding.py
@@ -1,7 +1,6 @@
 from __future__ import division, print_function, absolute_import
 import numpy as np
-from numpy.testing import (assert_allclose, run_module_suite, assert_raises,
-                           assert_, assert_equal)
+from numpy.testing import assert_allclose, assert_raises, assert_, assert_equal
 
 import pywt
 
@@ -168,7 +167,3 @@ def test_threshold_firm():
         mt_abs_firm = np.abs(d_firm[mt])
         assert_(np.all(mt_abs_firm < np.abs(d_hard[mt])))
         assert_(np.all(mt_abs_firm > np.abs(d_soft[mt])))
-
-
-if __name__ == '__main__':
-    run_module_suite()

--- a/pywt/tests/test_wavelet.py
+++ b/pywt/tests/test_wavelet.py
@@ -54,11 +54,11 @@ def test_wavelet_coefficients():
     wavelets = sum([pywt.wavelist(name) for name in families], [])
     for wavelet in wavelets:
         if (pywt.Wavelet(wavelet).orthogonal):
-            yield check_coefficients_orthogonal, wavelet
+            check_coefficients_orthogonal(wavelet)
         elif(pywt.Wavelet(wavelet).biorthogonal):
-            yield check_coefficients_biorthogonal, wavelet
+            check_coefficients_biorthogonal(wavelet)
         else:
-            yield check_coefficients, wavelet
+            check_coefficients(wavelet)
 
 
 def check_coefficients_orthogonal(wavelet):

--- a/pywt/tests/test_wavelet.py
+++ b/pywt/tests/test_wavelet.py
@@ -2,7 +2,7 @@
 from __future__ import division, print_function, absolute_import
 
 import numpy as np
-from numpy.testing import run_module_suite, assert_allclose, assert_
+from numpy.testing import assert_allclose, assert_
 
 import pywt
 
@@ -264,7 +264,3 @@ def test_wavefun_bior13():
     assert_allclose(phi_r, phi_r_expect, rtol=1e-10, atol=1e-12)
     assert_allclose(psi_d, psi_d_expect, rtol=1e-10, atol=1e-12)
     assert_allclose(psi_r, psi_r_expect, rtol=1e-10, atol=1e-12)
-
-
-if __name__ == '__main__':
-    run_module_suite()

--- a/pywt/tests/test_wp.py
+++ b/pywt/tests/test_wp.py
@@ -3,8 +3,8 @@
 from __future__ import division, print_function, absolute_import
 
 import numpy as np
-from numpy.testing import (run_module_suite, assert_allclose, assert_,
-                           assert_raises, assert_equal)
+from numpy.testing import (assert_allclose, assert_, assert_raises,
+                           assert_equal)
 
 import pywt
 
@@ -195,7 +195,3 @@ def test_db3_roundtrip():
                             maxlevel=3)
     r = wp.reconstruct()
     assert_allclose(original, r, atol=1e-12, rtol=1e-12)
-
-
-if __name__ == '__main__':
-    run_module_suite()

--- a/pywt/tests/test_wp2d.py
+++ b/pywt/tests/test_wp2d.py
@@ -3,8 +3,8 @@
 from __future__ import division, print_function, absolute_import
 
 import numpy as np
-from numpy.testing import (run_module_suite, assert_allclose, assert_,
-                           assert_raises, assert_equal)
+from numpy.testing import (assert_allclose, assert_, assert_raises,
+                           assert_equal)
 
 import pywt
 
@@ -175,7 +175,3 @@ def test_2d_roundtrip():
                               maxlevel=3)
     r = wp.reconstruct()
     assert_allclose(original, r, atol=1e-12, rtol=1e-12)
-
-
-if __name__ == '__main__':
-    run_module_suite()

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,0 @@
-[nosetests]
-with-coverage = true
-with-doctest = true
-# Don't ignore files starting with '_'
-ignore-files = (?:^\.|^util)

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ from distutils.sysconfig import get_python_inc
 
 import setuptools
 from setuptools import setup, Extension
-
+from setuptools.command.test import test as TestCommand
 
 MAJOR = 1
 MINOR = 1
@@ -360,6 +360,24 @@ def parse_setuppy_commands():
     return True
 
 
+class PyTest(TestCommand):
+    user_options = [('pytest-args=', 'a', "Arguments to pass to py.test")]
+
+    def initialize_options(self):
+        TestCommand.initialize_options(self)
+        self.pytest_args = []
+
+    def finalize_options(self):
+        TestCommand.finalize_options(self)
+        self.test_args = []
+        self.test_suite = True
+
+    def run_tests(self):
+        #import here, cause outside the eggs aren't loaded
+        import pytest
+        errno = pytest.main(self.pytest_args)
+        sys.exit(errno)
+
 
 def setup_package():
     # Rewrite the version file everytime
@@ -410,8 +428,8 @@ def setup_package():
                       'pywt': ['tests/*.py', 'tests/data/*.npz',
                                'tests/data/*.py']},
         libraries=[c_lib],
-        cmdclass={'develop': develop_build_clib},
-        test_suite='nose.collector',
+        cmdclass={'develop': develop_build_clib, 'test': PyTest},
+        tests_require=['pytest'],
 
         install_requires=["numpy>=1.13.3"],
         setup_requires=["numpy>=1.13.3"],

--- a/tox.ini
+++ b/tox.ini
@@ -25,14 +25,14 @@ envlist = py35, py36, py37
 [testenv]
 deps =
     flake8
-    nose
+    pytest
     coverage
     cython
     numpy
     matplotlib
 changedir = {envdir}
 commands =
-    nosetests --tests {toxinidir}/pywt/tests
+    pytest {toxinidir}/pywt/tests -v
 # flake8 --exit-zero pywt
 
 [pep8]

--- a/util/readthedocs/requirements.txt
+++ b/util/readthedocs/requirements.txt
@@ -1,6 +1,6 @@
 numpy
 cython
-nose
+pytest
 wheel
 numpydoc
 matplotlib


### PR DESCRIPTION
This PR switches from `nose` to `pytest` as requested in #389, but has not tried to refactor any of the tests. Many tests could probably benefit from use of the `parametrize` decorator, for instance, although that could be left to a follow-up PR.

Some common code from `test_matlab_compatibility.py` and `test_matlab_compatibility_cwt.py` and code checking availability of `futures` was factored out into a common file `_pytest.py`, but otherwise the actual changes to the tests are pretty minimal.

There are a few remaining things to be resolved:

1.) Do we need to remove the ability to run tests via `pywt.test()` or is there a way to maintain that without requiring `nose`? It is still present currently, but uses `nose` indirectly via NumPy and there are a couple of failures now when running the test this way because skips related to optional dependency `pymatbridge` were not respected.

2.) I'm not sure yet if code coverage is working correctly after these changes.

3.) I haven't tested running the pymatbridge-based tests via `PYWT_XSLOW` yet.

closes #389
