### PR TITLE
update Tidelift link in the README [ci skip]

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -119,7 +119,7 @@ and documentation improvements are welcome.  Moreover, developers with an
 interest in PyWavelets are very welcome to join the development team!
 
 As of 2019, PyWavelets development is supported in part by Tidelift.
-`Help support PyWavelets with the Tidelift Subscription <https://tidelift.com/subscription/pkg/pypi-pywavelets?utm_source=pypi-pywavelets&utm_medium=referral&utm_campaign=readme>`_
+`Help support PyWavelets with the Tidelift Subscription <https://tidelift.com/subscription/pkg/pypi-pywavelets?utm_source=pypi-pywavelets&utm_medium=referral&utm_campaign=enterprise>`_
 
 
 Contact


### PR DESCRIPTION
This PR updates the Tidelift link in the README to take advantage of a promotion they are currently running. Basically, they will pay the project a bonus for any sales leads that result from users clicking on the link in this form. 

Tidelift also has provided a template for adding a "For Enterprise" page to the documentation that provides more context and similar links/buttons. I chose not to do that as part of this PR, but if others are in favor we can add it so users browsing on readthedocs would find a link to Tidelift as well. Adding the documentation page is optional and is not a requirement for continuing Tidelift support.
