### PR TITLE
Add wheel building and deployment via GitHub Actions and cibuildwheel

### DIFF
--- a/.github/workflows/wheel_tests_and_release.yml
+++ b/.github/workflows/wheel_tests_and_release.yml
@@ -8,7 +8,7 @@ on:
       - 'buildwheels*'
 env:
   CIBW_BUILD_VERBOSITY: 2
-  CIBW_BEFORE_BUILD: pip install cython
+  # CIBW_BEFORE_BUILD: pip install cython
   CIBW_TEST_REQUIRES: pytest
   CIBW_TEST_COMMAND: pytest --pyargs pywt
 
@@ -27,10 +27,9 @@ jobs:
           - os: ubuntu-18.04
             cibw_python: "cp39-*"
             cibw_manylinux: manylinux2010
-        include:
           - os: ubuntu-18.04
             cibw_python: "cp310-*"
-            cibw_manylinux: manylinux2010
+            cibw_manylinux: manylinux2014
     steps:
       - uses: actions/checkout@v2
         with:
@@ -85,7 +84,7 @@ jobs:
         run: |
           python -m cibuildwheel --output-dir dist
         env:
-          CIBW_BUILD: "cp3?-* cp310-*"
+          CIBW_BUILD: "cp3?-*"  #  cp310-*
           CIBW_SKIP: "cp35-* cp36-*"
           CIBW_MANYLINUX_X86_64_IMAGE: manylinux1
           CIBW_MANYLINUX_I686_IMAGE: manylinux1
@@ -126,7 +125,7 @@ jobs:
         run: |
           python -m cibuildwheel --output-dir dist
         env:
-          CIBW_BUILD: "cp3?-* cp310-*"
+          CIBW_BUILD: "cp3?-*"  #  cp310-*
           CIBW_SKIP: "cp35-* cp36-*"
           CIBW_MANYLINUX_X86_64_IMAGE: manylinux1
           CIBW_MANYLINUX_I686_IMAGE: manylinux1
