### PR TITLE
Drop unintended Python 3.6 builds from Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,8 @@
 # After changing this file, check it on:
 #   http://lint.travis-ci.org/
 language: python
-os: linux
 dist: xenial
-arch:
-    - amd64
-    - arm64
+
 env:
   global:
     # Use non-interactive backend


### PR DESCRIPTION
I think when we added AArch64 we unintentionally caused a couple of Python 3.6 builds to be run. 