### PR TITLE
Require python >=3.5 in setup

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -420,6 +420,8 @@ def setup_package():
             "Programming Language :: Python :: 3.6",
             "Programming Language :: Python :: 3.7",
             "Programming Language :: Python :: 3.8",
+            "Programming Language :: Python :: 3 :: Only",
+            "Programming Language :: Python :: Implementation :: CPython",
             "Topic :: Software Development :: Libraries :: Python Modules"
         ],
         platforms=["Windows", "Linux", "Solaris", "Mac OS-X", "Unix"],

--- a/setup.py
+++ b/setup.py
@@ -435,6 +435,7 @@ def setup_package():
 
         install_requires=["numpy>=1.13.3"],
         setup_requires=["numpy>=1.13.3"],
+        python_requires=">=3.5",
     )
 
     if "--force" in sys.argv:

--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,9 @@ MICRO = 1
 ISRELEASED = False
 VERSION = '%d.%d.%d' % (MAJOR, MINOR, MICRO)
 
+# fail quicker on unsupported Python (prior to Cythonizing)
+if sys.version_info[:2] < (3, 5):
+    raise RuntimeError("Python version >= 3.5 required.")
 
 # Return the git revision as a string
 def git_version():


### PR DESCRIPTION
Try to prevent pip from installing from 1.1.x from source when using Python <3.5 (see scikit-image/scikit-image#4258)



