### PR TITLE
Run GitHub actions test cases using Python 3.11

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -50,7 +50,7 @@ jobs:
             PIP_FLAGS: "--pre"
             OPTIONS_NAME: "pre"
           - platform_id: manylinux_x86_64
-            python-version: 3.11
+            python-version: '3.11-dev'
             PIP_FLAGS: "--pre"
             OPTIONS_NAME: "pre"
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,7 +20,7 @@ jobs:
       # Ensure that a wheel builder finishes even if another fails
       fail-fast: false
       matrix:
-        python-version: [3.7, 3.8, 3.9, '3.10']
+        python-version: [3.7, 3.8, 3.9, '3.10', '3.11-dev']
         MINIMUM_REQUIREMENTS: [0]
         USE_SCIPY: [0]
         USE_SDIST: [0]
@@ -47,6 +47,10 @@ jobs:
             OPTIONS_NAME: "install-from-wheel"
           - platform_id: manylinux_x86_64
             python-version: 3.9
+            PIP_FLAGS: "--pre"
+            OPTIONS_NAME: "pre"
+          - platform_id: manylinux_x86_64
+            python-version: 3.11
             PIP_FLAGS: "--pre"
             OPTIONS_NAME: "pre"
 
@@ -155,7 +159,7 @@ jobs:
       # Ensure that a wheel builder finishes even if another fails
       fail-fast: false
       matrix:
-        python-version: [3.8, '3.10']
+        python-version: [3.8, '3.10', '3.11-dev']
         MINIMUM_REQUIREMENTS: [0]
         USE_SCIPY: [0]
         USE_SDIST: [0]

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,7 +7,7 @@ jobs:
 
   test_pywavelets_linux:
     name: linux-cp${{ matrix.python-version }}-${{ matrix.OPTIONS_NAME }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     env:
       MPLBACKEND: Agg
       CYTHON_TRACE: 1


### PR DESCRIPTION
This PR updates the MacOS and linux tests to include Python 3.11.

Windows tests are still on Appveyor and have not been updated here. Probably could switch those over to GHA at some point as well.