### PR TITLE
MAINT: bump minimum Python version to 3.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -59,7 +59,7 @@ matrix:
     - os: linux
       python: 3.7
       env:
-        - NUMPYSPEC="numpy==1.13.3"
+        - NUMPYSPEC="numpy==1.14.6"
         - MATPLOTLIBSPEC=matplotlib
         - CYTHONSPEC="cython==0.29.18"
         - REFGUIDE_CHECK=1  # run doctests only

--- a/.travis.yml
+++ b/.travis.yml
@@ -61,7 +61,7 @@ matrix:
       env:
         - NUMPYSPEC="numpy==1.13.3"
         - MATPLOTLIBSPEC=matplotlib
-        - CYTHONSPEC="cython==0.23.5"
+        - CYTHONSPEC="cython==0.29.18"
         - REFGUIDE_CHECK=1  # run doctests only
     - os: osx
       osx_image: xcode7.3

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ env:
 matrix:
   include:
     - os: linux
-      python: 3.6
+      python: 3.7
       env:
         - NUMPYSPEC=numpy
         - MATPLOTLIBSPEC=matplotlib
@@ -25,7 +25,7 @@ matrix:
         - USE_WHEEL=1
     - arch: arm64
       os: linux
-      python: 3.6
+      python: 3.7
       env:
         - NUMPYSPEC=numpy
         - MATPLOTLIBSPEC=matplotlib
@@ -57,7 +57,7 @@ matrix:
         - CYTHONSPEC=cython
         - USE_SDIST=1
     - os: linux
-      python: 3.5
+      python: 3.7
       env:
         - NUMPYSPEC="numpy==1.13.3"
         - MATPLOTLIBSPEC=matplotlib
@@ -70,7 +70,7 @@ matrix:
         - NUMPYSPEC=numpy
         - MATPLOTLIBSPEC=matplotlib
         - CYTHONSPEC=cython
-        - TRAVIS_PYTHON_VERSION=3.5
+        - TRAVIS_PYTHON_VERSION=3.7
 cache: pip
 
 before_install:

--- a/README.rst
+++ b/README.rst
@@ -66,7 +66,7 @@ Installation
 ------------
 
 PyWavelets supports `Python`_ >=3.7, and is only dependent on `NumPy`_
-(supported versions are currently ``>= 1.13.3``). To pass all of the tests,
+(supported versions are currently ``>= 1.14.6``). To pass all of the tests,
 `Matplotlib`_ is also required. `SciPy`_ is also an optional dependency. When
 present, FFT-based continuous wavelet transforms will use FFTs from SciPy
 rather than NumPy.

--- a/README.rst
+++ b/README.rst
@@ -65,7 +65,7 @@ For more usage examples see the `demo`_ directory in the source package.
 Installation
 ------------
 
-PyWavelets supports `Python`_ >=3.5, and is only dependent on `NumPy`_
+PyWavelets supports `Python`_ >=3.7, and is only dependent on `NumPy`_
 (supported versions are currently ``>= 1.13.3``). To pass all of the tests,
 `Matplotlib`_ is also required. `SciPy`_ is also an optional dependency. When
 present, FFT-based continuous wavelet transforms will use FFTs from SciPy

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,10 +7,6 @@
 
 environment:
   matrix:
-    - PYTHON: "C:\\Python35"
-    - PYTHON: "C:\\Python35-x64"
-    - PYTHON: "C:\\Python36"
-    - PYTHON: "C:\\Python36-x64"
     - PYTHON: "C:\\Python37"
     - PYTHON: "C:\\Python37-x64"
     - PYTHON: "C:\\Python38"

