### PR TITLE
test_cwt_batch can have small differences on some arches (resolves #640)

### DIFF
--- a/pywt/tests/test_cwt_wavelets.py
+++ b/pywt/tests/test_cwt_wavelets.py
@@ -420,7 +420,8 @@ def test_cwt_batch(axis, method):
     assert_equal(cfs.shape[1 + axis], sst.shape[axis])
 
     # batch result on stacked input is the same as stacked 1d result
-    assert_almost_equal(cfs, np.stack((cfs1,) * n_batch, axis=batch_axis + 1))
+    assert_almost_equal(cfs, np.stack((cfs1,) * n_batch, axis=batch_axis + 1),
+                        decimal=12)
 
 
 def test_cwt_small_scales():

--- a/pywt/tests/test_cwt_wavelets.py
+++ b/pywt/tests/test_cwt_wavelets.py
@@ -420,7 +420,7 @@ def test_cwt_batch(axis, method):
     assert_equal(cfs.shape[1 + axis], sst.shape[axis])
 
     # batch result on stacked input is the same as stacked 1d result
-    assert_equal(cfs, np.stack((cfs1,) * n_batch, axis=batch_axis + 1))
+    assert_almost_equal(cfs, np.stack((cfs1,) * n_batch, axis=batch_axis + 1))
 
 
 def test_cwt_small_scales():


### PR DESCRIPTION
This appears to resolve the test failure on aarch64 - not sure how appropriate this is.