### PR TITLE
remove unneeded PYTHONHASHSEED=0 from pytest.ini

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -10,6 +10,3 @@ filterwarnings =
     ignore:numpy.dtype size changed
     ignore:numpy.ufunc size changed
     ignore::UserWarning:cpuinfo,
-
-env =
-    PYTHONHASHSEED=0


### PR DESCRIPTION
When trying to run tests with pytest 6.1, I was encountering the following error:

```
PyWavelets version 1.1.1
Compiled with C99 complex support.
INTERNALERROR> Traceback (most recent call last):
INTERNALERROR>   File "/home/lee8rx/miniconda3/envs/pyir/lib/python3.7/site-packages/_pytest/main.py", line 257, in wrap_session
INTERNALERROR>     session.exitstatus = doit(config, session) or 0
INTERNALERROR>   File "/home/lee8rx/miniconda3/envs/pyir/lib/python3.7/site-packages/_pytest/main.py", line 312, in _main
INTERNALERROR>     config.hook.pytest_collection(session=session)
INTERNALERROR>   File "/home/lee8rx/miniconda3/envs/pyir/lib/python3.7/site-packages/pluggy/hooks.py", line 286, in __call__
INTERNALERROR>     return self._hookexec(self, self.get_hookimpls(), kwargs)
INTERNALERROR>   File "/home/lee8rx/miniconda3/envs/pyir/lib/python3.7/site-packages/pluggy/manager.py", line 93, in _hookexec
INTERNALERROR>     return self._inner_hookexec(hook, methods, kwargs)
INTERNALERROR>   File "/home/lee8rx/miniconda3/envs/pyir/lib/python3.7/site-packages/pluggy/manager.py", line 87, in <lambda>
INTERNALERROR>     firstresult=hook.spec.opts.get("firstresult") if hook.spec else False,
INTERNALERROR>   File "/home/lee8rx/miniconda3/envs/pyir/lib/python3.7/site-packages/pluggy/callers.py", line 203, in _multicall
INTERNALERROR>     gen.send(outcome)
INTERNALERROR>   File "/home/lee8rx/miniconda3/envs/pyir/lib/python3.7/site-packages/_pytest/config/__init__.py", line 1207, in pytest_collection
INTERNALERROR>     self._validate_config_options()
INTERNALERROR>   File "/home/lee8rx/miniconda3/envs/pyir/lib/python3.7/site-packages/_pytest/config/__init__.py", line 1230, in _validate_config_options
INTERNALERROR>     self._warn_or_fail_if_strict("Unknown config option: {}\n".format(key))
INTERNALERROR>   File "/home/lee8rx/miniconda3/envs/pyir/lib/python3.7/site-packages/_pytest/config/__init__.py", line 1266, in _warn_or_fail_if_strict
INTERNALERROR>     self.issue_config_time_warning(PytestConfigWarning(message), stacklevel=3)
INTERNALERROR>   File "/home/lee8rx/miniconda3/envs/pyir/lib/python3.7/site-packages/_pytest/config/__init__.py", line 1318, in issue_config_time_warning
INTERNALERROR>     warnings.warn(warning, stacklevel=stacklevel)
INTERNALERROR> pytest.PytestConfigWarning: Unknown config option: env
```

The error goes away if `pytest-env` is also installed. This is due to the env configuration option in our pytest.ini. I think this option was copied from NumPy and is not needed here, so I have removed it rather than requiring pytest-env for testing.

