### PR TITLE
MAINT: remove use of deprecated np.int/float aliases

### DIFF
--- a/demo/fswavedecn_mondrian.py
+++ b/demo/fswavedecn_mondrian.py
@@ -32,12 +32,12 @@ def mondrian(shape=(256, 256), nx=5, ny=8, seed=4):
     rstate = np.random.RandomState(seed)
     min_dx = 0
     while(min_dx < 3):
-        xp = np.sort(np.round(rstate.rand(nx-1)*shape[0]).astype(np.int))
+        xp = np.sort(np.round(rstate.rand(nx-1)*shape[0]).astype(np.int64))
         xp = np.concatenate(((0, ), xp, (shape[0], )))
         min_dx = np.min(np.diff(xp))
     min_dy = 0
     while(min_dy < 3):
-        yp = np.sort(np.round(rstate.rand(ny-1)*shape[1]).astype(np.int))
+        yp = np.sort(np.round(rstate.rand(ny-1)*shape[1]).astype(np.int64))
         yp = np.concatenate(((0, ), yp, (shape[1], )))
         min_dy = np.min(np.diff(yp))
     img = np.zeros(shape)

--- a/doc/source/pyplots/cwt_scaling_demo.py
+++ b/doc/source/pyplots/cwt_scaling_demo.py
@@ -24,7 +24,7 @@ for n, scale in enumerate(scales):
         np.arange(scale * width + 1) / (scale * step))
     if np.max(j) >= np.size(int_psi):
         j = np.delete(j, np.where((j >= np.size(int_psi)))[0])
-    j = j.astype(np.int)
+    j = j.astype(np.int_)
 
     # normalize int_psi for easier plotting
     int_psi /= np.abs(int_psi).max()

--- a/pywt/tests/test_cwt_wavelets.py
+++ b/pywt/tests/test_cwt_wavelets.py
@@ -127,7 +127,7 @@ def test_continuous_wavelet_invalid_dtype():
     with pytest.raises(ValueError):
         pywt.ContinuousWavelet('gaus5', np.complex64)
     with pytest.raises(ValueError):
-        pywt.ContinuousWavelet('gaus5', np.int)
+        pywt.ContinuousWavelet('gaus5', np.int_)
 
 
 def test_cgau():

--- a/pywt/tests/test_wavelet.py
+++ b/pywt/tests/test_wavelet.py
@@ -243,7 +243,7 @@ def test_wavefun_bior13():
                              0.03125, -0.0625, -0.09375, -0.125, -0.15234375,
                              -0.12890625, -0.03515625, 0.00390625, 0.01367188,
                              0.01757813, 0.00195313, -0.00195313, 0., 0., 0.])
-    phi_r_expect = np.zeros(x.size, dtype=np.float)
+    phi_r_expect = np.zeros(x.size, dtype=np.float64)
     phi_r_expect[15:23] = 1
 
     psi_d_expect = np.array([0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -253,7 +253,7 @@ def test_wavefun_bior13():
                              0.03125, 0.109375, 0.140625, 0.015625, -0.015625,
                              0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0])
 
-    psi_r_expect = np.zeros(x.size, dtype=np.float)
+    psi_r_expect = np.zeros(x.size, dtype=np.float64)
     psi_r_expect[7:15] = -0.125
     psi_r_expect[15:19] = 1
     psi_r_expect[19:23] = -1


### PR DESCRIPTION
Deprecated in numpy 1.20.0