### PR TITLE
register markers for pytest 4.5 compatibility

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -15,7 +15,7 @@ recursive-include demo *
 include cythonize.dat
 
 # Add build and testing tools
-include tox.ini
+include tox.ini pytest.ini
 recursive-include util *
 
 # Exclude what we don't want to include

--- a/pywt/conftest.py
+++ b/pywt/conftest.py
@@ -1,0 +1,6 @@
+import pytest
+
+
+def pytest_configure(config):
+    config.addinivalue_line("markers",
+                            "slow: Tests that are slow.")


### PR DESCRIPTION
registers `pytest.mark.slow` as used to mark slow tests. Hopefully this should get CI working again with current `pytest`

`pytest.ini` was missing from `MANIFEST.in`, so I have added it here
