### PR TITLE
DOC: Fix level of headers

### DIFF
--- a/doc/source/ref/idwt-inverse-discrete-wavelet-transform.rst
+++ b/doc/source/ref/idwt-inverse-discrete-wavelet-transform.rst
@@ -14,12 +14,12 @@ Single level ``idwt``
 
 
 Multilevel reconstruction using ``waverec``
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+-------------------------------------------
 
 .. autofunction:: waverec
 
 
 Direct reconstruction with ``upcoef``
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+-------------------------------------
 
 .. autofunction:: upcoef


### PR DESCRIPTION
The `waverec` and `upcoef` header levels were one step deeper and didn't appear on the index page of the API reference.