### PR TITLE
CWT: Interpolate wavelet values (Issue #531)

### DIFF
--- a/pywt/_cwt.py
+++ b/pywt/_cwt.py
@@ -146,10 +146,12 @@ def cwt(data, scales, wavelet, sampling_period=1., method='conv', axis=-1):
         data = data.reshape((-1, data.shape[-1]))
 
     for i, scale in enumerate(scales):
+        # Determine scale-dependent sampling instants
         step = 1.0 / scale
-        xs = np.arange(x[0], x[-1]+0.1*step, step)
-        if xs[-1] >= x[-1]:
+        xs = np.arange(x[0], x[-1]+0.01*step, step)
+        if xs[-1] > x[-1]:
             xs = xs[:-1]
+        # Approximate values by linear interpolation
         int_psi_scale = np.interp(xs, x, int_psi)[::-1]
 
         if method == 'conv':

--- a/pywt/_cwt.py
+++ b/pywt/_cwt.py
@@ -146,12 +146,11 @@ def cwt(data, scales, wavelet, sampling_period=1., method='conv', axis=-1):
         data = data.reshape((-1, data.shape[-1]))
 
     for i, scale in enumerate(scales):
-        step = x[1] - x[0]
-        j = np.arange(scale * (x[-1] - x[0]) + 1) / (scale * step)
-        j = j.astype(int)  # floor
-        if j[-1] >= int_psi.size:
-            j = np.extract(j < int_psi.size, j)
-        int_psi_scale = int_psi[j][::-1]
+        step = 1.0 / scale
+        xs = np.arange(x[0], x[-1]+0.1*step, step)
+        if xs[-1] >= x[-1]:
+            xs = xs[:-1]
+        int_psi_scale = np.interp(xs, x, int_psi)[::-1]
 
         if method == 'conv':
             if data.ndim == 1:


### PR DESCRIPTION
The current implementation of CWT first takes equi-distant samples (currently 1024) over the range of the wavelet, then integrates the samples using `np.cumsum`.

Later on, the correct sampling instants are determined for each scale. The sample _values_ are approximated by taking the value of the precomputed integral at the next smaller sampling instant. One can also view this as sampling jitter. It results in clearly visible artefacts (see issues #531 and #570).

This pull request aims to (mostly) eliminate the visible artefacts by _interpolating_ the integral values at the scale-dependent sampling instants. This approximation is obviously more accurate (except perhaps for pathological cases), as can be seen in the attached plots. It is also low-complexity and avoids potentially expensive recomputing of wavelet samples.

The pull request is a result of the discussions about pull request #574. It solves the most urgent (and least controversial) issue addressed in #574, namely the strong visible artefacts at higher scales.

The proposed code passed all tests when running `pywt.tests()`.

![pywt_old](https://user-images.githubusercontent.com/5549788/98568992-021e5f00-22b2-11eb-9116-5a3c9064ca49.png)
![pywt_new](https://user-images.githubusercontent.com/5549788/98569074-19f5e300-22b2-11eb-8677-a2f9b6be434d.png)
