### PR TITLE
add missing release notes from other branches

### DIFF
--- a/doc/release/0.5.1-notes.rst
+++ b/doc/release/0.5.1-notes.rst
@@ -1,0 +1,34 @@
+==============================
+PyWavelets 0.5.1 Release Notes
+==============================
+
+PyWavelets 0.5.1 is a bug-fix release with no new features compared to 0.5.0
+
+
+Bugs Fixed
+==========
+
+In release 0.5.0 the wrong edge mode was used for the following three
+deprecated modes: ``ppd``, ``sp1``, and ``per``.  All deprecated edge mode
+names are now correctly converted to the corresponding new names.
+
+One-dimensional discrete wavelet transforms did not properly respect the
+``axis`` argument for complex-valued data.  Prior to this release, the last
+axis was always transformed for arrays with complex dtype.  This fix affects
+``dwt``, ``idwt``, ``wavedec``, ``waverec``.
+
+Authors
+=======
+
+* Gregory R. Lee
+
+Issues closed for v0.5.1
+------------------------
+
+- `#245 <https://github.com/PyWavelets/pywt/issues/245>`__: Keyword "per" for dwt extension mode
+
+Pull requests for v0.5.1
+------------------------
+
+- `#244 <https://github.com/PyWavelets/pywt/issues/244>`__: FIX: dwt, idwt with complex data now pass axis argument properly
+- `#246 <https://github.com/PyWavelets/pywt/issues/246>`__: fix bug in deprecated mode name conversion

