### PR TITLE
cwt with fft convolution support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,12 +19,15 @@ matrix:
         - CYTHONSPEC=cython
         - USE_WHEEL=1
     - os: linux
-      python: 3.7-dev
+      python: 3.7
+      dist: xenial # travis-ci/travis-ci/issues/9815
+      sudo: true
       env:
         - NUMPYSPEC=numpy
         - MATPLOTLIBSPEC=matplotlib
         - CYTHONSPEC=cython
         - USE_SDIST=1
+        - USE_SCIPY=1
     - os: linux
       python: 3.5
       env:
@@ -59,6 +62,7 @@ before_install:
   - pip install pytest pytest-cov coverage codecov futures
   - set -o pipefail
   - if [ "${USE_WHEEL}" == "1" ]; then pip install wheel; fi
+  - if [ "${USE_SCIPY}" == "1" ]; then pip install scipy; fi
   - |
     if [ "${REFGUIDE_CHECK}" == "1" ]; then
         pip install sphinx numpydoc

--- a/README.rst
+++ b/README.rst
@@ -65,9 +65,11 @@ For more usage examples see the `demo`_ directory in the source package.
 Installation
 ------------
 
-PyWavelets supports `Python`_ >=3.5, and is only dependent on `Numpy`_
+PyWavelets supports `Python`_ >=3.5, and is only dependent on `NumPy`_
 (supported versions are currently ``>= 1.13.3``). To pass all of the tests,
-`Matplotlib`_ is also required.
+`Matplotlib`_ is also required. `SciPy`_ is also an optional dependency. When
+present, FFT-based continuous wavelet transforms will use FFTs from SciPy
+rather than NumPy.
 
 There are binary wheels for Intel Linux, Windows and macOS / OSX on PyPi.  If
 you are on one of these platforms, you should get a binary (precompiled)
@@ -138,7 +140,8 @@ If you wish to cite PyWavelets in a publication, you may use the following DOI.
 .. _Anaconda: https://www.continuum.io
 .. _GitHub: https://github.com/PyWavelets/pywt
 .. _GitHub Issues: https://github.com/PyWavelets/pywt/issues
-.. _Numpy: http://www.numpy.org
+.. _NumPy: https://www.numpy.org
+.. _SciPy: https://www.scipy.org
 .. _original developer: http://en.ig.ma
 .. _Python: http://python.org/
 .. _Python Package Index: http://pypi.python.org/pypi/PyWavelets/

--- a/benchmarks/benchmarks/cwt_benchmarks.py
+++ b/benchmarks/benchmarks/cwt_benchmarks.py
@@ -6,12 +6,13 @@ class CwtTimeSuiteBase(object):
     """
     Set-up for CWT timing.
     """
-    params = ([32, 128, 512],
+    params = ([32, 128, 512, 2048],
               ['cmor', 'cgau4', 'fbsp', 'gaus4', 'mexh', 'morl', 'shan'],
-              [16, 64, 256])
-    param_names = ('n', 'wavelet', 'max_scale')
+              [16, 64, 256],
+              ['conv', 'fft'])
+    param_names = ('n', 'wavelet', 'max_scale', 'method')
 
-    def setup(self, n, wavelet, max_scale):
+    def setup(self, n, wavelet, max_scale, method):
         try:
             from pywt import cwt
         except ImportError:
@@ -21,5 +22,12 @@ class CwtTimeSuiteBase(object):
 
 
 class CwtTimeSuite(CwtTimeSuiteBase):
-    def time_cwt(self, n, wavelet, max_scale):
-        pywt.cwt(self.data, self.scales, wavelet)
+    def time_cwt(self, n, wavelet, max_scale, method):
+        try:
+            pywt.cwt(self.data, self.scales, wavelet, method=method)
+        except TypeError:
+            # older PyWavelets does not support use of the method argument
+            if method == 'fft':
+                raise NotImplementedError(
+                    "fft-based convolution not available.")
+            pywt.cwt(self.data, self.scales, wavelet)

