### PR TITLE
update the pad utility function and make it part of the public API

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -36,6 +36,7 @@ except TypeError:
 extensions = ['sphinx.ext.doctest', 'sphinx.ext.autodoc', 'sphinx.ext.todo',
               'sphinx.ext.extlinks', 'sphinx.ext.mathjax',
               'sphinx.ext.autosummary', 'numpydoc',
+              'sphinx.ext.intersphinx',
               'matplotlib.sphinxext.plot_directive']
 
 # Add any paths that contain templates here, relative to this directory.
@@ -224,3 +225,9 @@ plot_include_source = True
 plot_formats = [('png', 96), 'pdf']
 plot_html_show_formats = False
 plot_html_show_source_link = False
+
+# -- Options for intersphinx extension ---------------------------------------
+
+# Intersphinx to get Numpy and other targets
+intersphinx_mapping = {
+    'numpy': ('https://docs.scipy.org/doc/numpy/', None)}

--- a/doc/source/pyplots/plot_boundary_modes.py
+++ b/doc/source/pyplots/plot_boundary_modes.py
@@ -5,7 +5,7 @@ the behavior of the various boundary modes.
 
 In practice, which signal extension mode is beneficial will depend on the
 signal characteristics.  For this particular signal, some modes such as
-"periodic",  "antisymmetric" and "zeros" result in large discontinuities that
+"periodic",  "antisymmetric" and "zero" result in large discontinuities that
 would lead to large amplitude boundary coefficients in the detail coefficients
 of a discrete wavelet transform.
 """
@@ -28,5 +28,5 @@ boundary_mode_subplot(x, 'antireflect', axes[4], symw=True)
 boundary_mode_subplot(x, 'periodization', axes[5], symw=False)
 boundary_mode_subplot(x, 'smooth', axes[6], symw=False)
 boundary_mode_subplot(x, 'constant', axes[7], symw=False)
-boundary_mode_subplot(x, 'zeros', axes[8], symw=False)
+boundary_mode_subplot(x, 'zero', axes[8], symw=False)
 plt.show()

--- a/doc/source/ref/signal-extension-modes.rst
+++ b/doc/source/ref/signal-extension-modes.rst
@@ -136,3 +136,15 @@ periodization      per           N/A
 antisymmetric      asym, asymh   N/A
 antireflect        asymw         reflect, reflect_type='odd'
 ================== ============= ===========================
+
+Padding using PyWavelets Signal Extension Modes - ``pad``
+---------------------------------------------------------
+
+.. autofunction:: pad
+
+Pywavelets provides a function, :func:`pad`, that operate like
+:func:`numpy.pad`, but supporting the PyWavelets signal extension modes
+discussed above. For efficiency, the DWT routines in PyWavelets do not
+expclitly create padded signals using this function. It can be used to manually
+prepad signals to reduce boundary effects in functions such as :func:`cwt` and
+:func:`swt` that do not currently support all of these signal extension modes.

--- a/pywt/_doc_utils.py
+++ b/pywt/_doc_utils.py
@@ -4,8 +4,10 @@ from itertools import product
 import numpy as np
 from matplotlib import pyplot as plt
 
+from ._dwt import pad
+
 __all__ = ['wavedec_keys', 'wavedec2_keys', 'draw_2d_wp_basis',
-           'draw_2d_fswavedecn_basis', 'pad', 'boundary_mode_subplot']
+           'draw_2d_fswavedecn_basis', 'boundary_mode_subplot']
 
 
 def wavedec_keys(level):
@@ -147,63 +149,6 @@ def draw_2d_fswavedecn_basis(shape, levels, fmt='k', plot_kwargs={}, ax=None,
                         horizontalalignment='center',
                         verticalalignment='center')
     return fig, ax
-
-
-def pad(x, pad_widths, mode):
-    """Extend a 1D signal using a given boundary mode.
-
-    Like numpy.pad but supports all PyWavelets boundary modes.
-    """
-    if np.isscalar(pad_widths):
-        pad_widths = (pad_widths, pad_widths)
-
-    if x.ndim > 1:
-        raise ValueError("This padding function is only for 1D signals.")
-
-    if mode in ['symmetric', 'reflect']:
-        xp = np.pad(x, pad_widths, mode=mode)
-    elif mode in ['periodic', 'periodization']:
-        if mode == 'periodization' and x.size % 2 == 1:
-            raise ValueError("periodization expects an even length signal.")
-        xp = np.pad(x, pad_widths, mode='wrap')
-    elif mode == 'zeros':
-        xp = np.pad(x, pad_widths, mode='constant', constant_values=0)
-    elif mode == 'constant':
-        xp = np.pad(x, pad_widths, mode='edge')
-    elif mode == 'smooth':
-        xp = np.pad(x, pad_widths, mode='linear_ramp',
-                    end_values=(x[0] + pad_widths[0] * (x[0] - x[1]),
-                                x[-1] + pad_widths[1] * (x[-1] - x[-2])))
-    elif mode == 'antisymmetric':
-        # implement by flipping portions symmetric padding
-        npad_l, npad_r = pad_widths
-        xp = np.pad(x, pad_widths, mode='symmetric')
-        r_edge = npad_l + x.size - 1
-        l_edge = npad_l
-        # width of each reflected segment
-        seg_width = x.size
-        # flip reflected segments on the right of the original signal
-        n = 1
-        while r_edge <= xp.size:
-            segment_slice = slice(r_edge + 1,
-                                  min(r_edge + 1 + seg_width, xp.size))
-            if n % 2:
-                xp[segment_slice] *= -1
-            r_edge += seg_width
-            n += 1
-
-        # flip reflected segments on the left of the original signal
-        n = 1
-        while l_edge >= 0:
-            segment_slice = slice(max(0, l_edge - seg_width), l_edge)
-            if n % 2:
-                xp[segment_slice] *= -1
-            l_edge -= seg_width
-            n += 1
-    elif mode == 'antireflect':
-        npad_l, npad_r = pad_widths
-        xp = np.pad(x, pad_widths, mode='reflect', reflect_type='odd')
-    return xp
 
 
 def boundary_mode_subplot(x, mode, ax, symw=True):

--- a/pywt/_doc_utils.py
+++ b/pywt/_doc_utils.py
@@ -181,7 +181,7 @@ def boundary_mode_subplot(x, mode, ax, symw=True):
         left -= 0.5
         step = len(x)
         rng = range(-2, 4)
-    if mode in ['smooth', 'constant', 'zeros']:
+    if mode in ['smooth', 'constant', 'zero']:
         rng = range(0, 2)
     for rep in rng:
         ax.plot((left + rep * step) * o2, [xp.min() - .5, xp.max() + .5], 'k-')

--- a/pywt/_dwt.py
+++ b/pywt/_dwt.py
@@ -135,7 +135,6 @@ def dwt(data, wavelet, mode='symmetric', axis=-1):
         Axis over which to compute the DWT. If not given, the
         last axis is used.
 
-
     Returns
     -------
     (cA, cD) : tuple
@@ -210,7 +209,6 @@ def idwt(cA, cD, wavelet, mode='symmetric', axis=-1):
     axis: int, optional
         Axis over which to compute the inverse DWT. If not given, the
         last axis is used.
-
 
     Returns
     -------
@@ -406,7 +404,7 @@ def upcoef(part, coeffs, wavelet, level=1, take=0):
 def pad(x, pad_widths, mode):
     """Extend a 1D signal using a given boundary mode.
 
