### PR TITLE
BLD: update Cython build dependency to recent release and <3.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@
 requires = [
     "wheel",
     "setuptools",
-    "Cython>=0.29.18",
+    "Cython>=0.29.24,<3.0",
 
     # NumPy dependencies - to update these, sync from
     # https://github.com/scipy/oldest-supported-numpy/, and then


### PR DESCRIPTION
This seems healthy, Cython 3.x alpha releases have significant changes in them.