### PR TITLE
Fix typos discovered by codespell

### DIFF
--- a/demo/batch_processing.py
+++ b/demo/batch_processing.py
@@ -1,5 +1,5 @@
 """
-Demo: Parallel processing accross images
+Demo: Parallel processing across images
 
 Multithreading can be used to run transforms on a set of images in parallel.
 This will give a net performance benefit if the images to be transformed are

--- a/demo/fswavedecn_mondrian.py
+++ b/demo/fswavedecn_mondrian.py
@@ -58,7 +58,7 @@ coeffs_dwt = pywt.wavedecn(img, wavelet='db1', level=None)
 # convert coefficient dictionary to a single array
 coeff_array_dwt, _ = pywt.coeffs_to_array(coeffs_dwt)
 
-# perform fully seperable DWT
+# perform fully separable DWT
 fswavedecn_result = pywt.fswavedecn(img, wavelet='db1')
 
 nnz_dwt = np.sum(coeff_array_dwt != 0)

--- a/doc/release/0.5.0-notes.rst
+++ b/doc/release/0.5.0-notes.rst
@@ -40,9 +40,9 @@ Highlights of this release include:
 New features
 ============
 
-1D Continous Wavelet Transforms
+1D Continuous Wavelet Transforms
 -------------------------------
-A wide range of continous wavelets are now available.  These include the
+A wide range of continuous wavelets are now available.  These include the
 following:
 
 - Gaussian wavelets (``gaus1``...``gaus8``)
@@ -174,12 +174,12 @@ This list of names is automatically generated, and may not be fully complete.
 Issues closed for v0.5.0
 ------------------------
 
-- `#48 <https://github.com/PyWavelets/pywt/issues/48>`__: Continous wavelet transform?
+- `#48 <https://github.com/PyWavelets/pywt/issues/48>`__: Continuous wavelet transform?
 - `#127 <https://github.com/PyWavelets/pywt/issues/127>`__: Reorganize _pywt
 - `#160 <https://github.com/PyWavelets/pywt/issues/160>`__: Appveyor failing on recent PRs
 - `#163 <https://github.com/PyWavelets/pywt/issues/163>`__: Set up coveralls
 - `#166 <https://github.com/PyWavelets/pywt/issues/166>`__: Wavelet coefficients to single array (and vice versa?)
-- `#177 <https://github.com/PyWavelets/pywt/issues/177>`__: Fail to install pywt due to the use of index_t which conflict with the defination in /usr/include/sys/types.h on smartos sysmte(open solaris like system)
+- `#177 <https://github.com/PyWavelets/pywt/issues/177>`__: Fail to install pywt due to the use of index_t which conflict with the definition in /usr/include/sys/types.h on smartos system(open solaris like system)
 - `#180 <https://github.com/PyWavelets/pywt/issues/180>`__: Memory leak
 - `#187 <https://github.com/PyWavelets/pywt/issues/187>`__: 'reflect' signal extension mode
 - `#189 <https://github.com/PyWavelets/pywt/issues/189>`__: bump minimum numpy version?
@@ -189,7 +189,7 @@ Issues closed for v0.5.0
 - `#209 <https://github.com/PyWavelets/pywt/issues/209>`__: broken doctests
 - `#210 <https://github.com/PyWavelets/pywt/issues/210>`__: Run doctests in CI setup
 - `#211 <https://github.com/PyWavelets/pywt/issues/211>`__: Typo in iswt documentation
-- `#217 <https://github.com/PyWavelets/pywt/issues/217>`__: `blank_discrete_wavelet` does not properly intiailize some properties
+- `#217 <https://github.com/PyWavelets/pywt/issues/217>`__: `blank_discrete_wavelet` does not properly initialize some properties
 - `#231 <https://github.com/PyWavelets/pywt/issues/231>`__: I can't compile pywt
 
 

--- a/doc/release/0.5.2-notes.rst
+++ b/doc/release/0.5.2-notes.rst
@@ -10,7 +10,7 @@ Bugs Fixed
 
 The ``pywt.data.nino`` data reader is now compatible with numpy 1.12. (#273)
 
-The ``wp_scalogram.py`` demo is now compatibile with matplotlib 2.0. (#276)
+The ``wp_scalogram.py`` demo is now compatible with matplotlib 2.0. (#276)
 
 Fixed a sporadic segmentation fault affecting stationary wavelet transforms of
 multi-dimensional data. (#289)

--- a/doc/release/1.0.0-notes.rst
+++ b/doc/release/1.0.0-notes.rst
@@ -51,11 +51,11 @@ data.
 
 More flexible specification of some continuous wavelets
 -------------------------------------------------------
-The continous wavelets ``"cmor"``, ``"shan"`` and ``"fbsp"`` now let the user
+The continuous wavelets ``"cmor"``, ``"shan"`` and ``"fbsp"`` now let the user
 specify attributes such as their center frequency and bandwidth that were
 previously fixed. See more on this in the section on deprecated features.
 
-Fully Separable Discrete Wavelet Transfrom
+Fully Separable Discrete Wavelet Transform
 ------------------------------------------
 A new variant of the multilevel n-dimensional DWT has been implemented. It is
 known as the fully separable wavelet transform (FSWT). The functions
@@ -95,7 +95,7 @@ without having to explicitly compute a transform.
 Deprecated features
 ===================
 
-The continous wavelets with names ``"cmor"``, ``"shan"`` and ``"fbsp"``
+The continuous wavelets with names ``"cmor"``, ``"shan"`` and ``"fbsp"``
 should now be modified to include formerly hard-coded attributes such as their
 center frequency and bandwidth. Use of the bare names "cmor". "shan" and
 "fbsp"  is now deprecated. For "cmor" (and "shan"), the form of the wavelet
@@ -235,7 +235,7 @@ A total of 53 pull requests were merged for this release.
 * `#303 <https://github.com/PyWavelets/pywt/pull/303>`__: DOC: better document how to handle omitted coefficients in multilevel...
 * `#309 <https://github.com/PyWavelets/pywt/pull/309>`__: Document how max levels are determined for multilevel DWT and...
 * `#310 <https://github.com/PyWavelets/pywt/pull/310>`__: parse CWT wavelet names for parameters
-* `#314 <https://github.com/PyWavelets/pywt/pull/314>`__: TST: Explicity align data records in test_byte_offset()
+* `#314 <https://github.com/PyWavelets/pywt/pull/314>`__: TST: Explicitly align data records in test_byte_offset()
 * `#317 <https://github.com/PyWavelets/pywt/pull/317>`__: TST: specify rtol and atol for assert_allclose calls in test_swt_decomposition
 * `#320 <https://github.com/PyWavelets/pywt/pull/320>`__: Suggest using default conda channel to install
 * `#321 <https://github.com/PyWavelets/pywt/pull/321>`__: BLD: add pyproject.toml file (PEP 518 support).
@@ -260,7 +260,7 @@ A total of 53 pull requests were merged for this release.
 * `#369 <https://github.com/PyWavelets/pywt/pull/369>`__: remove iswt2's restriction on non-square inputs
 * `#376 <https://github.com/PyWavelets/pywt/pull/376>`__: add common 1d synthetic signals
 * `#377 <https://github.com/PyWavelets/pywt/pull/377>`__: minor update to demo_signals
-* `#378 <https://github.com/PyWavelets/pywt/pull/378>`__: numpy: 1.15 multiindexing warning. targetted fix
+* `#378 <https://github.com/PyWavelets/pywt/pull/378>`__: numpy: 1.15 multiindexing warning. targeted fix
 * `#380 <https://github.com/PyWavelets/pywt/pull/380>`__: BLD: fix doc build on ReadTheDocs, need matplotlib for plots...
 * `#381 <https://github.com/PyWavelets/pywt/pull/381>`__: Fix corner case for small scales in CWT
 * `#382 <https://github.com/PyWavelets/pywt/pull/382>`__: avoid FutureWarnings related to multiindexing in Numpy1.15

--- a/doc/release/1.0.1-notes.rst
+++ b/doc/release/1.0.1-notes.rst
@@ -14,7 +14,7 @@ its __setitem__ method) has been fixed.
 The order that the individual subband coefficients were stacked by the
 function ``pywt.ravel_coeffs`` is now guaranteed to be consistent across all
 supported Python versions. Explicit alphabetic ordering of subband coefficient
-names is used for consitent ordering regardless of Python version.
+names is used for consistent ordering regardless of Python version.
 
 Authors
 =======

--- a/doc/release/1.0.2-notes.rst
+++ b/doc/release/1.0.2-notes.rst
@@ -47,7 +47,7 @@ Issues closed for v1.0.2
 
 - `#447 <https://github.com/PyWavelets/pywt/issues/447>`__: Issue using pywt.WaveletPacket2D
 - `#449 <https://github.com/PyWavelets/pywt/issues/449>`__: Coefficients arrays must have the same dtype error in iswt function
-- `#460 <https://github.com/PyWavelets/pywt/issues/460>`__: iswtn error when using axes and excluded dim is desn't comply to the level
+- `#460 <https://github.com/PyWavelets/pywt/issues/460>`__: iswtn error when using axes and excluded dim is doesn't comply to the level
 
 Pull requests for v1.0.2
 ------------------------
@@ -67,7 +67,7 @@ The backports listed above correspond to the following PRs from the master branc
 - `#438 <https://github.com/PyWavelets/pywt/issues/438>`__: Fix spelling of "Garrote"
 - `#446 <https://github.com/PyWavelets/pywt/issues/446>`__: Spelling correction
 - `#448 <https://github.com/PyWavelets/pywt/issues/448>`__: Properly trim wavelet packet node coefficients during reconstruction
-- `#450 <https://github.com/PyWavelets/pywt/issues/450>`__: handle mixed dtype cofficients correctly across inverse transforms
+- `#450 <https://github.com/PyWavelets/pywt/issues/450>`__: handle mixed dtype coefficients correctly across inverse transforms
 - `#452 <https://github.com/PyWavelets/pywt/issues/452>`__: bump minimum supported Cython version
 - `#462 <https://github.com/PyWavelets/pywt/issues/462>`__: fix bug in iswtn for data of arbitrary shape when using user-specified axes
 

--- a/doc/release/1.1.0-notes.rst
+++ b/doc/release/1.1.0-notes.rst
@@ -79,7 +79,7 @@ Bugs Fixed
 
 - For some boundary modes and data sizes, round-trip ``dwt``/``idwt`` can
   result in an output that has one additional coefficient. Prior to this
-  relese, this could cause a failure during ``WaveletPacket`` or
+  release, this could cause a failure during ``WaveletPacket`` or
   ``WaveletPacket2D`` reconstruction. These wavelet packet transforms have now
   been fixed and round-trip wavelet packet transforms always preserve the
   original data shape. (#448)
@@ -139,7 +139,7 @@ Pull requests for v1.1.0
 - `#442 <https://github.com/PyWavelets/pywt/pull/442>`__: document the numpy.pad equivalent of 'antireflect'
 - `#446 <https://github.com/PyWavelets/pywt/pull/446>`__: Spelling correction
 - `#448 <https://github.com/PyWavelets/pywt/pull/448>`__: Properly trim wavelet packet node coefficients during reconstruction
-- `#450 <https://github.com/PyWavelets/pywt/pull/450>`__: handle mixed dtype cofficients correctly across inverse transforms
+- `#450 <https://github.com/PyWavelets/pywt/pull/450>`__: handle mixed dtype coefficients correctly across inverse transforms
 - `#462 <https://github.com/PyWavelets/pywt/pull/462>`__: fix bug in iswtn for data of arbitrary shape when using user-specified...
 - `#463 <https://github.com/PyWavelets/pywt/pull/463>`__: TST: fix misc. doctest failures (test_doc.py)
 - `#471 <https://github.com/PyWavelets/pywt/pull/471>`__: user-friendly error messages about multilevel DWT format

--- a/doc/source/dev/conduct/code_of_conduct.rst
+++ b/doc/source/dev/conduct/code_of_conduct.rst
@@ -123,7 +123,7 @@ PyWavelets-conduct@googlegroups.com. Currently, the committee consists of:
 - Alexandre de Siqueira
 
 If your report involves any members of the committee, or if they feel they have
-a conflict of interest in handling it, then they will recurse themselves from
+a conflict of interest in handling it, then they will recuse themselves from
 considering your report. Alternatively, if for any reason you feel
 uncomfortable making a report to the committee, then you can also contact:
 

--- a/doc/source/dev/conduct/code_of_conduct.rst
+++ b/doc/source/dev/conduct/code_of_conduct.rst
@@ -123,7 +123,7 @@ PyWavelets-conduct@googlegroups.com. Currently, the committee consists of:
 - Alexandre de Siqueira
 
 If your report involves any members of the committee, or if they feel they have
-a conflict of interest in handling it, then they will recuse themselves from
+a conflict of interest in handling it, then they will recurse themselves from
 considering your report. Alternatively, if for any reason you feel
 uncomfortable making a report to the committee, then you can also contact:
 
@@ -163,7 +163,7 @@ Endnotes
 --------
 
 We are thankful to the SciPy developers for creating the code of conduct we
-have adapated here.
+have adapted here.
 
 - `Scipy Code of Conduct <http://scipy.github.io/devdocs/dev/conduct/code_of_conduct.html>`_
 

--- a/doc/source/dev/conduct/report_handling_manual.rst
+++ b/doc/source/dev/conduct/report_handling_manual.rst
@@ -218,4 +218,4 @@ Conflicts of Interest
 ~~~~~~~~~~~~~~~~~~~~~
 
 In the event of any conflict of interest, a committee member must immediately
-notify the other members, and recurse themselves if necessary.
+notify the other members, and recuse themselves if necessary.

--- a/doc/source/dev/conduct/report_handling_manual.rst
+++ b/doc/source/dev/conduct/report_handling_manual.rst
@@ -218,4 +218,4 @@ Conflicts of Interest
 ~~~~~~~~~~~~~~~~~~~~~
 
 In the event of any conflict of interest, a committee member must immediately
-notify the other members, and recuse themselves if necessary.
+notify the other members, and recurse themselves if necessary.

--- a/doc/source/dev/testing.rst
+++ b/doc/source/dev/testing.rst
@@ -3,7 +3,7 @@
 Testing
 =======
 
-Continous integration with Travis-CI
+Continuous integration with Travis-CI
 ------------------------------------
 
 The project is using `Travis-CI <https://travis-ci.org/PyWavelets/pywt>`_ service

--- a/doc/source/ref/2d-decompositions-overview.rst
+++ b/doc/source/ref/2d-decompositions-overview.rst
@@ -37,7 +37,7 @@ of the wavelet transform to sparsely represent natural images is a key
 property that makes it desirable in applications such as image compression and
 restoration.
 
-Fully Seperable Discrete Wavelet Transform
+Fully Separable Discrete Wavelet Transform
 ------------------------------------------
 An alternative decomposition results in first fully decomposing one axis of the
 data prior to moving onto each additional axis in turn. This is illustrated

--- a/doc/source/ref/wavelet-packets.rst
+++ b/doc/source/ref/wavelet-packets.rst
@@ -27,7 +27,7 @@ methods.
 Here 1D, 2D and ND refer to the number of axes of the data to be transformed.
 All wavelet packet objects can operate on general n-dimensional arrays, but the
 1D or 2D classes apply transforms along only 1 or 2 dimensions. The ND classes
-allow transforms over an arbtirary number of axes of n-dimensional data.
+allow transforms over an arbitrary number of axes of n-dimensional data.
 
 The below diagram illustrates the inheritance tree:
 

--- a/pywt/_dwt.py
+++ b/pywt/_dwt.py
@@ -356,7 +356,7 @@ def upcoef(part, coeffs, wavelet, level=1, take=0):
         * 'a' - approximations reconstruction is performed
         * 'd' - details reconstruction is performed
     coeffs : array_like
-        Coefficients array to recontruct
+        Coefficients array to reconstruct
     wavelet : Wavelet object or name
         Wavelet to use
     level : int, optional

--- a/pywt/_extensions/c/convolution.template.h
+++ b/pywt/_extensions/c/convolution.template.h
@@ -70,7 +70,7 @@ int CAT(TYPE, _downsampling_convolution_periodization)(
  * filter   - filter data
  * F        - filter data length
  * output   - output data
- * O        - output lenght (currently not used)
+ * O        - output length (currently not used)
  * mode     - signal extension mode
  */
 

--- a/pywt/_multilevel.py
+++ b/pywt/_multilevel.py
@@ -525,7 +525,7 @@ def waverecn(coeffs, wavelet, mode='symmetric', axes=None):
     if len(ds) > 0 and not all([isinstance(d, dict) for d in ds]):
         raise ValueError((
             "Unexpected detail coefficient type: {}. Detail coefficients "
-            "must be a dicionary of arrays as returned by wavedecn. If "
+            "must be a dictionary of arrays as returned by wavedecn. If "
             "you are using pywt.array_to_coeffs or pywt.unravel_coeffs, "
             "please specify output_format='wavedecn'").format(type(ds[0])))
 
@@ -771,7 +771,7 @@ def coeffs_to_array(coeffs, padding=0, axes=None):
     coeff_slices = []
     coeff_slices.append(a_slices)
 
-    # loop over the detail cofficients, adding them to coeff_arr
+    # loop over the detail coefficients, adding them to coeff_arr
     ds = coeffs[1:]
     for coeff_dict in ds:
         coeff_slices.append({})  # new dictionary for detail coefficients
@@ -1094,7 +1094,7 @@ def ravel_coeffs(coeffs, axes=None):
     coeff_slices.append(a_slice)
     coeff_shapes.append(coeffs[0].shape)
 
-    # loop over the detail cofficients, embedding them in coeff_arr
+    # loop over the detail coefficients, embedding them in coeff_arr
     ds = coeffs[1:]
     offset = a_size
     for coeff_dict in ds:

--- a/pywt/data/_readers.py
+++ b/pywt/data/_readers.py
@@ -155,7 +155,7 @@ def ecg():
 def nino():
     """
     This data contains the averaged monthly sea surface temperature in degrees
