### PR TITLE
preserve single precision in CWT

### DIFF
--- a/benchmarks/benchmarks/cwt_benchmarks.py
+++ b/benchmarks/benchmarks/cwt_benchmarks.py
@@ -9,20 +9,22 @@ class CwtTimeSuiteBase(object):
     params = ([32, 128, 512, 2048],
               ['cmor', 'cgau4', 'fbsp', 'gaus4', 'mexh', 'morl', 'shan'],
               [16, 64, 256],
-              ['conv', 'fft'])
-    param_names = ('n', 'wavelet', 'max_scale', 'method')
+              [np.float32, np.float64],
+              ['conv', 'fft'],
+              )
+    param_names = ('n', 'wavelet', 'max_scale', 'dtype', 'method')
 
-    def setup(self, n, wavelet, max_scale, method):
+    def setup(self, n, wavelet, max_scale, dtype, method):
         try:
             from pywt import cwt
         except ImportError:
             raise NotImplementedError("cwt not available")
-        self.data = np.ones(n, dtype='float')
-        self.scales = np.arange(1, max_scale+1)
+        self.data = np.ones(n, dtype=dtype)
+        self.scales = np.arange(1, max_scale + 1)
 
 
 class CwtTimeSuite(CwtTimeSuiteBase):
-    def time_cwt(self, n, wavelet, max_scale, method):
+    def time_cwt(self, n, wavelet, max_scale, dtype, method):
         try:
             pywt.cwt(self.data, self.scales, wavelet, method=method)
         except TypeError:


### PR DESCRIPTION
As discussed with @alsauve in #479, `cwt` currently promotes single precision inputs to double precision. This behavior is inconsistent with all other transforms in PyWavelets.

In this PR:
1.) the output array is declared matching the precision of the input.
2.) the internal convolution or FFT-based convolutions operate at the precision of the input

Aside from consistency this can improve performance and reduce memory use when working with single precision data.