### PR TITLE
Fix bugs in automated wheel deployment

### DIFF
--- a/.github/workflows/wheel_tests_and_release.yml
+++ b/.github/workflows/wheel_tests_and_release.yml
@@ -187,6 +187,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install twine
+          pip install "cython<3" numpy
       
       - uses: actions/download-artifact@v2
         id: download

--- a/.github/workflows/wheel_tests_and_release.yml
+++ b/.github/workflows/wheel_tests_and_release.yml
@@ -171,7 +171,7 @@ jobs:
 
   deploy:
     name: Release
-    needs: [build_linux_37_and_above_wheels, build_macos_wheels, build_windows_wheels]
+    needs: [build_linux_37_and_above_wheels, build_linux_aarch64_wheels, build_macos_wheels, build_windows_wheels]
     if: github.repository_owner == 'PyWavelets' && startsWith(github.ref, 'refs/tags/v') && always()
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Wheels built successfully for v1.2.0, but the automated wheel deployment failed. As a workaround, wheels for v1.2.0 were manually uploaded using twine.

This PR should fix two issues that occurred:
1.) The deployment was attempted before the `aarch64` wheels builds had completed.
2.) Creating the sdist failed because Cython was missing