--- a/doc/source/common_refs.rst
+++ b/doc/source/common_refs.rst
@@ -5,7 +5,8 @@
 .. _GitHub: https://github.com/PyWavelets/pywt
 .. _GitHub repository: https://github.com/PyWavelets/pywt
 .. _GitHub Issues: https://github.com/PyWavelets/pywt/issues
-.. _Numpy: http://www.numpy.org
+.. _NumPy: https://www.numpy.org
+.. _SciPy: https://www.scipy.org
 .. _original developer: http://en.ig.ma
 .. _Python: http://python.org/
 .. _Python Package Index: http://pypi.python.org/pypi/PyWavelets/

--- a/doc/source/install.rst
+++ b/doc/source/install.rst
@@ -39,11 +39,12 @@ PyWavelets source code directory (containing ``setup.py``) and type::
 The requirements needed to build from source are:
 
  - Python_ 2.7 or >=3.4
- - Numpy_ >= 1.13.3
+ - NumPy_ >= 1.13.3
  - Cython_ >= 0.23.5  (if installing from git, not from a PyPI source release)
 
 To run all the tests for PyWavelets, you will also need to install the
-Matplotlib_ package.
+Matplotlib_ package. If SciPy_ is available, FFT-based continuous wavelet
+transforms will use the FFT implementation from SciPy instead of NumPy.
 
 .. seealso::  :ref:`Development guide <dev-index>` section contains more
               information on building and installing from source code.

--- a/pywt/_cwt.py
+++ b/pywt/_cwt.py
@@ -16,8 +16,8 @@ except ImportError:
     # Do provide a fallback so scipy is an optional requirement
     def next_fast_len(n):
         """Given a number of samples `n`, returns the next power of two
-        following this numbe to take advantage of FFT speedup.
-        This fallback is less efficient as `scipy.fftpack.next_fast_len`
+        following this number to take advantage of FFT speedup.
+        This fallback is less efficient than `scipy.fftpack.next_fast_len`
         """
         return 2**ceil(np.log2(n))
 

--- a/pywt/_cwt.py
+++ b/pywt/_cwt.py
@@ -1,8 +1,12 @@
+from math import floor, ceil
+from scipy.fftpack import next_fast_len
+
 import numpy as np
 
 from ._extensions._pywt import (DiscreteContinuousWavelet, ContinuousWavelet,
                                 Wavelet, _check_dtype)
 from ._functions import integrate_wavelet, scale2frequency
+
 
 __all__ = ["cwt"]
 
@@ -29,15 +33,17 @@ def cwt(data, scales, wavelet, sampling_period=1., method='conv'):
         The values computed for ``coefs`` are independent of the choice of
         ``sampling_period`` (i.e. ``scales`` is not scaled by the sampling
         period).
-    method : convolution method name
-        Can be any of     
-            - ``conv`` uses only the ``numpyp.conv`` function
-            - ``fft`` uses frequency domain convolution with ``numpyp.fft.fft``
-        The ``conv`` method complexity is O(len(scale)*len(data)).
-        The ``fft`` method is O(N*log2(N)) with N=len(scale)+len(data)-1,
-        it is well suited for large size signals but slightly slower than 
-        ``conv`` on small ones.
-        
+    method : {'conv', 'fft'}, optional
+        The method used to compute the CWT. Can be any of:
+            - ``conv`` uses ``numpy.convolve``.
+            - ``fft`` uses frequency domain convolution via ``numpy.fft.fft``.
+            - ``auto`` uses automatic selection based on an estimate of the
+              computational complexity at each scale.
+        The ``conv`` method complexity is ``O(len(scale) * len(data))``.
+        The ``fft`` method is ``O(N * log2(N))`` with
+        ``N = len(scale) + len(data) - 1``. It is well suited for large size
+        signals but slightly slower than ``conv`` on small ones.
+
     Returns
     -------
     coefs : array_like
@@ -82,65 +88,60 @@ def cwt(data, scales, wavelet, sampling_period=1., method='conv'):
         wavelet = DiscreteContinuousWavelet(wavelet)
     if np.isscalar(scales):
         scales = np.array([scales])
