### PR TITLE
Update GitHub Actions workflow to build Python 3.10 wheels

### DIFF
--- a/.github/workflows/wheel_tests_and_release.yml
+++ b/.github/workflows/wheel_tests_and_release.yml
@@ -1,6 +1,8 @@
 name: Build Wheels and Release
 on:
   push:
+    branches:
+      - 'wheels_py310'
     tags:
       - 'v*'
       - 'buildwheels*'

--- a/.github/workflows/wheel_tests_and_release.yml
+++ b/.github/workflows/wheel_tests_and_release.yml
@@ -1,8 +1,6 @@
 name: Build Wheels and Release
 on:
   push:
-    branches:
-      - 'wheels_py310'
     tags:
       - 'v*'
       - 'buildwheels*'
@@ -84,7 +82,7 @@ jobs:
         env:
           CIBW_BUILD: ${{ matrix.cibw_python }}
           CIBW_ARCHS_LINUX: aarch64
-          CIBW_SKIP: *-musllinux_*
+          CIBW_SKIP: "*-musllinux_*"
           CIBW_MANYLINUX_X86_64_IMAGE: ${{ matrix.cibw_manylinux }}
           CIBW_MANYLINUX_I686_IMAGE: ${{ matrix.cibw_manylinux }}
       - uses: actions/upload-artifact@v2

--- a/.github/workflows/wheel_tests_and_release.yml
+++ b/.github/workflows/wheel_tests_and_release.yml
@@ -84,6 +84,7 @@ jobs:
         env:
           CIBW_BUILD: ${{ matrix.cibw_python }}
           CIBW_ARCHS_LINUX: aarch64
+          CIBW_SKIP: *-musllinux_*
           CIBW_MANYLINUX_X86_64_IMAGE: ${{ matrix.cibw_manylinux }}
           CIBW_MANYLINUX_I686_IMAGE: ${{ matrix.cibw_manylinux }}
       - uses: actions/upload-artifact@v2

--- a/.github/workflows/wheel_tests_and_release.yml
+++ b/.github/workflows/wheel_tests_and_release.yml
@@ -25,6 +25,9 @@ jobs:
           - os: ubuntu-18.04
             cibw_python: "cp39-*"
             cibw_manylinux: manylinux2010
+          - os: ubuntu-18.04
+            cibw_python: "cp310-*"
+            cibw_manylinux: manylinux2014
     steps:
       - uses: actions/checkout@v2
         with:
@@ -79,7 +82,7 @@ jobs:
         run: |
           python -m cibuildwheel --output-dir dist
         env:
-          CIBW_BUILD: "cp3?-*"
+          CIBW_BUILD: "cp3?-* cp310-*"
           CIBW_SKIP: "cp36-*"
           CIBW_ARCHS_MACOS: x86_64 arm64 universal2
           CIBW_MANYLINUX_X86_64_IMAGE: manylinux1
@@ -121,7 +124,7 @@ jobs:
         run: |
           python -m cibuildwheel --output-dir dist
         env:
-          CIBW_BUILD: "cp3?-*"
+          CIBW_BUILD: "cp3?-* cp310-*"
           CIBW_SKIP: "cp36-*"
           CIBW_MANYLINUX_X86_64_IMAGE: manylinux1
           CIBW_MANYLINUX_I686_IMAGE: manylinux1

--- a/.github/workflows/wheel_tests_and_release.yml
+++ b/.github/workflows/wheel_tests_and_release.yml
@@ -38,6 +38,39 @@ jobs:
         name: Install Python
         with:
           python-version: '3.9'
+      - name: Install cibuildwheel
+        run: |
+          python -m pip install cibuildwheel
+      - name: Build the wheel
+        run: |
+          python -m cibuildwheel --output-dir dist
+        env:
+          CIBW_BUILD: ${{ matrix.cibw_python }}
+          CIBW_ARCHS_LINUX: x86_64 i686
+          CIBW_MANYLINUX_X86_64_IMAGE: ${{ matrix.cibw_manylinux }}
+          CIBW_MANYLINUX_I686_IMAGE: ${{ matrix.cibw_manylinux }}
+      - uses: actions/upload-artifact@v2
+        with:
+          name: wheels
+          path: ./dist/*.whl
+
+  build_linux_aarch64_wheels:
+    name: Build python ${{ matrix.cibw_python }} aarch64 wheels on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-18.04]
+        cibw_python: [ "cp37-*", "cp38-*" , "cp39-*", "cp310-*"]
+        cibw_manylinux: [ manylinux2014 ]
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-python@v2
+        name: Install Python
+        with:
+          python-version: '3.9'
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1
         with:
@@ -50,7 +83,7 @@ jobs:
           python -m cibuildwheel --output-dir dist
         env:
           CIBW_BUILD: ${{ matrix.cibw_python }}
-          CIBW_ARCHS_LINUX: auto aarch64
+          CIBW_ARCHS_LINUX: aarch64
           CIBW_MANYLINUX_X86_64_IMAGE: ${{ matrix.cibw_manylinux }}
           CIBW_MANYLINUX_I686_IMAGE: ${{ matrix.cibw_manylinux }}
       - uses: actions/upload-artifact@v2


### PR DESCRIPTION
This was tested on my local branch and all of the wheels built successfully (see: https://github.com/grlee77/pywt/runs/4132967779?check_suite_focus=true). 

I had to disable some `musl` wheels (see [PEP656](https://www.python.org/dev/peps/pep-0656/)) on aarch64 or those jobs are right around the timeout threshold. That timeout is why there is a `CIBW_SKIP: "*-musllinux_*"` set for this case.