### PR TITLE
Update wheel building workflow to include Python 3.11

### DIFF
--- a/.github/workflows/wheel_tests_and_release.yml
+++ b/.github/workflows/wheel_tests_and_release.yml
@@ -98,8 +98,14 @@ jobs:
       fail-fast: false
       matrix:
         os: [macos-latest]
-        cibw_python: [ "cp37-*", "cp38-*", "cp39-*", "cp310-*" , "cp311-*" ]
+        cibw_python: [ "cp38-*", "cp39-*", "cp310-*" , "cp311-*" ]
         cibw_arch: [ "x86_64", "arm64"]
+        include:
+          # only build x86_64 for Python 3.7
+          - os: macos-latest
+            cibw_python: "cp37-*"
+            cibw_manylinux: manylinux2010
+            cibw_arch: "x86_64"        
     env:
       MACOSX_DEPLOYMENT_TARGET: "10.13"
     steps:

--- a/.github/workflows/wheel_tests_and_release.yml
+++ b/.github/workflows/wheel_tests_and_release.yml
@@ -99,7 +99,7 @@ jobs:
       matrix:
         os: [macos-latest]
         cibw_python: [ "cp38-*", "cp39-*", "cp310-*" , "cp311-*" ]
-        cibw_arch: [ "x86_64", "arm64", "universal2"]
+        cibw_arch: [ "x86_64", "arm64"]
     env:
       MACOSX_DEPLOYMENT_TARGET: "10.13"
     steps:

--- a/.github/workflows/wheel_tests_and_release.yml
+++ b/.github/workflows/wheel_tests_and_release.yml
@@ -13,7 +13,7 @@ env:
 
 
 jobs:
-  build_linux_37_and_above_wheels:
+  build_linux_x86_64_wheels:
     name: Build python ${{ matrix.cibw_python }} ${{ matrix.cibw_arch }} wheels on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:
@@ -23,12 +23,6 @@ jobs:
         cibw_python: [ "cp38-*", "cp39-*", "cp310-*", "cp311-*"]
         cibw_manylinux: [ manylinux2014 ]
         cibw_arch: [ "x86_64"]
-        include:
-          # manylinux2010 for Python 3.7 cases
-          - os: ubuntu-18.04
-            cibw_python: "cp37-*"
-            cibw_manylinux: manylinux2010
-            cibw_arch: "x86_64"
     steps:
       - uses: actions/checkout@v2
         with:
@@ -61,7 +55,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-18.04]
-        cibw_python: [ "cp37-*" , "cp38-*" , "cp39-*", "cp310-*", "cp311-*"]
+        cibw_python: [ "cp38-*" , "cp39-*", "cp310-*", "cp311-*"]
         cibw_manylinux: [ manylinux2014 ]
     steps:
       - uses: actions/checkout@v2
@@ -100,12 +94,6 @@ jobs:
         os: [macos-latest]
         cibw_python: [ "cp38-*", "cp39-*", "cp310-*" , "cp311-*" ]
         cibw_arch: [ "x86_64", "arm64"]
-        include:
-          # only build x86_64 for Python 3.7
-          - os: macos-latest
-            cibw_python: "cp37-*"
-            cibw_manylinux: manylinux2010
-            cibw_arch: "x86_64"        
     env:
       MACOSX_DEPLOYMENT_TARGET: "10.13"
     steps:
@@ -149,7 +137,7 @@ jobs:
       matrix:
         os: [windows-latest]
         cibw_arch: ["AMD64", "x86"]
-        cibw_python: ["cp37-*", "cp38-*", "cp39-*", "cp310-*", "cp311-*"]
+        cibw_python: ["cp38-*", "cp39-*", "cp310-*", "cp311-*"]
         # exclude:
         #   - os: windows-latest
         #     cibw_python: "cp310-*"
@@ -183,7 +171,7 @@ jobs:
 
   deploy:
     name: Release
-    needs: [build_linux_37_and_above_wheels, build_linux_aarch64_wheels, build_macos_wheels, build_windows_wheels]
+    needs: [build_linux_x86_64_wheels, build_linux_aarch64_wheels, build_macos_wheels, build_windows_wheels]
     if: github.repository_owner == 'PyWavelets' && startsWith(github.ref, 'refs/tags/v') && always()
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/wheel_tests_and_release.yml
+++ b/.github/workflows/wheel_tests_and_release.yml
@@ -20,7 +20,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-18.04]
-        cibw_python: [ "cp38-*", "cp39-*", "cp310-*"]
+        cibw_python: [ "cp38-*", "cp39-*", "cp310-*", "cp311-*"]
         cibw_manylinux: [ manylinux2014 ]
         cibw_arch: [ "x86_64"]
         include:
@@ -61,7 +61,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-18.04]
-        cibw_python: [ "cp37-*" , "cp38-*" , "cp39-*", "cp310-*"]
+        cibw_python: [ "cp37-*" , "cp38-*" , "cp39-*", "cp310-*", "cp311-*"]
         cibw_manylinux: [ manylinux2014 ]
     steps:
       - uses: actions/checkout@v2
