### PR TITLE
remove zenodo reference from the main text per JOSS editor request

### DIFF
--- a/doc/paper/paper.bib
+++ b/doc/paper/paper.bib
@@ -1,40 +1,4 @@
 
-@Misc{pywavelets_zenodo,
-  author       = {Gregory R. Lee and
-                  Ralf Gommers and
-                  Kai Wohlfahrt and
-                  Filip Wasilewski and
-                  Aaron O'Leary and
-                  Holger Nahrstaedt and
-                  David Menéndez Hurtado and
-                  Thomas Arildsen and
-                  Helder Oliveira and
-                  Ankit Agrawal and
-                  Sylvain Lannuzel and
-                  Michel Pelletier and
-                  Matthew Brett and
-                  Frank Yu and
-                  Daniel M. Pelt and
-                  Saket Choudhary and
-                  Daniele Tricoli and
-                  Alexandre Saint and
-                  Mike DePalatis and
-                  Michael Marino and
-                  Mark Harfouche and
-                  Jonathan Dan and
-                  John Kirkham and
-                  Jacopo Antonello and
-                  Dawid Laszuk and
-                  Daniel Goertzen and
-                  Balint Reczey and
-                  0-tree},
-  title        = {PyWavelets/pywt: PyWavelets v1.0.0},
-  month        = aug,
-  year         = 2018,
-  doi          = {10.5281/zenodo.1407172},
-  url          = {https://doi.org/10.5281/zenodo.1407172}
-}
-TODO: determine real name for 0-tree
 
 @Book{mallat2008wavelet,
   title = {A wavelet tour of signal processing: the sparse way},

--- a/doc/paper/paper.md
+++ b/doc/paper/paper.md
@@ -85,8 +85,7 @@ transform like the standard discrete wavelet transform.
 
 A number of common 1D demo signals used in the literature and in the manuscript
 by Stephan Mallat [-@mallat2008wavelet] are provided for use in teaching and for
-purposes of reproducible research. The source code for ``PyWavelets`` has been
-archived to Zenodo with the linked DOI: [@pywavelets_zenodo].
+purposes of reproducible research.
 
 # Acknowledgements
 


### PR DESCRIPTION
I think this should be the last modification for the JOSS review:
https://github.com/openjournals/joss-reviews/issues/1237

@rgommers:
I think I have to create a new tag to match the JOSS version reviewed so there will be a matching Zenodo DOI.

I think we should probably just backport the paper text to the 1.0.x branch and make a new 1.0.3 release there so that can serve as the version reviewed. 

Currently the `paper.md/paper.bib` are only in the master branch, but I don't think we really have anything much new from a user standpoint to justify a new release from master. I think the main new things in master are just dropping Python 2.x support and the switch to pytest.

