### PR TITLE
ContinuousWavelet: add tests for dtype and remove unused **kwargs

### DIFF
--- a/doc/source/ref/wavelets.rst
+++ b/doc/source/ref/wavelets.rst
@@ -260,13 +260,14 @@ from plain Python lists of filter coefficients and a *filter bank-like* object.
 ``ContinuousWavelet`` object
 ----------------------------
 
-.. class:: ContinuousWavelet(name)
+.. class:: ContinuousWavelet(name, dtype=np.float64)
 
   Describes properties of a continuous wavelet identified by the specified wavelet ``name``.
   In order to use a built-in wavelet the ``name`` parameter must be a valid
   wavelet name from the :func:`pywt.wavelist` list.
 
   :param name: Wavelet name
+  :param dtype: numpy.dtype to use for the wavelet. Can be numpy.float64 or numpy.float32.
 
   **Example:**
 

--- a/pywt/_extensions/_pywt.pyx
+++ b/pywt/_extensions/_pywt.pyx
@@ -691,6 +691,10 @@ cdef public class ContinuousWavelet [type ContinuousWaveletType, object Continuo
         # builtin wavelet
         self.name = name.lower()
         self.dt = dtype
+        if np.dtype(self.dt) not in [np.float32, np.float64]:
+            raise ValueError(
+                "Only np.float32 and np.float64 dtype are supported for "
+                "ContinuousWavelet objects.")
         if len(self.name) >= 4 and self.name[:4] in ['cmor', 'shan', 'fbsp']:
             base_name = self.name[:4]
             if base_name == self.name:

--- a/pywt/_extensions/_pywt.pyx
+++ b/pywt/_extensions/_pywt.pyx
@@ -677,7 +677,7 @@ cdef public class Wavelet [type WaveletType, object WaveletObject]:
 
 cdef public class ContinuousWavelet [type ContinuousWaveletType, object ContinuousWaveletObject]:
     """
-    ContinuousWavelet(name) object describe properties of
+    ContinuousWavelet(name, dtype) object describe properties of
     a continuous wavelet identified by name.
 
     In order to use a built-in wavelet the parameter name must be
@@ -685,15 +685,12 @@ cdef public class ContinuousWavelet [type ContinuousWaveletType, object Continuo
 
     """
     #cdef readonly properties
-    def __cinit__(self, name=u"", dtype = None, **kwargs):
+    def __cinit__(self, name=u"", dtype=np.float64):
         cdef object family_code, family_number
 
         # builtin wavelet
         self.name = name.lower()
-        if (dtype is None):
-            self.dt = np.float64
-        else:
-            self.dt = dtype
+        self.dt = dtype
         if len(self.name) >= 4 and self.name[:4] in ['cmor', 'shan', 'fbsp']:
             base_name = self.name[:4]
             if base_name == self.name:

--- a/pywt/tests/test_cwt_wavelets.py
+++ b/pywt/tests/test_cwt_wavelets.py
@@ -115,6 +115,21 @@ def test_gaus():
         assert_allclose(X, x)
 
 
+@pytest.mark.parametrize('dtype', [np.float32, np.float64])
+def test_continuous_wavelet_dtype(dtype):
+    wavelet = pywt.ContinuousWavelet('cmor1.5-1.0', dtype)
+    int_psi, x = pywt.integrate_wavelet(wavelet)
+    assert int_psi.real.dtype == dtype
+    assert x.dtype == dtype
+
+
+def test_continuous_wavelet_invalid_dtype():
+    with pytest.raises(ValueError):
+        pywt.ContinuousWavelet('gaus5', np.complex64)
+    with pytest.raises(ValueError):
+        pywt.ContinuousWavelet('gaus5', np.int)
+
+
 def test_cgau():
     LB = -5
     UB = 5


### PR DESCRIPTION
The `ContinuousWavelet` object allows specifying single or double precision via a dtype argument. This seems to work as expected, although is undocumented. This PR documents this `dtype` parameter and adds tests for it. I also removed an unused `**kwargs` parameter from the `__cinit__`.

Finally, this adds validation during wavelet creation to give a clear error when specifying an unsupported `dtype`. Prior to this PR the wavelet can be created with unsupported dtypes, but then when trying to use it via `wavefun` or `integrate_wavelet`, one would get errors like:

```Python
pywt.integrate_wavelet(wavelet=pywt.ContinuousWavelet('cmor1.5-1.0', np.complex64), precision=8)
Traceback (most recent call last):

  File "<ipython-input-79-c5c9ef8f093b>", line 1, in <module>
    pywt.integrate_wavelet(wavelet=pywt.ContinuousWavelet('cmor1.5-1.0', np.complex64), precision=8)

  File "/home/lee8rx/my_git/pyir/pywt/pywt/_functions.py", line 104, in integrate_wavelet
    functions_approximations = wavelet.wavefun(precision)

  File "pywt/_extensions/_pywt.pyx", line 953, in pywt._extensions._pywt.ContinuousWavelet.wavefun

ValueError: Buffer dtype mismatch, expected 'float32_t' but got 'complex float'
```