-    This function operates like `numpy.pad` but supports all signal extension
+    This function operates like ``numpy.pad`` but supports all signal extension
     modes that can be used by PyWavelets discrete wavelet transforms.
 
     Parameters
@@ -420,7 +418,7 @@ def pad(x, pad_widths, mode):
         axis. (pad,) or int is a shortcut for before = after = pad width for
         all axes.
     mode : str, optional
-        Signal extension mode, see Modes.
+        Signal extension mode, see :ref:`Modes <ref-modes>`.
 
     Returns
     -------
@@ -430,9 +428,9 @@ def pad(x, pad_widths, mode):
 
     Notes
     -----
-    The performance of padding in dimensions > 1 will be substantially slower
-    for modes `smooth` and `antisymmetric` as these modes are not supported in
-    an efficient manner by the underlying `numpy.pad` function.
+    The performance of padding in dimensions > 1 may be substantially slower
+    for modes ``smooth`` and ``antisymmetric`` as these modes are not supported
+    efficiently by the underlying ``numpy.pad`` function.
     """
     x = np.asanyarray(x)
 

--- a/pywt/_dwt.py
+++ b/pywt/_dwt.py
@@ -404,8 +404,8 @@ def upcoef(part, coeffs, wavelet, level=1, take=0):
 def pad(x, pad_widths, mode):
     """Extend a 1D signal using a given boundary mode.
 