-    Celcius of the Pacific Ocean, between 0-10 degrees South and 90-80 degrees West, from 1950 to 2016.
+    Celsius of the Pacific Ocean, between 0-10 degrees South and 90-80 degrees West, from 1950 to 2016.
     This dataset is in the public domain and was obtained from NOAA.
     National Oceanic and Atmospheric Administration's National Weather Service
     ERSSTv4 dataset, nino 3, http://www.cpc.ncep.noaa.gov/data/indices/
@@ -188,7 +188,7 @@ def nino():
     # sst_csv = pd.read_csv("http://www.cpc.ncep.noaa.gov/data/indices/ersst4.nino.mth.81-10.ascii", sep=' ', skipinitialspace=True)
     # take only full years
     n = int(np.floor(sst_csv.shape[0]/12.)*12.)
-    # Building the mean of three mounth
+    # Building the mean of three months
     # the 4. column is nino 3
     sst = np.mean(np.reshape(np.array(sst_csv)[:n, 4], (n//3, -1)), axis=1)
     sst = (sst - np.mean(sst)) / np.std(sst, ddof=1)

--- a/pywt/data/_wavelab_signals.py
+++ b/pywt/data/_wavelab_signals.py
@@ -39,7 +39,7 @@ def demo_signal(name='Bumps', n=None):
     ----------
     name : {'Blocks', 'Bumps', 'HeaviSine', 'Doppler', ...}
         The type of test signal to generate (`name` is case-insensitive). If
-        `name` is set to `'list'`, a list of the avialable test functions is
+        `name` is set to `'list'`, a list of the available test functions is
         returned.
     n : int or None
         The length of the test signal. This should be provided for all test

--- a/pywt/tests/test_matlab_compatibility.py
+++ b/pywt/tests/test_matlab_compatibility.py
@@ -48,7 +48,7 @@ def test_accuracy_pymatbridge():
     mlab = Matlab()
 
     rstate = np.random.RandomState(1234)
-    # max RMSE (was 1.0e-10, is reduced to 5.0e-5 due to different coefficents)
+    # max RMSE (was 1.0e-10, is reduced to 5.0e-5 due to different coefficients)
     epsilon = 5.0e-5
     epsilon_pywt_coeffs = 1.0e-10
     mlab.start()
@@ -74,7 +74,7 @@ def test_accuracy_pymatbridge():
 def test_accuracy_precomputed():
     # Keep this specific random seed to match the precomputed Matlab result.
     rstate = np.random.RandomState(1234)
-    # max RMSE (was 1.0e-10, is reduced to 5.0e-5 due to different coefficents)
+    # max RMSE (was 1.0e-10, is reduced to 5.0e-5 due to different coefficients)
     epsilon = 5.0e-5
     epsilon_pywt_coeffs = 1.0e-10
     for wavelet in wavelets:

--- a/pywt/tests/test_matlab_compatibility_cwt.py
+++ b/pywt/tests/test_matlab_compatibility_cwt.py
@@ -43,7 +43,7 @@ def test_accuracy_pymatbridge_cwt():
     Matlab = pytest.importorskip("pymatbridge.Matlab")
     mlab = Matlab()
     rstate = np.random.RandomState(1234)
-    # max RMSE (was 1.0e-10, is reduced to 5.0e-5 due to different coefficents)
+    # max RMSE (was 1.0e-10, is reduced to 5.0e-5 due to different coefficients)
     epsilon = 1e-15
     epsilon_psi = 1e-15
     mlab.start()

--- a/pywt/tests/test_multidim.py
+++ b/pywt/tests/test_multidim.py
@@ -398,7 +398,7 @@ def test_dwt2_dimension_error():
 
 
 def test_per_axis_wavelets_and_modes():
-    # tests seperate wavelet and edge mode for each axis.
+    # tests separate wavelet and edge mode for each axis.
     rstate = np.random.RandomState(1234)
     data = rstate.randn(16, 16, 16)
 

--- a/pywt/tests/test_multilevel.py
+++ b/pywt/tests/test_multilevel.py
@@ -803,7 +803,7 @@ def test_waverecn_axes_errors():
 
 
 def test_per_axis_wavelets_and_modes():
-    # tests seperate wavelet and edge mode for each axis.
+    # tests separate wavelet and edge mode for each axis.
     rstate = np.random.RandomState(1234)
     data = rstate.randn(24, 24, 16)
 

--- a/pywt/tests/test_swt.py
+++ b/pywt/tests/test_swt.py
@@ -285,7 +285,7 @@ def test_swt2_axes():
     assert_allclose(cV1, cH2, atol=atol)
     assert_allclose(cD1, cD2, atol=atol)
 
-    # reverify iswt2 restores the orginal data
+    # reverify iswt2 restores the original data
     r1 = pywt.iswt2([cA1, (cH1, cV1, cD1)], current_wavelet)
     assert_allclose(X, r1, atol=atol)
     r2 = pywt.iswt2([cA2, (cH2, cV2, cD2)], current_wavelet, axes=(1, 0))
@@ -419,7 +419,7 @@ def test_swtn_iswtn_unique_shape_per_axis():
 
 
 def test_per_axis_wavelets():
-    # tests seperate wavelet for each axis.
+    # tests separate wavelet for each axis.
     rstate = np.random.RandomState(1234)
     data = rstate.randn(16, 16, 16)
     level = 3

--- a/pywt/tests/test_wp.py
+++ b/pywt/tests/test_wp.py
@@ -163,7 +163,7 @@ def test_wavelet_packet_dtypes():
         # no unnecessary copy made
         assert_(wp.data is x)
 
-        # assiging to a node should not change supported dtypes
+        # assigning to a node should not change supported dtypes
         wp['d'] = wp['d'].data
         assert_equal(wp['d'].data.dtype, x.dtype)
 

--- a/pywt/tests/test_wp2d.py
+++ b/pywt/tests/test_wp2d.py
@@ -182,7 +182,7 @@ def test_wavelet_packet_dtypes():
         # no unnecessary copy made
         assert_(wp.data is x)
 
-        # assiging to a node should not change supported dtypes
+        # assigning to a node should not change supported dtypes
         wp['d'] = wp['d'].data
         assert_equal(wp['d'].data.dtype, x.dtype)
 

--- a/pywt/tests/test_wpnd.py
+++ b/pywt/tests/test_wpnd.py
@@ -28,7 +28,7 @@ def test_traversing_tree_nd():
     assert_allclose(wp['dd'].data, np.zeros((4, 4)), rtol=1e-12, atol=1e-14)
 
     assert_allclose(wp['aa'*2].data, np.array([[10., 26.]] * 2), rtol=1e-12)
-    # __getitem__ using a tuple acces instead
+    # __getitem__ using a tuple access instead
     assert_allclose(wp[('aa', 'aa')].data, np.array([[10., 26.]] * 2),
                     rtol=1e-12)
 

--- a/setup.py
+++ b/setup.py
@@ -388,7 +388,7 @@ class PyTest(TestCommand):
 
 
 def setup_package():
-    # Rewrite the version file everytime
+    # Rewrite the version file every time
     write_version_py()
 
     metadata = dict(

--- a/util/refguide_check.py
+++ b/util/refguide_check.py
@@ -519,7 +519,7 @@ class Checker(doctest.OutputChecker):
 
     def _do_check(self, want, got):
         # This should be done exactly as written to correctly handle all of
-        # numpy-comparable objects, strings, and heterogenous tuples
+        # numpy-comparable objects, strings, and heterogeneous tuples
         try:
             if want == got:
                 return True


### PR DESCRIPTION
`codespell --ignore-words-list=addional,daa,dda,gaus,haa,hav,hda,leary,nd,recuse,tthe,wth --skip="*.bib" .`
https://pypi.org/project/codespell