-    dt_out = None  # currently keep the 1.0.2 behaviour: TODO fix in/out dtype consistency
+    dt_out = None  # TODO: fix in/out dtype consistency in a subsequent PR
     if data.ndim == 1:
         if wavelet.complex_cwt:
             dt_out = complex
-        out = np.zeros((np.size(scales), data.size), dtype=dt_out)
+        out = np.empty((np.size(scales), data.size), dtype=dt_out)
         precision = 10
         int_psi, x = integrate_wavelet(wavelet, precision=precision)
-        
+
         if method == 'fft':
-            # for FFT the buffer needs:
-            # - to be as large as the sum of data length and and maximum wavelet
-            #   support to avoid circular convolution effects
-            # - additional padding to reach a power of 2 for CPU-optimal FFT
-            size_pad = lambda s: 2**np.int(np.ceil(np.log2(s[0] + s[1])))
-            size_scale0 = size_pad( (len(data), 
-                                     np.take(scales, 0) * ((x[-1] - x[0]) + 1)) )
+            size_scale0 = -1
             fft_data = None
         elif not method == 'conv':
             raise ValueError("method must be 'conv' or 'fft'")
 
-        for i in np.arange(np.size(scales)):
+        for i, scale in enumerate(scales):
             step = x[1] - x[0]
-            j = np.floor(
-                np.arange(scales[i] * (x[-1] - x[0]) + 1) / (scales[i] * step))
-            if np.max(j) >= np.size(int_psi):
-                j = np.delete(j, np.where((j >= np.size(int_psi)))[0])
-            int_psi_scale = int_psi[j.astype(np.int)][::-1]
-               
+            j = np.arange(scale * (x[-1] - x[0]) + 1) / (scale * step)
+            j = j.astype(int)  # floor
+            if j[-1] >= int_psi.size:
+                j = np.extract(j < int_psi.size, j)
+            int_psi_scale = int_psi[j][::-1]
+
             if method == 'conv':
                 conv = np.convolve(data, int_psi_scale)
             else:
-                size_scale = size_pad( (len(data), len(int_psi_scale)) )
+                # the padding is selected for
+                # - optimal FFT complexity
+                # - to be larger than the two signals length to avoid circular
+                #   convolution
+                size_scale = next_fast_len(data.size + int_psi_scale.size - 1)
                 if size_scale != size_scale0:
                     # the fft of data changes when padding size changes thus
                     # it has to be recomputed
-                    fft_data = None
-                size_scale0 = size_scale
-                if fft_data is None:
                     fft_data = np.fft.fft(data, size_scale)
+                size_scale0 = size_scale
                 fft_wav = np.fft.fft(int_psi_scale, size_scale)
-                conv = np.fft.ifft(fft_wav*fft_data)
-                conv = conv[0:len(data)+len(int_psi_scale)-1]
-                
-            coef = - np.sqrt(scales[i]) * np.diff(conv)
+                conv = np.fft.ifft(fft_wav * fft_data)
+                conv = conv[:data.size + int_psi_scale.size - 1]
+
+            coef = - np.sqrt(scale) * np.diff(conv)
             if not np.iscomplexobj(out):
                 coef = np.real(coef)
             d = (coef.size - data.size) / 2.
             if d > 0:
-                out[i, :] = coef[int(np.floor(d)):int(-np.ceil(d))]
+                out[i, :] = coef[floor(d):-ceil(d)]
             elif d == 0.:
                 out[i, :] = coef
             else:
                 raise ValueError(
-                    "Selected scale of {} too small.".format(scales[i]))
+                    "Selected scale of {} too small.".format(scale))
         frequencies = scale2frequency(wavelet, scales, precision)
         if np.isscalar(frequencies):
             frequencies = np.array([frequencies])
-        for i in np.arange(len(frequencies)):
-            frequencies[i] /= sampling_period
+        frequencies /= sampling_period
         return out, frequencies
     else:
         raise ValueError("Only dim == 1 supported")

--- a/pywt/_cwt.py
+++ b/pywt/_cwt.py
@@ -1,7 +1,4 @@
 from math import floor, ceil
