### PR TITLE
MAINT: fix doc build on ReadTheDocs

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -230,4 +230,4 @@ plot_html_show_source_link = False
 
 # Intersphinx to get Numpy and other targets
 intersphinx_mapping = {
-    'numpy': ('https://docs.scipy.org/doc/numpy/', None)}
+    'numpy': ('https://numpy.org/devdocs', None)}

--- a/util/readthedocs/requirements.txt
+++ b/util/readthedocs/requirements.txt
@@ -4,3 +4,4 @@ pytest
 wheel
 numpydoc
 matplotlib
+docutils<0.18


### PR DESCRIPTION
This is the workaround for https://github.com/sphinx-doc/sphinx/issues/9788

Also update the intersphinx link for NumPy. NumPy moved away from
docs.scipy.org quite a while ago. Pointing to numpy.org/devdocs
matches what SciPy does.