--- a/doc/release/0.5.2-notes.rst
+++ b/doc/release/0.5.2-notes.rst
@@ -1,0 +1,52 @@
+==============================
+PyWavelets 0.5.2 Release Notes
+==============================
+
+PyWavelets 0.5.2 is a bug-fix release with no new features compared to 0.5.1.
+
+
+Bugs Fixed
+==========
+
+The ``pywt.data.nino`` data reader is now compatible with numpy 1.12. (#273)
+
+The ``wp_scalogram.py`` demo is now compatibile with matplotlib 2.0. (#276)
+
+Fixed a sporadic segmentation fault affecting stationary wavelet transforms of
+multi-dimensional data. (#289)
+
+``idwtn`` now treats coefficients set to None to be treated as zeros (#291).
+This makes the behavior consistent with its docstring as well as idwt2.
+Previously this raised an error.
+
+The tests are now included when installing from wheels or when running
+``python setup.py install``. (#292)
+
+A bug leading to a potential ``RuntimeError`` was fixed in ``waverec``.
+This bug only affected transforms where the data was >1D and the transformed
+axis was not the first axis of the array. (#294).
+
+Authors
+=======
+
+* Ralf Gommers
+* Gregory R. Lee
+
+Issues closed for v0.5.2
+------------------------
+
+- `#280 <https://github.com/PyWavelets/pywt/issues/280>`__: No tests found from installed version
+- `#288 <https://github.com/PyWavelets/pywt/issues/288>`__: RuntimeErrors and segfaults from swt2() in threaded environments
+- `#290 <https://github.com/PyWavelets/pywt/issues/290>`__: idwtn should treat coefficients set to None as zeros
+- `#293 <https://github.com/PyWavelets/pywt/issues/293>`__: bug in waverec of n-dimensional data when axis != 0
+
+Pull requests for v0.5.2
+------------------------
+
+- `#273 <https://github.com/PyWavelets/pywt/issues/273>`__: fix non-integer index error
+- `#276 <https://github.com/PyWavelets/pywt/issues/276>`__: update wp_scalogram demo work with matplotlib 2.0
+- `#289 <https://github.com/PyWavelets/pywt/issues/289>`__: fix memory leak in swt_axis
+- `#291 <https://github.com/PyWavelets/pywt/issues/291>`__: idwtn should allow coefficients to be set as None
+- `#292 <https://github.com/PyWavelets/pywt/issues/292>`__: MAINT: ensure tests are included in wheels
+- `#294 <https://github.com/PyWavelets/pywt/issues/294>`__: FIX: shape adjustment in waverec should not assume a transform along …
+- `#295 <https://github.com/PyWavelets/pywt/issues/295>`__: MAINT: fix readthedocs build issue, update numpy version specifier

--- a/doc/release/1.0.1-notes.rst
+++ b/doc/release/1.0.1-notes.rst
@@ -1,0 +1,34 @@
+==============================
+PyWavelets 1.0.1 Release Notes
+==============================
+
+PyWavelets 1.0.1 is a bug-fix release with no new features compared to 1.0.0.
+
+
+Bugs Fixed
+==========
+
+Key-based assignment of coefficients to a ``FswavedecnResult`` object (i.e. via
+its __setitem__ method) has been fixed.
+
+The order that the individual subband coefficients were stacked by the
+function ``pywt.ravel_coeffs`` is now guaranteed to be consistent across all
+supported Python versions. Explicit alphabetic ordering of subband coefficient
+names is used for consitent ordering regardless of Python version.
+
+Authors
+=======
+
+* Gregory R. Lee
+
+Issues closed for v1.0.1
+------------------------
+
+- `#426 <https://github.com/PyWavelets/pywt/issues/426>`__: Ordering of the coefficients stacked in pywt.ravel_coeffs can vary across Python versions
+- `#425 <https://github.com/PyWavelets/pywt/issues/425>`__: error when trying to assign modified coefficients to a FswavedecnResults object
+
+Pull requests for v1.0.1
+------------------------
+
+- `#423 <https://github.com/PyWavelets/pywt/issues/423>`__: fix bug in FswavedecnResult.__setitem__ and improve docstrings
+- `#427 <https://github.com/PyWavelets/pywt/issues/427>`__: fix: enforce consistent coefficient order for ravel_coeffs

--- a/doc/release/1.0.2-notes.rst
+++ b/doc/release/1.0.2-notes.rst
@@ -1,0 +1,74 @@
+==============================
+PyWavelets 1.0.2 Release Notes
+==============================
+
+PyWavelets 1.0.2 is a bug-fix and maintenance release with no new features
+compared to 1.0.1.
+
+Bugs Fixed
+==========
+
+A bug in `iswtn` when using some combinations of user-specified axes was fixed.
+
+A potential error related to coefficient shape mismatch during WaveletPacket
+or WaveletPacket2D reconstruction was fixed.
+
+Other Changes
+=============
+
+A deprecated import of ``Iterable`` was fixed.
+
+The spelling of "Garrote" was fixed in the wavelet thresholding documentation.
+For backwards compatibility with 1.0.0, the incorrect ("garotte")
+spelling is also accepted for the ``mode`` parameter of ``pywt.threshold``.
+
+The spelling of "supported" was fixed in one of the ValueError messages that
+can be returned by ``pywt.cwt``.
+
+Cython language compatibility has been pinned to ``language_level = '2'``. This
+is in contrast to the `master` branch which is now using
+``language_level = '3'``. To support this, the minimum supported Cython version
+has been raised to 0.23.5.
+
+Authors
+=======
+
+Four authors contributed PRs for the 1.0.2 release.
+
+Thomas A. Caswell
+Corey Goldberg
+Gregory R. Lee
+Lokesh Ravindranathan
+
+Thanks also goes to Ralf Gommers as a reviewer of most of these.
+
+Issues closed for v1.0.2
+------------------------
+
+- `#447 <https://github.com/PyWavelets/pywt/issues/447>`__: Issue using pywt.WaveletPacket2D
+- `#449 <https://github.com/PyWavelets/pywt/issues/449>`__: Coefficients arrays must have the same dtype error in iswt function
+- `#460 <https://github.com/PyWavelets/pywt/issues/460>`__: iswtn error when using axes and excluded dim is desn't comply to the level
+
+Pull requests for v1.0.2
+------------------------
+
+- `#454 <https://github.com/PyWavelets/pywt/issues/454>`__: BLD: 1.0.x pin cython language level to '2'
+- `#455 <https://github.com/PyWavelets/pywt/issues/455>`__: backport of #448 (fix coefficient shape mismatch in WaveletPacket reconstruction)
+- `#456 <https://github.com/PyWavelets/pywt/issues/456>`__: MAINT: 1.0.x: Spelling correction
+- `#457 <https://github.com/PyWavelets/pywt/issues/457>`__: MAINT: 1.0.x Fix spelling of "Garrote"
+- `#458 <https://github.com/PyWavelets/pywt/issues/458>`__: MAINT: 1.0.x Fix deprecated import for Iterable
+- `#464 <https://github.com/PyWavelets/pywt/issues/464>`__: backport of #448 (fix coefficient shape mismatch in WaveletPacket reconstruction)
+- `#465 <https://github.com/PyWavelets/pywt/issues/465>`__: backport of gh-462 (iswtn axis fix)
+- `#469 <https://github.com/PyWavelets/pywt/issues/469>`__: MAINT 1.0.x backport #452 (bump minimum supported Cython version)
+
+The backports listed above correspond to the following PRs from the master branch
+
+- `#436 <https://github.com/PyWavelets/pywt/issues/436>`__: Fix deprecated import for Iterable
+- `#438 <https://github.com/PyWavelets/pywt/issues/438>`__: Fix spelling of "Garrote"
+- `#446 <https://github.com/PyWavelets/pywt/issues/446>`__: Spelling correction
+- `#448 <https://github.com/PyWavelets/pywt/issues/448>`__: Properly trim wavelet packet node coefficients during reconstruction
+- `#450 <https://github.com/PyWavelets/pywt/issues/450>`__: handle mixed dtype cofficients correctly across inverse transforms
+- `#452 <https://github.com/PyWavelets/pywt/issues/452>`__: bump minimum supported Cython version
+- `#462 <https://github.com/PyWavelets/pywt/issues/462>`__: fix bug in iswtn for data of arbitrary shape when using user-specified axes
+
+

--- a/doc/release/1.0.3-notes.rst
+++ b/doc/release/1.0.3-notes.rst
@@ -1,0 +1,8 @@
+==============================
+PyWavelets 1.0.3 Release Notes
+==============================
+
+PyWavelets 1.0.3 is functionally equivalent to the 1.0.2 release. It was made
+to add the add an archive of the JOSS paper to the 1.0.x branch and serve as a
+reference corresponding to the version of the software reviewed that was peer
+reviewed.

--- a/doc/release/1.1.1-notes.rst
+++ b/doc/release/1.1.1-notes.rst
@@ -1,0 +1,10 @@
+==============================
+PyWavelets 1.1.1 Release Notes
+==============================
+
+.. contents::
+
+This release is identical in functionality to 1.1.0.
+
+It fixes setup.py to prevent pip from trying to install from PyPI for
+Python < 3.5.

--- a/doc/source/release.0.5.1.rst
+++ b/doc/source/release.0.5.1.rst
@@ -1,0 +1,1 @@
+.. include:: ../release/0.5.1-notes.rst

--- a/doc/source/release.0.5.2.rst
+++ b/doc/source/release.0.5.2.rst
@@ -1,0 +1,1 @@
+.. include:: ../release/0.5.2-notes.rst

--- a/doc/source/release.1.0.1.rst
+++ b/doc/source/release.1.0.1.rst
@@ -1,0 +1,1 @@
+.. include:: ../release/1.0.1-notes.rst

--- a/doc/source/release.1.1.1.rst
+++ b/doc/source/release.1.1.1.rst
@@ -1,0 +1,1 @@
+.. include:: ../release/1.1.1-notes.rst

--- a/doc/source/release.1.1.2.rst
+++ b/doc/source/release.1.1.2.rst
@@ -1,0 +1,1 @@
+.. include:: ../release/1.1.2-notes.rst

--- a/doc/source/release.1.1.3.rst
+++ b/doc/source/release.1.1.3.rst
@@ -1,0 +1,1 @@
+.. include:: ../release/1.1.3-notes.rst

--- a/doc/source/releasenotes.rst
+++ b/doc/source/releasenotes.rst
@@ -7,5 +7,11 @@ Release Notes
    release.0.3.0
    release.0.4.0
    release.0.5.0
+   release.0.5.1
+   release.0.5.2
    release.1.0.0
+   release.1.0.1
+   release.1.0.2
+   release.1.0.3
    release.1.1.0
+   release.1.1.1


### PR DESCRIPTION
Various branches had release notes specific to micro-versions that were not present in the master branch. This PR collects all of them in master.
