### PR TITLE
MAINT: fix doc build issues

### DIFF
--- a/doc/source/ref/mra.rst
+++ b/doc/source/ref/mra.rst
@@ -1,4 +1,4 @@
-.. _ref-swt:
+.. _ref-mra:
 
 .. currentmodule:: pywt
 
@@ -27,17 +27,17 @@ Multilevel n-dimensional ``mran``
 .. autofunction:: mran
 
 Inverse Multilevel 1D ``imra``
-~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. autofunction:: imra
 
 Inverse Multilevel 2D ``imra2``
-~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. autofunction:: imra2
 
 Inverse Multilevel n-dimensional ``imran``
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. autofunction:: imran
 

--- a/doc/source/ref/wavelet-packets.rst
+++ b/doc/source/ref/wavelet-packets.rst
@@ -41,10 +41,6 @@ BaseNode - a common interface of WaveletPacket and WaveletPacket2D
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. class:: BaseNode
-           Node(BaseNode)
-           WaveletPacket(Node)
-           Node2D(BaseNode)
-           WaveletPacket2D(Node2D)
 
   .. note:: The BaseNode is a base class for :class:`Node` and :class:`Node2D`.
             It should not be used directly unless creating a new transformation
@@ -222,7 +218,6 @@ WaveletPacket and WaveletPacket tree Node
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. class:: Node(BaseNode)
-           WaveletPacket(Node)
 
   .. attribute:: node_name
 
@@ -276,7 +271,6 @@ WaveletPacket2D and WaveletPacket2D tree Node2D
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. class:: Node2D(BaseNode)
-           WaveletPacket2D(Node2D)
 
   .. attribute:: node_name
 

--- a/pywt/_mra.py
+++ b/pywt/_mra.py
@@ -41,7 +41,7 @@ def mra(data, wavelet, level=None, axis=-1, transform='swt',
 
     See Also
     --------
-    ``imra``, ``swt``
+    imra, swt
 
     Notes
     -----
@@ -128,7 +128,7 @@ def imra(mra_coeffs):
 
     See Also
     --------
-    ``mra``
+    mra
 
     References
     ----------
@@ -186,7 +186,7 @@ def mra2(data, wavelet, level=None, axes=(-2, -1), transform='swt2',
 
     See Also
     --------
-    ``imra2``, ``swt2``
+    imra2, swt2
 
     References
     ----------
@@ -264,7 +264,7 @@ def imra2(mra_coeffs):
 
     See Also
     --------
-    ``mra2``
+    mra2
 
     References
     ----------
@@ -311,7 +311,7 @@ def mran(data, wavelet, level=None, axes=None, transform='swtn',
 
     See Also
     --------
-    ``imran``, ``swtn``
+    imran, swtn
 
     Notes
     -----
@@ -411,7 +411,7 @@ def imran(mra_coeffs):
 
     See Also
     --------
-    ``mran``
+    mran
 
     References
     ----------


### PR DESCRIPTION
After the multi-resolution and n-D wavelet packets PRs
were merged, the doc build on RTD broke again (we have no CI
for doc build). This PR fixes all issues and warnings.

[ci skip]