### PR TITLE
MAINT: split bundled licenses into a separate file

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -18,15 +18,3 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
-
-
-The PyWavelets repository and source distributions bundle some code that is
-adapted from compatibly licensed projects. We list these here.
-
-Name: NumPy
-Files:  pywt/_pytesttester.py
-License: 3-clause BSD
-
-Name: SciPy
-Files:  setup.py, util/*
-License: 3-clause BSD

--- a/LICENSES_bundled.txt
+++ b/LICENSES_bundled.txt
@@ -1,0 +1,10 @@
+The PyWavelets repository and source distributions bundle some code that is
+adapted from compatibly licensed projects. We list these here.
+
+Name: NumPy
+Files:  pywt/_pytesttester.py
+License: 3-clause BSD
+
+Name: SciPy
+Files:  setup.py, util/*
+License: 3-clause BSD


### PR DESCRIPTION
The motivation here is to help GitHub correctly auto-identify the LICENSE as MIT.

(following the example of SciPy who did this recently for the same reason)