-from scipy.fftpack import next_fast_len
-
-import numpy as np
 
 from ._extensions._pywt import (DiscreteContinuousWavelet, ContinuousWavelet,
                                 Wavelet, _check_dtype)
@@ -9,6 +6,20 @@ from ._functions import integrate_wavelet, scale2frequency
 
 
 __all__ = ["cwt"]
+
+
+import numpy as np
+
+try:
+    from scipy.fftpack import next_fast_len
+except ImportError:
+    # Do provide a fallback so scipy is an optional requirement
+    def next_fast_len(n):
+        """Given a number of samples `n`, returns the next power of two
+        following this numbe to take advantage of FFT speedup.
+        This fallback is less efficient as `scipy.fftpack.next_fast_len`
+        """
+        return 2**ceil(np.log2(n))
 
 
 def cwt(data, scales, wavelet, sampling_period=1., method='conv'):

--- a/pywt/_cwt.py
+++ b/pywt/_cwt.py
@@ -33,12 +33,10 @@ def cwt(data, scales, wavelet, sampling_period=1., method='conv'):
         Can be any of     
             - ``conv`` uses only the ``numpyp.conv`` function
             - ``fft`` uses frequency domain convolution with ``numpyp.fft.fft``
-            - ``auto`` for automatic selection of the fastest convolution method 
-              depending on the complexity at each scale.
         The ``conv`` method complexity is O(len(scale)*len(data)).
         The ``fft`` method is O(N*log2(N)) with N=len(scale)+len(data)-1,
-        it is well suited for large size signals but slower than ``conv`` on
-        small ones.
+        it is well suited for large size signals but slightly slower than 
+        ``conv`` on small ones.
         
     Returns
     -------
@@ -92,7 +90,8 @@ def cwt(data, scales, wavelet, sampling_period=1., method='conv'):
         precision = 10
         int_psi, x = integrate_wavelet(wavelet, precision=precision)
         
-        if method in ('auto', 'fft'):
+        if method == 'fft':
+            # for FFT the buffer needs:
             # - to be as large as the sum of data length and and maximum wavelet
             #   support to avoid circular convolution effects
             # - additional padding to reach a power of 2 for CPU-optimal FFT
@@ -101,7 +100,7 @@ def cwt(data, scales, wavelet, sampling_period=1., method='conv'):
                                      np.take(scales, 0) * ((x[-1] - x[0]) + 1)) )
             fft_data = None
         elif not method == 'conv':
-            raise ValueError("method must be in: 'conv', 'fft' or 'auto'")
+            raise ValueError("method must be 'conv' or 'fft'")
 
         for i in np.arange(np.size(scales)):
             step = x[1] - x[0]
@@ -120,16 +119,11 @@ def cwt(data, scales, wavelet, sampling_period=1., method='conv'):
                     # it has to be recomputed
                     fft_data = None
                 size_scale0 = size_scale
-                nops_conv = len(data) * len(int_psi_scale)
-                nops_fft  = (2+(fft_data is None)) * size_scale * np.log2(size_scale)
-                if (method == 'fft') or ((method == 'auto') and (nops_fft < nops_conv)):
-                    if fft_data is None:
-                        fft_data = np.fft.fft(data, size_scale)
-                    fft_wav = np.fft.fft(int_psi_scale, size_scale)
-                    conv = np.fft.ifft(fft_wav*fft_data)
-                    conv = conv[0:len(data)+len(int_psi_scale)-1]
-                else:
-                    conv = np.convolve(data, int_psi_scale)
+                if fft_data is None:
+                    fft_data = np.fft.fft(data, size_scale)
+                fft_wav = np.fft.fft(int_psi_scale, size_scale)
+                conv = np.fft.ifft(fft_wav*fft_data)
+                conv = conv[0:len(data)+len(int_psi_scale)-1]
                 
             coef = - np.sqrt(scales[i]) * np.diff(conv)
             if not np.iscomplexobj(out):