-    This function operates like ``numpy.pad`` but supports all signal extension
-    modes that can be used by PyWavelets discrete wavelet transforms.
+    This function operates like :func:`numpy.pad` but supports all signal
+    extension modes that can be used by PyWavelets discrete wavelet transforms.
 
     Parameters
     ----------
@@ -413,10 +413,10 @@ def pad(x, pad_widths, mode):
         The array to pad
     pad_widths : {sequence, array_like, int}
         Number of values padded to the edges of each axis.
-        ((before_1, after_1), … (before_N, after_N)) unique pad widths for each
-        axis. ((before, after),) yields same before and after pad for each
-        axis. (pad,) or int is a shortcut for before = after = pad width for
-        all axes.
+        ``((before_1, after_1), … (before_N, after_N))`` unique pad widths for
+        each axis. ``((before, after),)`` yields same before and after pad for
+        each axis. ``(pad,)`` or int is a shortcut for
+        ``before = after = pad width`` for all axes.
     mode : str, optional
         Signal extension mode, see :ref:`Modes <ref-modes>`.
 
@@ -424,13 +424,17 @@ def pad(x, pad_widths, mode):
     -------
     pad : ndarray
         Padded array of rank equal to array with shape increased according to
-        `pad_width`.
+        ``pad_widths``.
 
     Notes
     -----
     The performance of padding in dimensions > 1 may be substantially slower