@@ -137,47 +136,47 @@ jobs:
           path: ./dist/*.whl
 
 
-  # deploy:
-  #   name: Release
-  #   needs: [build_linux_37_and_above_wheels, build_macos_wheels, build_windows_wheels]
-  #   if: github.repository_owner == 'PyWavelets' && startsWith(github.ref, 'refs/tags/v') && always()
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - uses: actions/checkout@v2
-  #       with:
-  #         fetch-depth: 0
-  #     - uses: actions/setup-python@v2
-  #       name: Install Python
-  #       with:
-  #         python-version: '3.7'
+  deploy:
+    name: Release
+    needs: [build_linux_37_and_above_wheels, build_macos_wheels, build_windows_wheels]
+    if: github.repository_owner == 'PyWavelets' && startsWith(github.ref, 'refs/tags/v') && always()
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-python@v2
+        name: Install Python
+        with:
+          python-version: '3.7'
       
-  #     - name: Install Twine
-  #       run: |
-  #         python -m pip install --upgrade pip
-  #         pip install -r requirements/build.txt
-  #         pip install twine
+      - name: Install Twine
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements/build.txt
+          pip install twine
       
-  #     - uses: actions/download-artifact@v2
-  #       id: download
-  #       with:
-  #         name: wheels
-  #         path: ./dist
+      - uses: actions/download-artifact@v2
+        id: download
+        with:
+          name: wheels
+          path: ./dist
     
-  #     - name: Publish the source distribution on PyPI
-  #       run: |
-  #         PYWT_VERSION=$(git describe --tags)
-  #         python setup.py sdist
-  #         ls -la ${{ github.workspace }}/dist
-  #         # We prefer to release wheels before source because otherwise there is a
-  #         # small window during which users who pip install pywt will require compilation.
-  #         twine upload ${{ github.workspace }}/dist/*.whl
-  #         twine upload ${{ github.workspace }}/dist/pywt-${PYWT_VERSION:1}.tar.gz
-  #       env:
-  #         TWINE_USERNAME: ${{ secrets.TWINE_USERNAME }}
-  #         TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
+      - name: Publish the source distribution on PyPI
+        run: |
+          PYWT_VERSION=$(git describe --tags)
+          python setup.py sdist
+          ls -la ${{ github.workspace }}/dist
+          # We prefer to release wheels before source because otherwise there is a
+          # small window during which users who pip install pywt will require compilation.
+          twine upload ${{ github.workspace }}/dist/*.whl
+          twine upload ${{ github.workspace }}/dist/pywt-${PYWT_VERSION:1}.tar.gz
+        env:
+          TWINE_USERNAME: ${{ secrets.TWINE_USERNAME }}
+          TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
               
-  #     - name: Github release
-  #       uses: softprops/action-gh-release@v1
-  #       env:
-  #         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  #         GITHUB_REPOSITORY: ${{ github.repository }}
+      - name: Github release
+        uses: softprops/action-gh-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}

--- a/.github/workflows/wheel_tests_and_release.yml
+++ b/.github/workflows/wheel_tests_and_release.yml
@@ -8,7 +8,7 @@ on:
       - 'buildwheels*'
 env:
   CIBW_BUILD_VERBOSITY: 2
-  CIBW_BEFORE_BUILD: pip install numpy cython
+  CIBW_BEFORE_BUILD: pip install cython
   CIBW_TEST_REQUIRES: pytest
   CIBW_TEST_COMMAND: pytest --pyargs pywt
 
@@ -26,6 +26,10 @@ jobs:
         include:
           - os: ubuntu-18.04
             cibw_python: "cp39-*"
+            cibw_manylinux: manylinux2010
+        include:
+          - os: ubuntu-18.04
+            cibw_python: "cp310-*"
             cibw_manylinux: manylinux2010
     steps:
       - uses: actions/checkout@v2
@@ -81,11 +85,10 @@ jobs:
         run: |
           python -m cibuildwheel --output-dir dist
         env:
-          CIBW_BUILD: "cp3?-*"
+          CIBW_BUILD: "cp3?-* cp310-*"
           CIBW_SKIP: "cp35-* cp36-*"
           CIBW_MANYLINUX_X86_64_IMAGE: manylinux1
           CIBW_MANYLINUX_I686_IMAGE: manylinux1
-          # CIBW_BEFORE_BUILD: pip install certifi numpy==1.16
           CC: /usr/bin/clang
           CXX: /usr/bin/clang++
           # CPPFLAGS: "-Xpreprocessor -fopenmp"
@@ -123,11 +126,10 @@ jobs:
         run: |
           python -m cibuildwheel --output-dir dist
         env:
-          CIBW_BUILD: "cp3?-*"
+          CIBW_BUILD: "cp3?-* cp310-*"
           CIBW_SKIP: "cp35-* cp36-*"
           CIBW_MANYLINUX_X86_64_IMAGE: manylinux1
           CIBW_MANYLINUX_I686_IMAGE: manylinux1
-          # CIBW_BEFORE_BUILD: pip install certifi numpy==1.16
 
       - uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/wheel_tests_and_release.yml
+++ b/.github/workflows/wheel_tests_and_release.yml
@@ -1,0 +1,181 @@
+name: Build Wheels and Release
+on:
+  push:
+    branches:
+      - cibuildwheel
+    tags:
+      - 'v*'
+      - 'buildwheels*'
+env:
+  CIBW_BUILD_VERBOSITY: 2
+  CIBW_BEFORE_BUILD: pip install numpy cython
+  CIBW_TEST_REQUIRES: pytest
+  CIBW_TEST_COMMAND: pytest --pyargs pywt
+
+
+jobs:
+  build_linux_37_and_above_wheels:
+    name: Build python ${{ matrix.cibw_python }} wheels on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-18.04]
+        cibw_python: [ "cp37-*", "cp38-*" ]
+        cibw_manylinux: [ manylinux1 ]
+        include:
+          - os: ubuntu-18.04
+            cibw_python: "cp39-*"
+            cibw_manylinux: manylinux2010
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-python@v2
+        name: Install Python
+        with:
+          python-version: '3.7'
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+        with:
+          platforms: arm64
+      - name: Install cibuildwheel
+        run: |
+          python -m pip install cibuildwheel
+      - name: Build the wheel
+        run: |
+          python -m cibuildwheel --output-dir dist
+        env:
+          CIBW_BUILD: ${{ matrix.cibw_python }}
+          CIBW_ARCHS_LINUX: auto aarch64
+          CIBW_MANYLINUX_X86_64_IMAGE: ${{ matrix.cibw_manylinux }}
+          CIBW_MANYLINUX_I686_IMAGE: ${{ matrix.cibw_manylinux }}
+      - uses: actions/upload-artifact@v2
+        with:
+          name: wheels
+          path: ./dist/*.whl
+
+  build_macos_wheels:
+    name: Build wheels on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macos-latest]
+    env:
+      MACOSX_DEPLOYMENT_TARGET: "10.13"
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-python@v2
+        name: Install Python
+        with:
+          python-version: '3.7'
+
+      - name: Install cibuildwheel
+        run: |
+          python -m pip install cibuildwheel
+      - name: Build wheels for CPython (MacOS)
+        run: |
+          python -m cibuildwheel --output-dir dist
+        env:
+          CIBW_BUILD: "cp3?-*"
+          CIBW_SKIP: "cp35-* cp36-*"
+          CIBW_MANYLINUX_X86_64_IMAGE: manylinux1
+          CIBW_MANYLINUX_I686_IMAGE: manylinux1
+          # CIBW_BEFORE_BUILD: pip install certifi numpy==1.16
+          CC: /usr/bin/clang
+          CXX: /usr/bin/clang++
+          # CPPFLAGS: "-Xpreprocessor -fopenmp"
+          # CFLAGS: "-Wno-implicit-function-declaration -I/usr/local/opt/libomp/include"
+          # CXXFLAGS: "-I/usr/local/opt/libomp/include"
+          # LDFLAGS: "-Wl,-rpath,/usr/local/opt/libomp/lib -L/usr/local/opt/libomp/lib -lomp"
+
+      - uses: actions/upload-artifact@v2
+        with:
+          name: wheels
+          path: ./dist/*.whl
+
+  build_windows_wheels:
+    name: Build wheels on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [windows-latest]
+
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-python@v2
+        name: Install Python
+        with:
+          python-version: '3.7'
+
+      - name: Install cibuildwheel
+        run: |
+          python -m pip install cibuildwheel
+      - name: Build Windows wheels for CPython
+        run: |
+          python -m cibuildwheel --output-dir dist
+        env:
+          CIBW_BUILD: "cp3?-*"
+          CIBW_SKIP: "cp35-* cp36-*"
+          CIBW_MANYLINUX_X86_64_IMAGE: manylinux1
+          CIBW_MANYLINUX_I686_IMAGE: manylinux1
+          # CIBW_BEFORE_BUILD: pip install certifi numpy==1.16
+
+      - uses: actions/upload-artifact@v2
+        with:
+          name: wheels
+          path: ./dist/*.whl
+
+
+  # deploy:
+  #   name: Release
+  #   needs: [build_linux_37_and_above_wheels, build_macos_wheels, build_windows_wheels]
+  #   if: github.repository_owner == 'PyWavelets' && startsWith(github.ref, 'refs/tags/v') && always()
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - uses: actions/checkout@v2
+  #       with:
+  #         fetch-depth: 0
+  #     - uses: actions/setup-python@v2
+  #       name: Install Python
+  #       with:
+  #         python-version: '3.7'
+      
+  #     - name: Install Twine
+  #       run: |
+  #         python -m pip install --upgrade pip
+  #         pip install -r requirements/build.txt
+  #         pip install twine
+      
+  #     - uses: actions/download-artifact@v2
+  #       id: download
+  #       with:
+  #         name: wheels
+  #         path: ./dist
+    
+  #     - name: Publish the source distribution on PyPI
+  #       run: |
+  #         PYWT_VERSION=$(git describe --tags)
+  #         python setup.py sdist
+  #         ls -la ${{ github.workspace }}/dist
+  #         # We prefer to release wheels before source because otherwise there is a
+  #         # small window during which users who pip install pywt will require compilation.
+  #         twine upload ${{ github.workspace }}/dist/*.whl
+  #         twine upload ${{ github.workspace }}/dist/pywt-${PYWT_VERSION:1}.tar.gz
+  #       env:
+  #         TWINE_USERNAME: ${{ secrets.TWINE_USERNAME }}
+  #         TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
+              
+  #     - name: Github release
+  #       uses: softprops/action-gh-release@v1
+  #       env:
+  #         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  #         GITHUB_REPOSITORY: ${{ github.repository }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,37 @@
+# Note that in maintenance branches, all build dependencies should
+# have an upper bound equal to the most recent already-released version
+# of the dependency. This to prevent that a future backwards-incompatible
+# release will break the source build of a PyWavelets release.
+
+
+[build-system]
+requires = [
+    "wheel",
+    "setuptools",
+    "Cython>=0.29.18",
+
+    # NumPy dependencies - to update these, sync from
+    # https://github.com/scipy/oldest-supported-numpy/, and then
+    # update minimum version to match our install_requires min version
+    # ----------------------------------------------------------------
+
+    # numpy 1.19 was the first minor release to provide aarch64 wheels, but
+    # wheels require fixes contained in numpy 1.19.2
+    "numpy==1.19.2; python_version=='3.8' and platform_machine=='aarch64'",
+    # aarch64 for py39 is covered by default requirement below
+
+    # arm64 on Darwin supports Python 3.8 and above requires numpy>=1.20.0
+    "numpy==1.20.0; python_version=='3.8' and platform_machine=='arm64' and platform_system=='Darwin'",
+    "numpy==1.20.0; python_version=='3.9' and platform_machine=='arm64' and platform_system=='Darwin'",
+
+    # default numpy requirements
+    "numpy==1.17.3; python_version=='3.8' and (platform_machine!='arm64' or platform_system!='Darwin') and platform_machine!='aarch64' and platform_python_implementation != 'PyPy'",
+    "numpy==1.19.3; python_version=='3.9' and (platform_machine!='arm64' or platform_system!='Darwin') and platform_python_implementation != 'PyPy'",
+
+    # For Python versions which aren't yet officially supported,
+    # we specify an unpinned NumPy which allows source distributions
+    # to be used and allows wheels to be used as soon as they
+    # become available.
+    "numpy; python_version>='3.10'",
+    "numpy; python_version>='3.8' and platform_python_implementation=='PyPy'",
+]


### PR DESCRIPTION
This PR is adapted from scikit-image/scikit-image#5397. 

Apparently we had added `pyproject.toml` here long ago and then removed it due to some issues with `pip` at that time. This PR reintroduces it so that the correct NumPy version will be used during these builds (it is based on SciPy's, but without the Pythran or Pybind11 requirements).

This also has automated deployment when pushing a version tag. If the automated deploy fails, we can still retrieve the wheels from the artifacts.