### PR TITLE
remove unused distutils import from __init__.py

### DIFF
--- a/pywt/__init__.py
+++ b/pywt/__init__.py
@@ -11,7 +11,6 @@ wavelet packets signal decomposition and reconstruction module.
 """
 
 from __future__ import division, print_function, absolute_import
-from distutils.version import LooseVersion
 
 from ._extensions._pywt import *
 from ._functions import *


### PR DESCRIPTION
I think this import may be the source of some errors seen on Travis in #539
Distutils itself imports from the deprecated `imp` module which is causing a `DeprecationWarning` that is apparently making `pytest` unhappy.

see: https://travis-ci.org/PyWavelets/pywt/jobs/633664005#L547