### PR TITLE
Add aarch64 wheels for Python 3.7 and fix manylinux versions

### DIFF
--- a/.github/workflows/wheel_tests_and_release.yml
+++ b/.github/workflows/wheel_tests_and_release.yml
@@ -59,7 +59,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-18.04]
-        cibw_python: [ "cp38-*" , "cp39-*", "cp310-*"]
+        cibw_python: [ "cp37-*" , "cp38-*" , "cp39-*", "cp310-*"]
         cibw_manylinux: [ manylinux2014 ]
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/wheel_tests_and_release.yml
+++ b/.github/workflows/wheel_tests_and_release.yml
@@ -14,7 +14,7 @@ env:
 
 jobs:
   build_linux_37_and_above_wheels:
-    name: Build python ${{ matrix.cibw_python }} wheels on ${{ matrix.os }}
+    name: Build python ${{ matrix.cibw_python }} ${{ matrix.cibw_arch }} wheels on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false

--- a/.github/workflows/wheel_tests_and_release.yml
+++ b/.github/workflows/wheel_tests_and_release.yml
@@ -20,15 +20,24 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-18.04]
-        cibw_python: [ "cp37-*", "cp38-*" ]
-        cibw_manylinux: [ manylinux1 ]
+        cibw_python: [ "cp38-*", "cp39-*" ]
+        cibw_manylinux: [ manylinux2014 ]
+        cibw_arch: [ "x86_64", "i686" ]
         include:
+          # manylinux2010 for Python 3.7 cases
           - os: ubuntu-18.04
-            cibw_python: "cp39-*"
+            cibw_python: "cp37-*"
             cibw_manylinux: manylinux2010
+            cibw_arch: "x86_64"
+          - os: ubuntu-18.04
+            cibw_python: "cp37-*"
+            cibw_manylinux: manylinux2010
+            cibw_arch: "i686"
+          # no i686 NumPy 1.21.x wheel for Python 3.10
           - os: ubuntu-18.04
             cibw_python: "cp310-*"
             cibw_manylinux: manylinux2014
+            cibw_arch: "x86_64"
     steps:
       - uses: actions/checkout@v2
         with:
@@ -45,9 +54,9 @@ jobs:
           python -m cibuildwheel --output-dir dist
         env:
           CIBW_BUILD: ${{ matrix.cibw_python }}
-          CIBW_ARCHS_LINUX: x86_64 i686
+          CIBW_ARCHS_LINUX: ${{ matrix.cibw_arch }}
           CIBW_MANYLINUX_X86_64_IMAGE: ${{ matrix.cibw_manylinux }}
-          CIBW_MANYLINUX_I686_IMAGE: ${{ matrix.cibw_manylinux }}
+          CIBW_MANYLINUX_I686_IMAGE: "manylinux2010"
       - uses: actions/upload-artifact@v2
         with:
           name: wheels
@@ -85,7 +94,6 @@ jobs:
           CIBW_ARCHS_LINUX: aarch64
           CIBW_SKIP: "*-musllinux_*"
           CIBW_MANYLINUX_X86_64_IMAGE: ${{ matrix.cibw_manylinux }}
-          CIBW_MANYLINUX_I686_IMAGE: ${{ matrix.cibw_manylinux }}
       - uses: actions/upload-artifact@v2
         with:
           name: wheels

--- a/.github/workflows/wheel_tests_and_release.yml
+++ b/.github/workflows/wheel_tests_and_release.yml
@@ -55,6 +55,7 @@ jobs:
         env:
           CIBW_BUILD: ${{ matrix.cibw_python }}
           CIBW_ARCHS_LINUX: ${{ matrix.cibw_arch }}
+          CIBW_SKIP: "*-musllinux_*"
           CIBW_MANYLINUX_X86_64_IMAGE: ${{ matrix.cibw_manylinux }}
           CIBW_MANYLINUX_I686_IMAGE: "manylinux2010"
       - uses: actions/upload-artifact@v2

--- a/.github/workflows/wheel_tests_and_release.yml
+++ b/.github/workflows/wheel_tests_and_release.yml
@@ -9,6 +9,7 @@ env:
   # CIBW_BEFORE_BUILD: pip install cython
   CIBW_TEST_REQUIRES: pytest
   CIBW_TEST_COMMAND: pytest --pyargs pywt
+  CIBW_ENVIRONMENT: PIP_PREFER_BINARY=1
 
 
 jobs:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ requires = [
 
     # numpy 1.19 was the first minor release to provide aarch64 wheels, but
     # wheels require fixes contained in numpy 1.19.2
+    "numpy==1.19.2; python_version=='3.7' and platform_machine=='aarch64'",
     "numpy==1.19.2; python_version=='3.8' and platform_machine=='aarch64'",
     # aarch64 for py39 is covered by default requirement below
 


### PR DESCRIPTION
closes #625

aside from adding `aarch64` for Python 3.7 this makes a few other changes:

1.) update to use manylinux2014 in most cases except for Python 3.7 or the i686 wheels (matching what NumPy provides).  These are also the manylinux versions we used in the scikit-image 0.19.x releases.

2.) adds PIP_PREFER_BINARY=1 flag so that a binary wheel version of NumPy will always be preferred during testing. This avoids potentially building NumPy or SciPy from source if a wheel is missing (e.g. most recent releases dropped Python 3.7)

3.) I added `CIBW_SKIP: "*-musllinux_*"` to skip all `musllinux` wheels, but I can revert that change if preferred.
