### PR TITLE
BLD: add missing import of warnings module to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,6 +5,7 @@ import os
 import sys
 import subprocess
 import textwrap
+import warnings
 from functools import partial
 from distutils.sysconfig import get_python_inc
 


### PR DESCRIPTION
The function `parse_setuppy_commands` issues a warning for unrecognized commands, but the import of `warnings` was missing.