### PR TITLE
Proof of concept on how to fix issues #531, #535 and #570

### DIFF
--- a/pywt/_functions.py
+++ b/pywt/_functions.py
@@ -17,8 +17,8 @@ from numpy.fft import fft
 from ._extensions._pywt import DiscreteContinuousWavelet, Wavelet, ContinuousWavelet
 
 
-__all__ = ["integrate_wavelet", "central_frequency", "scale2frequency", "qmf",
-           "orthogonal_filter_bank",
+__all__ = ["integrate_wavelet", "evaluate_wavelet", "central_frequency", 
+           "scale2frequency", "qmf", "orthogonal_filter_bank",
            "intwave", "centrfrq", "scal2frq", "orthfilt"]
 
 
@@ -117,6 +117,57 @@ def integrate_wavelet(wavelet, precision=8):
         phi_d, psi_d, phi_r, psi_r, x = functions_approximations
         step = x[1] - x[0]
         return _integrate(psi_d, step), _integrate(psi_r, step), x
+
+
+def evaluate_wavelet(wavelet, precision=8):
+    """
+    Evaluate `psi` wavelet function between lower and upper bound.
+
+    Parameters
+    ----------
+    wavelet : Wavelet instance or str
+        Wavelet to evaluate.  If a string, should be the name of a wavelet.
+    precision : int, optional
+        Number of wavelet function points computed with Wavelet's 
+        wavefun(level=precision) method (default: 8).
+
+    Returns
+    -------
+    [psi, x] :
+        for orthogonal wavelets
+    [psi_d, psi_r, x] :
+        for other wavelets
+
+
+    Examples
+    --------
+    >>> from pywt import Wavelet, evaluate_wavelet
+    >>> wavelet1 = Wavelet('db2')
+    >>> [psi, x] = evaluate_wavelet(wavelet1, precision=5)
+    >>> wavelet2 = Wavelet('bior1.3')
+    >>> [psi_d, psi_r, x] = evaluate_wavelet(wavelet2, precision=5)
+
+    """
+
+    if type(wavelet) in (tuple, list):
+        psi, x = np.asarray(wavelet[0]), np.asarray(wavelet[1])
+        return psi, x
+    elif not isinstance(wavelet, (Wavelet, ContinuousWavelet)):
+        wavelet = DiscreteContinuousWavelet(wavelet)
+
+    functions_approximations = wavelet.wavefun(precision)
+
+    if len(functions_approximations) == 2:      # continuous wavelet
+        psi, x = functions_approximations
+        return psi, x
+
+    elif len(functions_approximations) == 3:    # orthogonal wavelet
+        phi, psi, x = functions_approximations
+        return psi, x
+
+    else:                                       # biorthogonal wavelet
+        phi_d, psi_d, phi_r, psi_r, x = functions_approximations
+        return psi_d, psi_r, x
 
 
 def central_frequency(wavelet, precision=8):


### PR DESCRIPTION
This pull request is intended as a proof of concept to fix several issues of the CWT:
* #531  Precision of CWT
* #535  Complex Morlet wavelet not symmetric at fractional scales
* #570  Allow user to set precision in CWT

The issues are due to some pecularities of the CWT implementation:
* The wavelet function is sampled at 2**precision points. To compute the CWT, actual sampling instants are replaced by the values at the nearest (truncated) precomputed sampling instants. This yields inaccurate sampling values, which in turn results in all kinds of artefacts, as experienced in #531 and #570.
* The computation includes an integration step (using np.cumsum), followed later on by a differentiation step (using np.diff). This results in a loss of accuracy due to the accumulation of values (see #570). As far as I understand, the integration/differentiation step is not necessary at all and can be omitted.
* There is no provision to symmetrize sampling instants (see #535).

This pull request is intended as a starting point to remedy these problems.
The attached plots show that the problems described in #531 and #535 are no longer visible.
* The integration/differentation step has been removed.
* Sample values are taken at the correct sampling instants.
* If the range of the wavelet includes 0, samples are chosen such that 0 is a sampling instant.

Nevertheless, there are some open issues that have to be addressed:
* Currently, the samples are interpolated from 2**precision samples of the wavelet, which is a computationally efficient solution. There seems to be no need to increase precision beyond 10. However, this creates a dependency on scipy.interpolate due to the cubic spline interpolation.
There are at least two alternatives:
  * Apply linear interpolation with np.interp, which might impact accuracy
  * Evaluate the original wavelet, which likely increases computation time
* The scaling seems correct, but is it?
* Sampling instants might exclude upper and/or lower boundary points.
* One pywt test fails (test_cwt_small_scales).
![Issue_531](https://user-images.githubusercontent.com/5549788/95748758-cd12f280-0c9a-11eb-8443-0642434a33ee.png)
![Issue_535](https://user-images.githubusercontent.com/5549788/95748768-d13f1000-0c9a-11eb-97f2-52447f82ab07.png)