### PR TITLE
MAINT: update pyproject.toml and setup.py for Python 3.10

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,11 +28,12 @@ requires = [
     "numpy==1.17.3; python_version=='3.7' and (platform_machine!='arm64' or platform_system!='Darwin') and platform_machine!='aarch64' and platform_python_implementation != 'PyPy'",
     "numpy==1.17.3; python_version=='3.8' and (platform_machine!='arm64' or platform_system!='Darwin') and platform_machine!='aarch64' and platform_python_implementation != 'PyPy'",
     "numpy==1.19.3; python_version=='3.9' and (platform_machine!='arm64' or platform_system!='Darwin') and platform_python_implementation != 'PyPy'",
+    "numpy==1.21.4; python_version=='3.10' and platform_python_implementation != 'PyPy'",
 
     # For Python versions which aren't yet officially supported,
     # we specify an unpinned NumPy which allows source distributions
     # to be used and allows wheels to be used as soon as they
     # become available.
-    "numpy; python_version>='3.10'",
+    "numpy; python_version>='3.11'",
     "numpy; python_version>='3.8' and platform_python_implementation=='PyPy'",
 ]

--- a/setup.py
+++ b/setup.py
@@ -426,6 +426,7 @@ def setup_package():
             "Programming Language :: Python :: 3.7",
             "Programming Language :: Python :: 3.8",
             "Programming Language :: Python :: 3.9",
+            "Programming Language :: Python :: 3.10",
             "Topic :: Software Development :: Libraries :: Python Modules"
         ],
         platforms=["Windows", "Linux", "Solaris", "Mac OS-X", "Unix"],
@@ -440,7 +441,6 @@ def setup_package():
         tests_require=['pytest'],
 
         install_requires=["numpy>=1.17.3"],
-        setup_requires=["numpy>=1.17.3"],
         python_requires=">=3.7",
     )
 


### PR DESCRIPTION
Also remove `setup_requires` from `setup.py`. This is no longer needed,'
removing it avoids using `easy_install`. The role that `setup_requires`
used to play is now played by `pyproject.toml`. This change was made
in SciPy quite a while ago, so it's safe by now.

gh-603 adds CI support for Python 3.10. Also, https://github.com/conda-forge/pywavelets-feedstock/pull/42 aims to build a 3.10 conda-forge package. So I think we're due for a new release here.