### PR TITLE
Fix twine-based uploads to PyPI

### DIFF
--- a/.github/workflows/wheel_tests_and_release.yml
+++ b/.github/workflows/wheel_tests_and_release.yml
@@ -213,7 +213,7 @@ jobs:
           # We prefer to release wheels before source because otherwise there is a
           # small window during which users who pip install pywt will require compilation.
           twine upload ${{ github.workspace }}/dist/*.whl
-          twine upload ${{ github.workspace }}/dist/pywt-${PYWT_VERSION:1}.tar.gz
+          twine upload ${{ github.workspace }}/dist/PyWavelets-${PYWT_VERSION:1}.tar.gz
         env:
           TWINE_USERNAME: ${{ secrets.TWINE_USERNAME }}
           TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}

--- a/.github/workflows/wheel_tests_and_release.yml
+++ b/.github/workflows/wheel_tests_and_release.yml
@@ -215,9 +215,9 @@ jobs:
           twine upload ${{ github.workspace }}/dist/*.whl
           twine upload ${{ github.workspace }}/dist/PyWavelets-${PYWT_VERSION:1}.tar.gz
         env:
-          TWINE_USERNAME: ${{ secrets.TWINE_USERNAME }}
-          TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
-              
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.TWINE_TOKEN }}
+
       - name: Github release
         uses: softprops/action-gh-release@v1
         env:

--- a/setup.py
+++ b/setup.py
@@ -14,9 +14,9 @@ from setuptools import setup, Extension
 from setuptools.command.test import test as TestCommand
 
 MAJOR = 1
-MINOR = 3
+MINOR = 4
 MICRO = 0
-ISRELEASED = True
+ISRELEASED = False
 VERSION = '%d.%d.%d' % (MAJOR, MINOR, MICRO)
 
 


### PR DESCRIPTION
For 1.3.0, the wheels uploaded successfully, although I got a warning email from PyPI about needing to update from username/password to an API token since my account has 2FA enabled. I added a secret for that and updated the script here to use that.

Also, this PR fixes the name of the source tarball. I manually uploaded that one for 1.3.0.
