### PR TITLE
fix docstring's scale2frequency parameter order

### DIFF
--- a/pywt/_cwt.py
+++ b/pywt/_cwt.py
@@ -19,7 +19,7 @@ def cwt(data, scales, wavelet, sampling_period=1.):
         Input signal
     scales : array_like
         The wavelet scales to use. One can use
-        ``f = scale2frequency(scale, wavelet)/sampling_period`` to determine
+        ``f = scale2frequency(wavelet, scale)/sampling_period`` to determine
         what physical frequency, ``f``. Here, ``f`` is in hertz when the
         ``sampling_period`` is given in seconds.
     wavelet : Wavelet object or name


### PR DESCRIPTION
The example of scale2frequency in the cwt docstring had the scale and wavelet parameters backwards.