### PR TITLE
ENH: allow user to set `precision` in CWT, increase default to 12

### DIFF
--- a/pywt/_cwt.py
+++ b/pywt/_cwt.py
@@ -24,7 +24,7 @@ def next_fast_len(n):
     return 2**ceil(np.log2(n))
 
 
-def cwt(data, scales, wavelet, sampling_period=1., method='conv', axis=-1):
+def cwt(data, scales, wavelet, sampling_period=1., method='conv', precision=12, axis=-1):
     """
     cwt(data, scales, wavelet)
 
@@ -57,6 +57,11 @@ def cwt(data, scales, wavelet, sampling_period=1., method='conv', axis=-1):
         The ``fft`` method is ``O(N * log2(N))`` with
         ``N = len(scale) + len(data) - 1``. It is well suited for large size
         signals but slightly slower than ``conv`` on small ones.
+    precision: int, optional
+        Length of wavelet (2 ** precision) used to compute the CWT. Greater
+        will increase resolution, especially for lower and higher scales,
+        but compute a bit slower. Too low will distort coefficients
+        and their norms, with a zipper-like effect; recommended >= 12.
     axis: int, optional
         Axis over which to compute the CWT. If not given, the last axis is
         used.
@@ -116,7 +121,7 @@ def cwt(data, scales, wavelet, sampling_period=1., method='conv', axis=-1):
 
     dt_out = dt_cplx if wavelet.complex_cwt else dt
     out = np.empty((np.size(scales),) + data.shape, dtype=dt_out)
-    precision = 10
+
     int_psi, x = integrate_wavelet(wavelet, precision=precision)
     int_psi = np.conj(int_psi) if wavelet.complex_cwt else int_psi
 

--- a/pywt/_cwt.py
+++ b/pywt/_cwt.py
@@ -24,7 +24,8 @@ def next_fast_len(n):
     return 2**ceil(np.log2(n))
 
 
-def cwt(data, scales, wavelet, sampling_period=1., method='conv', precision=12, axis=-1):
+def cwt(data, scales, wavelet, sampling_period=1., method='conv', 
+        precision=12, axis=-1):
     """
     cwt(data, scales, wavelet)
 

--- a/pywt/_cwt.py
+++ b/pywt/_cwt.py
@@ -27,8 +27,6 @@ def next_fast_len(n):
 def cwt(data, scales, wavelet, sampling_period=1., method='conv', axis=-1,
         *, precision=12):
     """
-    cwt(data, scales, wavelet)
-
     One dimensional Continuous Wavelet Transform.
 
     Parameters

--- a/pywt/_cwt.py
+++ b/pywt/_cwt.py
@@ -59,9 +59,9 @@ def cwt(data, scales, wavelet, sampling_period=1., method='conv', precision=12, 
         signals but slightly slower than ``conv`` on small ones.
     precision: int, optional
         Length of wavelet (2 ** precision) used to compute the CWT. Greater
-        will increase resolution, especially for lower and higher scales,
-        but compute a bit slower. Too low will distort coefficients
-        and their norms, with a zipper-like effect; recommended >= 12.
+        will increase resolution, especially for higher scales, but will
+        compute a bit slower. Too low will distort coefficients and their
+        norms, with a zipper-like effect; recommended >= 12.
     axis: int, optional
         Axis over which to compute the CWT. If not given, the last axis is
         used.

--- a/pywt/_cwt.py
+++ b/pywt/_cwt.py
@@ -24,8 +24,8 @@ def next_fast_len(n):
     return 2**ceil(np.log2(n))
 
 
-def cwt(data, scales, wavelet, sampling_period=1., method='conv', 
-        precision=12, axis=-1):
+def cwt(data, scales, wavelet, sampling_period=1., method='conv', axis=-1,
+        *, precision=12):
     """
     cwt(data, scales, wavelet)
 
@@ -58,14 +58,15 @@ def cwt(data, scales, wavelet, sampling_period=1., method='conv',
         The ``fft`` method is ``O(N * log2(N))`` with
         ``N = len(scale) + len(data) - 1``. It is well suited for large size
         signals but slightly slower than ``conv`` on small ones.
-    precision: int, optional
-        Length of wavelet (2 ** precision) used to compute the CWT. Greater
-        will increase resolution, especially for higher scales, but will
-        compute a bit slower. Too low will distort coefficients and their
-        norms, with a zipper-like effect; recommended >= 12.
     axis: int, optional
         Axis over which to compute the CWT. If not given, the last axis is
         used.
+    precision: int, optional
+        Length of wavelet (``2 ** precision``) used to compute the CWT. Greater
+        will increase resolution, especially for higher scales, but will
+        compute a bit slower. Too low will distort coefficients and their
+        norms, with a zipper-like effect. The default is 12, it's recommended
+        to use >=12.
 
     Returns
     -------

--- a/pywt/tests/test_matlab_compatibility_cwt.py
+++ b/pywt/tests/test_matlab_compatibility_cwt.py
@@ -149,7 +149,7 @@ def _load_matlab_result_psi(wavelet):
 
 def _check_accuracy(data, w, scales, coefs, wavelet, epsilon):
     # PyWavelets result
-    coefs_pywt, freq = pywt.cwt(data, scales, w)
+    coefs_pywt, freq = pywt.cwt(data, scales, w, precision=10)
 
     # coefs from Matlab are from R2012a which is missing the complex conjugate
     # as shown in Eq. 2 of Torrence and Compo. We take the complex conjugate of


### PR DESCRIPTION
Addresses [this Issue](https://github.com/PyWavelets/pywt/issues/531#issue-510962058). Detailed explanation [here](https://dsp.stackexchange.com/a/70643/50076); a summary:

 1. Low `precision` distorts CWT, and heavily at high scales. 
 2. With the L2-norm used, scales beyond `64` are _increasingly_ distorted.
 3. Zipper-like artifacts can be seen in computed heatmaps
 4. `precision=10` is low, and `precision=12` does not add much computation cost, while considerably remedying 1-3.

At the least, the user should get to decide `precision` instead of carving it in stone. And a doc/comment should be made about these caveats.

<hr>

**Improvement comparison**

<img src="https://user-images.githubusercontent.com/16495490/94836413-02f6e200-0424-11eb-994f-e495c3ecb96f.png" width="450">

<details>
  <summary><b>Code</b></summary>

```python
import numpy as np
import matplotlib.pyplot as plt

from pywt._extensions._pywt import DiscreteContinuousWavelet
from pywt._functions import integrate_wavelet
#%%##########################################################################
def l2(x):
    return np.sqrt(np.sum(np.abs(x ** 2)))

scales = np.power(2 ** (1 / 32), np.arange(1, 320 + 1))
wavelet = DiscreteContinuousWavelet('morl')
#%%##########################################################################
l2res = []
for precision in (10, 12, 14):
    l2res.append([])
    for scale in scales:
        int_psi, x = integrate_wavelet(wavelet, precision=precision)
        step = x[1] - x[0]
        linrange = max(x) - min(x)

        j = np.arange(scale * linrange + 1) / (scale * step)
        j = j.astype(int)  # floor
        if j[-1] >= int_psi.size:
            j = np.extract(j < int_psi.size, j)
        int_psi_scale = int_psi[j][::-1].real
        l2res[-1].append(l2(np.diff(int_psi_scale) * np.sqrt(scale)))
    
#%%##########################################################################
plt.plot(np.log2(scales), l2res[0])
plt.plot(np.log2(scales), l2res[1])
plt.plot(np.log2(scales), l2res[2])
plt.show()
```

</details>