--- a/doc/release/1.2.0-notes.rst
+++ b/doc/release/1.2.0-notes.rst
@@ -1,0 +1,30 @@
+==============================
+PyWavelets 1.2.0 Release Notes
+==============================
+
+.. contents::
+
+We are very pleased to announce the release of PyWavelets 1.2.
+
+PyWavelets now requires Python 3.7+.
+
+
+New features
+============
+
+
+Backwards incompatible changes
+==============================
+
+
+Bugs Fixed
+==========
+
+
+Other changes
+=============
+
+- PyWavelets has dropped support for Python 3.5 and 3.6 in this release.
+
+Authors
+=======

--- a/doc/source/dev/installing_build_dependencies.rst
+++ b/doc/source/dev/installing_build_dependencies.rst
@@ -20,7 +20,7 @@ Installing Cython
 Use ``pip`` (http://pypi.python.org/pypi/pip) to install Cython_::
 
 
-    pip install Cython>=0.16
+    pip install Cython
 
 
 Installing numpy

--- a/doc/source/dev/preparing_windows_build_environment.rst
+++ b/doc/source/dev/preparing_windows_build_environment.rst
@@ -14,7 +14,7 @@ Depending on your Python version, a different version of the Microsoft Visual
 C++ compiler will be required to build extensions. The same compiler that was
 used to build Python itself should be used.
 
-For Python 3.5, 3.6 and 3.7 it will be MSVC 2015.
+For Python 3.7 or 3.8 it will be MSVC 2015.
 
 The MSVC version should be printed when starting a Python REPL, and can be
 checked against the note below:

--- a/doc/source/dev/testing.rst
+++ b/doc/source/dev/testing.rst
@@ -45,9 +45,9 @@ Running tests with Tox
 ----------------------
 
 There's also a config file for running tests with `Tox`_ (``pip install tox``).
-To for example run tests for Python 3.5 and 3.6 use::
+To for example run tests for Python 3.7 and 3.8 use::
 
-  tox -e py35,py36
+  tox -e py37,py38
 
 For more information see the `Tox`_ documentation.
 

--- a/setup.py
+++ b/setup.py
@@ -423,8 +423,6 @@ def setup_package():
             "Programming Language :: C",
             "Programming Language :: Python",
             "Programming Language :: Python :: 3",
-            "Programming Language :: Python :: 3.5",
-            "Programming Language :: Python :: 3.6",
             "Programming Language :: Python :: 3.7",
             "Programming Language :: Python :: 3.8",
             "Topic :: Software Development :: Libraries :: Python Modules"
@@ -442,7 +440,7 @@ def setup_package():
 
         install_requires=["numpy>=1.13.3"],
         setup_requires=["numpy>=1.13.3"],
-        python_requires=">=3.5",
+        python_requires=">=3.7",
     )
 
     if "--force" in sys.argv:

--- a/setup.py
+++ b/setup.py
@@ -438,8 +438,8 @@ def setup_package():
         cmdclass={'develop': develop_build_clib, 'test': PyTest},
         tests_require=['pytest'],
 
-        install_requires=["numpy>=1.13.3"],
-        setup_requires=["numpy>=1.13.3"],
+        install_requires=["numpy>=1.14.6"],
+        setup_requires=["numpy>=1.14.6"],
         python_requires=">=3.7",
     )
 

--- a/tox.ini
+++ b/tox.ini
@@ -13,14 +13,14 @@
 #     - Use pip to install the pywt sdist into the virtualenv
 #     - Run the pywt tests
 # To run against a specific subset of Python versions, use:
-#   tox -e py36,py37
+#   tox -e py37,py38
 
 # Tox assumes that you have appropriate Python interpreters already
-# installed and that they can be run as 'python3.6', 'python3.7', etc.
+# installed and that they can be run as 'python3.7', 'python3.8', etc.
 
 [tox]
 toxworkdir = {homedir}/.tox/pywt/
-envlist = py35, py36, py37
+envlist = py37, py38
 
 [testenv]
 deps =


### PR DESCRIPTION
In think all cases in `.travis.yml` are still distinct. (The cases bumped from 3.6->3.7 were testing wheel builds instead of sdist)