--- a/pywt/tests/test_cwt_wavelets.py
+++ b/pywt/tests/test_cwt_wavelets.py
@@ -2,7 +2,7 @@
 from __future__ import division, print_function, absolute_import
 
 from numpy.testing import (assert_allclose, assert_warns, assert_almost_equal,
-                           assert_raises, assert_equal)
+                           assert_raises)
 import numpy as np
 import pywt
 
@@ -374,48 +374,16 @@ def test_cwt_small_scales():
     
 
 def test_cwt_method_fft():
-    data = np.zeros(32, dtype=np.float32)
+    rstate = np.random.RandomState(1)
+    data = rstate.randn(50)
     data[15] = 1.
-    scales1  = 1
-    wavelet  = 'cmor1.5-1.0'
-    
-    # build a reference cwt with the legacy np.conv() method
-    cfs_conv, _ = pywt.cwt(data, scales1, wavelet, method='conv')
-
-    # compare with the fft based convolution
-    cfs_fft, _  = pywt.cwt(data, scales1, wavelet, method='fft')
-    assert_allclose(cfs_conv, cfs_fft, rtol=0, atol=1e-13)
-
-
-def test_cwt_method_auto():
-    np.random.seed(1)
-    data = np.random.randn(50)
-    scales  = [1, 5, 25, 125]
+    scales   = [1, 32, 64]
     wavelet  = 'cmor1.5-1.0'
     
     # build a reference cwt with the legacy np.conv() method
     cfs_conv, _ = pywt.cwt(data, scales, wavelet, method='conv')
 
-    # 'fft' method switches for scale 2 with len(data)==50
-    cfs_fft, _  = pywt.cwt(data, scales, wavelet, method='auto')
+    # compare with the fft based convolution
+    cfs_fft, _  = pywt.cwt(data, scales, wavelet, method='fft')
     assert_allclose(cfs_conv, cfs_fft, rtol=0, atol=1e-13)
-    
-
-def test_cwt_dtype():
-    """Currently output dtype precision is fixed in version 1.0.2"""
-    wavelet = 'mexh'
-    scales  = 1
-    dtype_expected = {
-        np.float16: np.float64,
-        np.float32: np.float64,
-        np.float64: np.float64,
-        np.float128: np.float64,
-        np.complex64: np.float64,
-        np.complex128: np.float64,
-        np.complex256: np.float64,
-        }
-    for dtype_in, dtype_out in dtype_expected.items():
-        data   = np.zeros(2, dtype=dtype_in)
-        cfs, f = pywt.cwt(data, scales, wavelet)
-        assert_equal(dtype_out, cfs.dtype)
 

--- a/pywt/tests/test_cwt_wavelets.py
+++ b/pywt/tests/test_cwt_wavelets.py
@@ -371,19 +371,18 @@ def test_cwt_small_scales():
 
     # extremely short scale factors raise a ValueError
     assert_raises(ValueError, pywt.cwt, data, scales=0.01, wavelet='mexh')
-    
+
 
 def test_cwt_method_fft():
     rstate = np.random.RandomState(1)
     data = rstate.randn(50)
     data[15] = 1.
-    scales   = [1, 32, 64]
+    scales   = np.arange(1, 64)
     wavelet  = 'cmor1.5-1.0'
-    
+
     # build a reference cwt with the legacy np.conv() method
     cfs_conv, _ = pywt.cwt(data, scales, wavelet, method='conv')
 
     # compare with the fft based convolution
     cfs_fft, _  = pywt.cwt(data, scales, wavelet, method='fft')
     assert_allclose(cfs_conv, cfs_fft, rtol=0, atol=1e-13)
-


### PR DESCRIPTION
This pull request contains the support for fast convolution support with fast fourier transform (FFT) as discussed in issue #479 .   
The speed improvement is visible for signals over signal/scales over 100/50, and becomes highly significant by more than a factor 10 for EEG like signals with 100K+ samples.

From a user point of view the only change is the new keyword `method='fft'`, the behaviour of the function has been kept identical to the 1.0.2 release for both signature and dtype of output. Support for compliance between input and output dtype has been prepared.

* The patch passes the 1500+ test suite and provides additionals tests which compare the numerical results of both methods.
* documentation has been added to the cwt() function header
