### PR TITLE
add axis support to cwt

### DIFF
--- a/benchmarks/benchmarks/cwt_benchmarks.py
+++ b/benchmarks/benchmarks/cwt_benchmarks.py
@@ -20,6 +20,7 @@ class CwtTimeSuiteBase(object):
         except ImportError:
             raise NotImplementedError("cwt not available")
         self.data = np.ones(n, dtype=dtype)
+        self.batch_data = np.ones((5, n), dtype=dtype)
         self.scales = np.arange(1, max_scale + 1)
 
 
@@ -33,3 +34,12 @@ class CwtTimeSuite(CwtTimeSuiteBase):
                 raise NotImplementedError(
                     "fft-based convolution not available.")
             pywt.cwt(self.data, self.scales, wavelet)
+
+    def time_cwt_batch(self, n, wavelet, max_scale, dtype, method):
+        try:
+            pywt.cwt(self.batch_data, self.scales, wavelet, method=method,
+                     axis=-1)
+        except TypeError:
+            # older PyWavelets does not support the axis argument
+            raise NotImplementedError(
+                "axis argument not available.")

--- a/pywt/_cwt.py
+++ b/pywt/_cwt.py
@@ -66,12 +66,16 @@ def cwt(data, scales, wavelet, sampling_period=1., method='conv', axis=-1):
         The ``fft`` method is ``O(N * log2(N))`` with
         ``N = len(scale) + len(data) - 1``. It is well suited for large size
         signals but slightly slower than ``conv`` on small ones.
+    axis: int, optional
+        Axis over which to compute the CWT. If not given, the last axis is
+        used.
 
     Returns
     -------
     coefs : array_like
         Continuous wavelet transform of the input signal for the given scales
-        and wavelet
+        and wavelet. The first axis of ``coefs`` corresponds to the scales.
+        The remaining axes match the shape of ``data``.
     frequencies : array_like
         If the unit of sampling period are seconds and given, than frequencies
         are in hertz. Otherwise, a sampling period of 1 is assumed.
@@ -135,7 +139,7 @@ def cwt(data, scales, wavelet, sampling_period=1., method='conv', axis=-1):
         # move axis to be transformed last (so it is contiguous)
         data = data.swapaxes(-1, axis)
 
-        # reshape to (n_batch, data.shape[axis])
+        # reshape to (n_batch, data.shape[-1])
         data_shape_pre = data.shape
         data = data.reshape((-1, data.shape[-1]))
 
@@ -195,4 +199,3 @@ def cwt(data, scales, wavelet, sampling_period=1., method='conv', axis=-1):
         frequencies = np.array([frequencies])
     frequencies /= sampling_period
     return out, frequencies
-


### PR DESCRIPTION
Users requested batched operation for `cwt` in #445. This can be done by adding an `axis` argument as in this PR. This PR allows the input data to be n-dimensional with batched operation over all axes aside from the specified cwt `axis`. For 1D data, the behavior is unchanged from before.

The final shape of the output for n-dimensional `data` becomes:
``(len(scales),) + data.shape``  (i.e. the scales dimension is always first as it was for the 1D case previously)

For the `'conv'` case implementation is via a simple for loop, but for the `'fft'` case we do not have to repeat the FFT of the wavelet filter for each item in the batch, so there is a performance benefit to batched operation.

a subset of benchmark results.
first, for non-batch cases
```
              -------------------------------------------- ---------------------
                n     wavelet   max_scale       dtype         conv       fft    
              ====== ========= =========== =============== ========== ==========

               128      mexh        16      numpy.float32   2.01±0ms   5.13±0ms 
               128      mexh        16      numpy.float64   4.32±0ms   5.99±0ms 

               2048     shan       256      numpy.float32   397±0ms    68.0±0ms 
               2048     shan       256      numpy.float64   864±0ms    100±0ms  
```

a few batch (n_batch=5) cases
```
               128      mexh        16      numpy.float32   6.68±0ms   6.67±0ms 
               128      mexh        16      numpy.float64   5.46±0ms   7.39±0ms 

               2048     shan       256      numpy.float32   1.87±0s    178±0ms  
               2048     shan       256      numpy.float64   4.32±0s    291±0ms
```

Summary for the 2048/shan/float32 case:

    with conv: n_batch=5 batch takes 4.7 times longer than the non-batch case

    with fft:  n_batch=5 batch takes 1.8 times longer than the non-batch case

    for the non-batch case, mode 'fft' is 5.8 times faster than 'conv'

    for the n_batch=5 batch case, mode 'fft' is 10.5 times faster than 'conv'

closes #445 