### PR TITLE
MAINT: add a .mailmap file for git

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -4,8 +4,9 @@ Daniel M. Pelt <d.m.pelt@cwi.nl> Daniel M Pelt <dmpelt@lbl.gov>
 Gregory R. Lee <grlee77@gmail.com> Gregory R. Lee <gregory.lee@cchmc.org>
 Gregory R. Lee <grlee77@gmail.com> Gregory Lee <grlee77@gmail.com>
 Holger Nahrstaedt <holgernahrstaedt@gmx.de> Holger Nahrstaedt <holgern@users.noreply.github.com>
-Kai Wohlfahrt <kai.scorpio@gmail.com> <kjw53@cam.ac.uk>
-Kai Wohlfahrt <kai.scorpio@gmail.com> Kai <kai.scorpio@gmail.com>
+Kai Wohlfahrt <kai.wohlfahrt@gmail.com> <kai.scorpio@gmail.com>
+Kai Wohlfahrt <kai.wohlfahrt@gmail.com> <kjw53@cam.ac.uk>
+Kai Wohlfahrt <kai.wohlfahrt@gmail.com> Kai <kai.scorpio@gmail.com>
 Ralf Gommers <ralf.gommers@gmail.com> <ralf.gommers@googlemail.com>
 Sylvain Lannuzel <sylvain.lannuzel@student.ecp.fr> SylvainLan <sylvain.lannuzel@student.ecp.fr>
 Helder Oliveira <heldercro@gmail.com> Helder <heldercro@gmail.com>

--- a/.mailmap
+++ b/.mailmap
@@ -1,12 +1,13 @@
 Aaron O'Leary <aaron.oleary@gmail.com> <eeaol@leeds.ac.uk>
 Alexandre Saint <snt.alex@gmail.com> asnt <snt.alex@gmail.com>
+Arthur Roullier <36152494+0-tree@users.noreply.github.com> 0-tree <36152494+0-tree@users.noreply.github.com>
 Daniel M. Pelt <d.m.pelt@cwi.nl> Daniel M Pelt <dmpelt@lbl.gov>
 Gregory R. Lee <grlee77@gmail.com> Gregory R. Lee <gregory.lee@cchmc.org>
 Gregory R. Lee <grlee77@gmail.com> Gregory Lee <grlee77@gmail.com>
+Helder Oliveira <heldercro@gmail.com> Helder <heldercro@gmail.com>
 Holger Nahrstaedt <holgernahrstaedt@gmx.de> Holger Nahrstaedt <holgern@users.noreply.github.com>
 Kai Wohlfahrt <kai.wohlfahrt@gmail.com> <kai.scorpio@gmail.com>
 Kai Wohlfahrt <kai.wohlfahrt@gmail.com> <kjw53@cam.ac.uk>
 Kai Wohlfahrt <kai.wohlfahrt@gmail.com> Kai <kai.scorpio@gmail.com>
 Ralf Gommers <ralf.gommers@gmail.com> <ralf.gommers@googlemail.com>
 Sylvain Lannuzel <sylvain.lannuzel@student.ecp.fr> SylvainLan <sylvain.lannuzel@student.ecp.fr>
-Helder Oliveira <heldercro@gmail.com> Helder <heldercro@gmail.com>

--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,11 @@
+Aaron O'Leary <aaron.oleary@gmail.com> <eeaol@leeds.ac.uk>
+Alexandre Saint <snt.alex@gmail.com> asnt <snt.alex@gmail.com>
+Daniel M. Pelt <d.m.pelt@cwi.nl> Daniel M Pelt <dmpelt@lbl.gov>
+Gregory R. Lee <grlee77@gmail.com> Gregory R. Lee <gregory.lee@cchmc.org>
+Gregory R. Lee <grlee77@gmail.com> Gregory Lee <grlee77@gmail.com>
+Holger Nahrstaedt <holgernahrstaedt@gmx.de> Holger Nahrstaedt <holgern@users.noreply.github.com>
+Kai Wohlfahrt <kai.scorpio@gmail.com> <kjw53@cam.ac.uk>
+Kai Wohlfahrt <kai.scorpio@gmail.com> Kai <kai.scorpio@gmail.com>
+Ralf Gommers <ralf.gommers@gmail.com> <ralf.gommers@googlemail.com>
+Sylvain Lannuzel <sylvain.lannuzel@student.ecp.fr> SylvainLan <sylvain.lannuzel@student.ecp.fr>
+Helder Oliveira <heldercro@gmail.com> Helder <heldercro@gmail.com>


### PR DESCRIPTION
This PR adds a git `.mailmap` file.

I only added the users who had:
1.) duplicate entries due to variant names and email addresses
2.) to resolve a GitHub ID to an actual name
Let me know if you think it should also have the remaining users without duplicate entries.

Visual inspection of the output of `git shortlog -sne` indicates that it seems to be working as expected locally. (The length of the shortlog decreases from 42 to 34 after this change and I don't see any more duplicates).

I'm not optimistic that adding this will fix the GitHub contributors page: some posts I read elsewhere indicated that GitHub itself doesn't use this file, but perhaps that could have changed in the meantime.

**Another case of missing data from GitHub's contributors page:**
@sciunto is actually the 7th highest contributor in number of commits (29) in the output of `git shortlog -sne` but doesn't show up on the contributors page on GitHub. I assume this is because the email address associated with the commits has spaces instead of `@` or `.` in it.  Assuming that was intentional, I didn't want to presume to add it here.  Please let me know if you would like it to be there.

@0-tree: As a past contributor here, please provide your real name if you would like your contribution to be credited using it.