-    for modes ``smooth`` and ``antisymmetric`` as these modes are not supported
-    efficiently by the underlying ``numpy.pad`` function.
+    for modes ``'smooth'`` and ``'antisymmetric'`` as these modes are not
+    supported efficiently by the underlying :func:`numpy.pad` function.
+
+    Note that the behavior of the ``'constant'`` mode here follows the
+    PyWavelets convention which is different from NumPy (it is equivalent to
+    ``mode='edge'`` in :func:`numpy.pad`).
     """
     x = np.asanyarray(x)
 

--- a/pywt/_utils.py
+++ b/pywt/_utils.py
@@ -2,6 +2,7 @@
 #                    <https://github.com/PyWavelets/pywt>
 # See COPYING for license details.
 import inspect
+import numpy as np
 import sys
 from collections.abc import Iterable
 
@@ -17,7 +18,7 @@ else:
 
 
 def _as_wavelet(wavelet):
-    """Convert wavelet name to a Wavelet object"""
+    """Convert wavelet name to a Wavelet object."""
     if not isinstance(wavelet, (ContinuousWavelet, Wavelet)):
         wavelet = DiscreteContinuousWavelet(wavelet)
     if isinstance(wavelet, ContinuousWavelet):

--- a/pywt/tests/test_dwt_idwt.py
+++ b/pywt/tests/test_dwt_idwt.py
@@ -2,8 +2,8 @@
 from __future__ import division, print_function, absolute_import
 
 import numpy as np
-from numpy.testing import assert_allclose, assert_, assert_raises
-
+from numpy.testing import (assert_allclose, assert_, assert_raises,
+                           assert_array_equal)
 import pywt
 
 # Check that float32, float64, complex64, complex128 are preserved.
@@ -228,8 +228,72 @@ def test_error_on_continuous_wavelet():
 def test_dwt_zero_size_axes():
     # raise on empty input array
     assert_raises(ValueError, pywt.dwt, [], 'db2')
-  
+
     # >1D case uses a different code path so check there as well
     x = np.ones((1, 4))[0:0, :]  # 2D with a size zero axis
     assert_raises(ValueError, pywt.dwt, x, 'db2', axis=0)
 
+
+def test_pad_1d():
+    x = [1, 2, 3]
+    assert_array_equal(pywt.pad(x, (4, 6), 'periodization'),
+                       [1, 2, 3, 3, 1, 2, 3, 3, 1, 2, 3, 3, 1, 2])
+    assert_array_equal(pywt.pad(x, (4, 6), 'periodic'),
+                       [3, 1, 2, 3, 1, 2, 3, 1, 2, 3, 1, 2, 3])
+    assert_array_equal(pywt.pad(x, (4, 6), 'constant'),
+                       [1, 1, 1, 1, 1, 2, 3, 3, 3, 3, 3, 3, 3])
+    assert_array_equal(pywt.pad(x, (4, 6), 'zero'),
+                       [0, 0, 0, 0, 1, 2, 3, 0, 0, 0, 0, 0, 0])
+    assert_array_equal(pywt.pad(x, (4, 6), 'smooth'),
+                       [-3, -2, -1, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
+    assert_array_equal(pywt.pad(x, (4, 6), 'symmetric'),
+                       [3, 3, 2, 1, 1, 2, 3, 3, 2, 1, 1, 2, 3])
+    assert_array_equal(pywt.pad(x, (4, 6), 'antisymmetric'),
+                       [3, -3, -2, -1, 1, 2, 3, -3, -2, -1, 1, 2, 3])
+    assert_array_equal(pywt.pad(x, (4, 6), 'reflect'),
+                       [1, 2, 3, 2, 1, 2, 3, 2, 1, 2, 3, 2, 1])
+    assert_array_equal(pywt.pad(x, (4, 6), 'antireflect'),
+                       [-3, -2, -1, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
+
+    # equivalence of various pad_width formats
+    assert_array_equal(pywt.pad(x, 4, 'periodic'),
+                       pywt.pad(x, (4, 4), 'periodic'))
+
+    assert_array_equal(pywt.pad(x, (4, ), 'periodic'),
+                       pywt.pad(x, (4, 4), 'periodic'))
+
+    assert_array_equal(pywt.pad(x, [(4, 4)], 'periodic'),
+                       pywt.pad(x, (4, 4), 'periodic'))
+
+
+def test_pad_errors():
+    # negative pad width
+    x = [1, 2, 3]
+    assert_raises(ValueError, pywt.pad, x, -2, 'periodic')
+
+    # wrong length pad width
+    assert_raises(ValueError, pywt.pad, x, (1, 1, 1), 'periodic')
+
+    # invalid mode name
+    assert_raises(ValueError, pywt.pad, x, 2, 'bad_mode')
+
+
+def test_pad_nd():
+    for ndim in [2, 3]:
+        x = np.arange(4**ndim).reshape((4, ) * ndim)
+        if ndim == 2:
+            pad_widths = [(2, 1), (2, 3)]
+        else:
+            pad_widths = [(2, 1), ] * ndim
+        for mode in pywt.Modes.modes:
+            xp = pywt.pad(x, pad_widths, mode)
+
+            # expected result is the same as applying along axes separably
+            xp_expected = x.copy()
+            for ax in range(ndim):
+                xp_expected = np.apply_along_axis(pywt.pad,
+                                                  ax,
+                                                  xp_expected,
+                                                  pad_widths=[pad_widths[ax]],
+                                                  mode=mode)
+            assert_array_equal(xp, xp_expected)


### PR DESCRIPTION
This PR moves `pad` from `_doc_utils.py` to `_dwt.py` and adds it to the top-level API (as `pywt.pad`). I chose `_dwt.py` because the DWT-based functions are the ones that currently use this type of boundary handling, but it could just as well go into `_utils.py` or elsewhere.

The function was updated to have n-dimensional support and handle `pad_widths` in a manner consistent with NumPy .

The handling of pad_widths is based on inspection of [numpy.lib.arraypad._as_pairs](https://github.com/numpy/numpy/blob/d89c4c7e7850578e5ee61e3e09abd86318906975/numpy/lib/arraypad.py#L889). Because it is not part of the public numpy API, I thought it was best to just replicate the behavior locally.

closes #473