@@ -117,7 +117,7 @@ jobs:
         run: |
           python -m cibuildwheel --output-dir dist
         env:
-          CIBW_BUILD: "cp3?-* cp310-*"
+          CIBW_BUILD: "cp3?-* cp310-* cp311-*"
           CIBW_SKIP: "cp36-*"
           CIBW_ARCHS_MACOS: x86_64 arm64 universal2
           CIBW_MANYLINUX_X86_64_IMAGE: manylinux1
@@ -159,7 +159,7 @@ jobs:
         run: |
           python -m cibuildwheel --output-dir dist
         env:
-          CIBW_BUILD: "cp3?-* cp310-*"
+          CIBW_BUILD: "cp3?-* cp310-* cp311-*"
           CIBW_SKIP: "cp36-*"
           CIBW_MANYLINUX_X86_64_IMAGE: manylinux1
           CIBW_MANYLINUX_I686_IMAGE: manylinux1

--- a/.github/workflows/wheel_tests_and_release.yml
+++ b/.github/workflows/wheel_tests_and_release.yml
@@ -92,12 +92,14 @@ jobs:
           path: ./dist/*.whl
 
   build_macos_wheels:
-    name: Build wheels on ${{ matrix.os }}
+    name: Build python ${{ matrix.cibw_python }} ${{ matrix.cibw_arch }} wheels on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
         os: [macos-latest]
+        cibw_python: [ "cp38-*", "cp39-*", "cp310-*" , "cp311-*" ]
+        cibw_arch: [ "x86_64", "arm64", "universal2"]
     env:
       MACOSX_DEPLOYMENT_TARGET: "10.13"
     steps:
@@ -117,9 +119,8 @@ jobs:
         run: |
           python -m cibuildwheel --output-dir dist
         env:
-          CIBW_BUILD: "cp3?-* cp310-* cp311-*"
-          CIBW_SKIP: "cp36-*"
-          CIBW_ARCHS_MACOS: x86_64 arm64 universal2
+          CIBW_BUILD: ${{ matrix.cibw_python }}
+          CIBW_ARCHS_MACOS: ${{ matrix.cibw_arch }}
           CIBW_MANYLINUX_X86_64_IMAGE: manylinux1
           CIBW_MANYLINUX_I686_IMAGE: manylinux1
           CC: /usr/bin/clang
@@ -135,13 +136,18 @@ jobs:
           path: ./dist/*.whl
 
   build_windows_wheels:
-    name: Build wheels on ${{ matrix.os }}
+    name: Build ${{ matrix.cibw_python }} ${{ matrix.cibw_arch }} wheels on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
         os: [windows-latest]
-
+        cibw_arch: ["AMD64", "x86"]
+        cibw_python: ["cp38-*", "cp39-*", "cp310-*"]
+        # exclude:
+        #   - os: windows-latest
+        #     cibw_python: "cp310-*"
+        #     cibw_arch: x86
     steps:
       - uses: actions/checkout@v2
         with:
@@ -159,8 +165,8 @@ jobs:
         run: |
           python -m cibuildwheel --output-dir dist
         env:
-          CIBW_BUILD: "cp3?-* cp310-* cp311-*"
-          CIBW_SKIP: "cp36-*"
+          CIBW_BUILD: ${{ matrix.cibw_python }}
+          CIBW_ARCHS_WINDOWS: ${{ matrix.cibw_arch }}
           CIBW_MANYLINUX_X86_64_IMAGE: manylinux1
           CIBW_MANYLINUX_I686_IMAGE: manylinux1
 

--- a/.github/workflows/wheel_tests_and_release.yml
+++ b/.github/workflows/wheel_tests_and_release.yml
@@ -143,7 +143,7 @@ jobs:
       matrix:
         os: [windows-latest]
         cibw_arch: ["AMD64", "x86"]
-        cibw_python: ["cp38-*", "cp39-*", "cp310-*"]
+        cibw_python: ["cp38-*", "cp39-*", "cp310-*", "cp311-*"]
         # exclude:
         #   - os: windows-latest
         #     cibw_python: "cp310-*"
@@ -174,7 +174,6 @@ jobs:
         with:
           name: wheels
           path: ./dist/*.whl
-
 
   deploy:
     name: Release

--- a/.github/workflows/wheel_tests_and_release.yml
+++ b/.github/workflows/wheel_tests_and_release.yml
@@ -98,7 +98,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [macos-latest]
-        cibw_python: [ "cp38-*", "cp39-*", "cp310-*" , "cp311-*" ]
+        cibw_python: [ "cp37-*", "cp38-*", "cp39-*", "cp310-*" , "cp311-*" ]
         cibw_arch: [ "x86_64", "arm64"]
     env:
       MACOSX_DEPLOYMENT_TARGET: "10.13"
@@ -143,7 +143,7 @@ jobs:
       matrix:
         os: [windows-latest]
         cibw_arch: ["AMD64", "x86"]
-        cibw_python: ["cp38-*", "cp39-*", "cp310-*", "cp311-*"]
+        cibw_python: ["cp37-*", "cp38-*", "cp39-*", "cp310-*", "cp311-*"]
         # exclude:
         #   - os: windows-latest
         #     cibw_python: "cp310-*"

--- a/.github/workflows/wheel_tests_and_release.yml
+++ b/.github/workflows/wheel_tests_and_release.yml
@@ -20,23 +20,14 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-18.04]
-        cibw_python: [ "cp38-*", "cp39-*" ]
+        cibw_python: [ "cp38-*", "cp39-*", "cp310-*"]
         cibw_manylinux: [ manylinux2014 ]
-        cibw_arch: [ "x86_64", "i686" ]
+        cibw_arch: [ "x86_64"]
         include:
           # manylinux2010 for Python 3.7 cases
           - os: ubuntu-18.04
             cibw_python: "cp37-*"
             cibw_manylinux: manylinux2010
-            cibw_arch: "x86_64"
-          - os: ubuntu-18.04
-            cibw_python: "cp37-*"
-            cibw_manylinux: manylinux2010
-            cibw_arch: "i686"
-          # no i686 NumPy 1.21.x wheel for Python 3.10
-          - os: ubuntu-18.04
-            cibw_python: "cp310-*"
-            cibw_manylinux: manylinux2014
             cibw_arch: "x86_64"
     steps:
       - uses: actions/checkout@v2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,11 +30,12 @@ requires = [
     "numpy==1.17.3; python_version=='3.8' and (platform_machine!='arm64' or platform_system!='Darwin') and platform_machine!='aarch64' and platform_python_implementation != 'PyPy'",
     "numpy==1.19.3; python_version=='3.9' and (platform_machine!='arm64' or platform_system!='Darwin') and platform_python_implementation != 'PyPy'",
     "numpy==1.21.4; python_version=='3.10' and platform_python_implementation != 'PyPy'",
+    "numpy==1.23.3; python_version=='3.11' and platform_python_implementation != 'PyPy'",
 
     # For Python versions which aren't yet officially supported,
     # we specify an unpinned NumPy which allows source distributions
     # to be used and allows wheels to be used as soon as they
     # become available.
-    "numpy; python_version>='3.11'",
+    "numpy; python_version>='3.12'",
     "numpy; python_version>='3.8' and platform_python_implementation=='PyPy'",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,11 +25,19 @@ requires = [
     "numpy==1.20.0; python_version=='3.8' and platform_machine=='arm64' and platform_system=='Darwin'",
     "numpy==1.20.0; python_version=='3.9' and platform_machine=='arm64' and platform_system=='Darwin'",
 
+    # On Windows we need to avoid 1.21.6, 1.22.0 and 1.22.1 because they were
+    # built with vc142. 1.22.3 is the first version that has 32-bit Windows
+    # wheels *and* was built with vc141. So use that:
+    "numpy==1.22.3; python_version=='3.10' and platform_system=='Windows' and platform_python_implementation != 'PyPy'",
+
     # default numpy requirements
     "numpy==1.17.3; python_version=='3.7' and (platform_machine!='arm64' or platform_system!='Darwin') and platform_machine!='aarch64' and platform_python_implementation != 'PyPy'",
     "numpy==1.17.3; python_version=='3.8' and (platform_machine!='arm64' or platform_system!='Darwin') and platform_machine!='aarch64' and platform_python_implementation != 'PyPy'",
     "numpy==1.19.3; python_version=='3.9' and (platform_machine!='arm64' or platform_system!='Darwin') and platform_python_implementation != 'PyPy'",
-    "numpy==1.21.4; python_version=='3.10' and platform_python_implementation != 'PyPy'",
+    # Note that 1.21.3 was the first version with a complete set of 3.10 wheels,
+    # however macOS was broken and it's safe C API/ABI-wise to build against 1.21.6
+    # (see oldest-supported-numpy issues gh-28 and gh-45)
+    "numpy==1.21.6; python_version=='3.10' and (platform_system!='Windows' and platform_machine!='loongarch64') and platform_python_implementation != 'PyPy'",
     "numpy==1.23.3; python_version=='3.11' and platform_python_implementation != 'PyPy'",
 
     # For Python versions which aren't yet officially supported,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@
 [build-system]
 requires = [
     "wheel",
-    "setuptools",
+    "setuptools<65",
     "Cython>=0.29.24,<3.0",
 
     # NumPy dependencies - to update these, sync from


### PR DESCRIPTION
This was initially successful for all but win32/Python 3.10:
https://github.com/grlee77/pywt/actions/runs/3028888975

Updating the pyproject.toml numpy pinnings for windows as in SciPy fixed the issue (non-windows cases were commented out in that commit):
https://github.com/grlee77/pywt/runs/8287429816?check_suite_focus=true

Aside from adding Python 3.11 this MR
- removes all linux `i686` builds
- splits the Windows and MacOS build matrix into parallel actions
- changed to using `ubuntu-latest`
- some updates to NumPy pinnings in pyproject.toml

Not sure if we should also drop the universal2 wheels on MacOS?
