### PR TITLE
Forward port: Add aarch64 wheels for Python 3.7 and fix manylinux versions

### DIFF
--- a/.github/workflows/wheel_tests_and_release.yml
+++ b/.github/workflows/wheel_tests_and_release.yml
@@ -59,7 +59,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-18.04]
-        cibw_python: [ "cp38-*" , "cp39-*", "cp310-*"]
+        cibw_python: [ "cp37-*" , "cp38-*" , "cp39-*", "cp310-*"]
         cibw_manylinux: [ manylinux2014 ]
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/wheel_tests_and_release.yml
+++ b/.github/workflows/wheel_tests_and_release.yml
@@ -14,7 +14,7 @@ env:
 
 jobs:
   build_linux_37_and_above_wheels:
-    name: Build python ${{ matrix.cibw_python }} wheels on ${{ matrix.os }}
+    name: Build python ${{ matrix.cibw_python }} ${{ matrix.cibw_arch }} wheels on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false

--- a/.github/workflows/wheel_tests_and_release.yml
+++ b/.github/workflows/wheel_tests_and_release.yml
@@ -20,15 +20,24 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-18.04]
-        cibw_python: [ "cp37-*", "cp38-*" ]
-        cibw_manylinux: [ manylinux1 ]
+        cibw_python: [ "cp38-*", "cp39-*" ]
+        cibw_manylinux: [ manylinux2014 ]
+        cibw_arch: [ "x86_64", "i686" ]
         include:
+          # manylinux2010 for Python 3.7 cases
           - os: ubuntu-18.04
-            cibw_python: "cp39-*"
+            cibw_python: "cp37-*"
             cibw_manylinux: manylinux2010
+            cibw_arch: "x86_64"
+          - os: ubuntu-18.04
+            cibw_python: "cp37-*"
+            cibw_manylinux: manylinux2010
+            cibw_arch: "i686"
+          # no i686 NumPy 1.21.x wheel for Python 3.10
           - os: ubuntu-18.04
             cibw_python: "cp310-*"
             cibw_manylinux: manylinux2014
+            cibw_arch: "x86_64"
     steps:
       - uses: actions/checkout@v2
         with:
@@ -45,9 +54,9 @@ jobs:
           python -m cibuildwheel --output-dir dist
         env:
           CIBW_BUILD: ${{ matrix.cibw_python }}
-          CIBW_ARCHS_LINUX: x86_64 i686
+          CIBW_ARCHS_LINUX: ${{ matrix.cibw_arch }}
           CIBW_MANYLINUX_X86_64_IMAGE: ${{ matrix.cibw_manylinux }}
-          CIBW_MANYLINUX_I686_IMAGE: ${{ matrix.cibw_manylinux }}
+          CIBW_MANYLINUX_I686_IMAGE: "manylinux2010"
       - uses: actions/upload-artifact@v2
         with:
           name: wheels
@@ -85,7 +94,6 @@ jobs:
           CIBW_ARCHS_LINUX: aarch64
           CIBW_SKIP: "*-musllinux_*"
           CIBW_MANYLINUX_X86_64_IMAGE: ${{ matrix.cibw_manylinux }}
-          CIBW_MANYLINUX_I686_IMAGE: ${{ matrix.cibw_manylinux }}
       - uses: actions/upload-artifact@v2
         with:
           name: wheels

--- a/.github/workflows/wheel_tests_and_release.yml
+++ b/.github/workflows/wheel_tests_and_release.yml
@@ -55,6 +55,7 @@ jobs:
         env:
           CIBW_BUILD: ${{ matrix.cibw_python }}
           CIBW_ARCHS_LINUX: ${{ matrix.cibw_arch }}
+          CIBW_SKIP: "*-musllinux_*"
           CIBW_MANYLINUX_X86_64_IMAGE: ${{ matrix.cibw_manylinux }}
           CIBW_MANYLINUX_I686_IMAGE: "manylinux2010"
       - uses: actions/upload-artifact@v2

--- a/.github/workflows/wheel_tests_and_release.yml
+++ b/.github/workflows/wheel_tests_and_release.yml
@@ -9,6 +9,7 @@ env:
   # CIBW_BEFORE_BUILD: pip install cython
   CIBW_TEST_REQUIRES: pytest
   CIBW_TEST_COMMAND: pytest --pyargs pywt
+  CIBW_ENVIRONMENT: PIP_PREFER_BINARY=1
 
 
 jobs:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ requires = [
 
     # numpy 1.19 was the first minor release to provide aarch64 wheels, but
     # wheels require fixes contained in numpy 1.19.2
+    "numpy==1.19.2; python_version=='3.7' and platform_machine=='aarch64'",
     "numpy==1.19.2; python_version=='3.8' and platform_machine=='aarch64'",
     # aarch64 for py39 is covered by default requirement below
 


### PR DESCRIPTION
Hi @rgommers, this PR is just a forward port of #626. I probably should have just made that PR to the main dev branch initially (I think I was thinking that we had already dropped 3.7 on this branch, but that was not yet the case).
