### PR TITLE
allow `git blame` to ignore specific revisions (e.g. codespell changes)

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,3 @@
+# .git-blame-ignore-revs
+# Applied codespell to the codebase
+5ce73c91800829950474aaa4f4036b2a589a2418


### PR DESCRIPTION
#651 seemed like it might be a good candidate for this functionality.

Reference: [ignore commits in blame view](https://docs.github.com/en/repositories/working-with-files/using-files/viewing-a-file#ignore-commits-in-the-blame-view)