### PR TITLE
provide setuptools upper bound for robustness against future changes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@
 [build-system]
 requires = [
     "wheel",
-    "setuptools<60",
+    "setuptools<65",
     "Cython>=0.29.24,<3.0",
 
     # NumPy dependencies - to update these, sync from

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@
 [build-system]
 requires = [
     "wheel",
-    "setuptools",
+    "setuptools<60",
     "Cython>=0.29.24,<3.0",
 
     # NumPy dependencies - to update these, sync from


### PR DESCRIPTION
closes #645

@rgommers: any opinion on exactly what version we should use as the upper bound? I just chose 60.0 here, but saw just now that [numpy uses a specific version (`==59.2.0`)](https://github.com/numpy/numpy/blob/397b6e51b446647839f548529d06dc80bf0a4c53/pyproject.toml#L4)