### PR TITLE
copy python_requires change from 1.1.x branch to master

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -435,6 +435,7 @@ def setup_package():
 
         install_requires=["numpy>=1.13.3"],
         setup_requires=["numpy>=1.13.3"],
+        python_requires=">=3.5",
     )
 
     if "--force" in sys.argv:


### PR DESCRIPTION
For the 1.1.1 release a `python_requires` line was added to `setup.py` so that pip would not try and fail to install 1.1.x on older Python releases such as 2.7. 

I should probably have done this in the master branch initially and then backported to 1.1.x, but we will have to do it the other way around now...
