### PR TITLE
Cython 3.0 compatibility: explicitly call import_array()

### DIFF
--- a/pywt/_extensions/_cwt.pxd
+++ b/pywt/_extensions/_cwt.pxd
@@ -1,6 +1,4 @@
 from ._pywt cimport ContinuousWavelet, data_t
-cimport numpy as np
-import numpy as np
+
 
 cpdef cwt_psi_single(data_t[::1] data, ContinuousWavelet wavelet, size_t output_len)
-

--- a/pywt/_extensions/_cwt.pyx
+++ b/pywt/_extensions/_cwt.pyx
@@ -7,7 +7,7 @@ from ._pywt cimport _check_dtype
 cimport numpy as np
 import numpy as np
 
-
+np.import_array()
 
 
 cpdef cwt_psi_single(data_t[::1] data, ContinuousWavelet wavelet, size_t output_len):

--- a/pywt/_extensions/_dwt.pyx
+++ b/pywt/_extensions/_dwt.pyx
@@ -9,6 +9,7 @@ import numpy as np
 
 include "config.pxi"
 
+np.import_array()
 
 cpdef dwt_max_level(size_t data_len, size_t filter_len):
     return common.dwt_max_level(data_len, filter_len)

--- a/pywt/_extensions/_pywt.pxd
+++ b/pywt/_extensions/_pywt.pxd
@@ -1,5 +1,8 @@
 from . cimport wavelet
 cimport numpy as np
+
+np.import_array()
+
 include "config.pxi"
 
 ctypedef Py_ssize_t pywt_index_t

--- a/pywt/_extensions/_swt.pyx
+++ b/pywt/_extensions/_swt.pyx
@@ -10,8 +10,10 @@ cimport numpy as np
 from .common cimport pywt_index_t
 from ._pywt cimport c_wavelet_from_object, cdata_t, Wavelet, _check_dtype
 
-
 include "config.pxi"
+
+np.import_array()
+
 
 def swt_max_level(size_t input_len):
     """


### PR DESCRIPTION
Building PyWavelets with Cython 3.0a1 leads to segfaults when calling some functions. Apparently, all files that `cimport numpy as np` should also have had a call to `np.import_array()`. We got away without this until now, but it was causing problems with 3.0a1. 

The changes proposed in cython/cython#3524 may resolve the segfault, but I think it is still a good idea for us to do the import explicitly. (I am also wondering if the lack of `import_array` is what is leading to the segfault in the `ppc64le+pypy` build in conda-forge/pywavelets-feedstock#35?)

A second issue encountered in `swt.pyx` (cython/cython#3527) has already been fixed in Cython master. 
