### PR TITLE
MAINT: update copyright year in license file to 2020

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,5 +1,5 @@
 Copyright (c) 2006-2012 Filip Wasilewski <http://en.ig.ma/>
-Copyright (c) 2012-2019 The PyWavelets Developers <https://github.com/PyWavelets/pywt>
+Copyright (c) 2012-2020 The PyWavelets Developers <https://github.com/PyWavelets/pywt>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in

--- a/pywt/__init__.py
+++ b/pywt/__init__.py
@@ -1,9 +1,9 @@
 # flake8: noqa
 
 # Copyright (c) 2006-2012 Filip Wasilewski <http://en.ig.ma/>
-# Copyright (c) 2012-2016 The PyWavelets Developers
+# Copyright (c) 2012-2020 The PyWavelets Developers
 #                         <https://github.com/PyWavelets/pywt>
-# See COPYING for license details.
+# See LICENSE for more details.
 
 """
 Discrete forward and inverse wavelet transform, stationary wavelet transform,


### PR DESCRIPTION
The main purpose of this PR is actually to trigger CI, to see if `setuptools 50.0` broke the build.