### PR TITLE
Remove `string_types`, which is a remnant of Python 2 support

### DIFF
--- a/pywt/_dwt.py
+++ b/pywt/_dwt.py
@@ -8,7 +8,7 @@ from ._extensions._dwt import (dwt_single, dwt_axis, idwt_single, idwt_axis,
                                upcoef as _upcoef, downcoef as _downcoef,
                                dwt_max_level as _dwt_max_level,
                                dwt_coeff_len as _dwt_coeff_len)
-from ._utils import string_types, _as_wavelet
+from ._utils import _as_wavelet
 
 
 __all__ = ["dwt", "idwt", "downcoef", "upcoef", "dwt_max_level",
@@ -61,7 +61,7 @@ def dwt_max_level(data_len, filter_len):
     """
     if isinstance(filter_len, Wavelet):
         filter_len = filter_len.dec_len
-    elif isinstance(filter_len, string_types):
+    elif isinstance(filter_len, str):
         if filter_len in wavelist(kind='discrete'):
             filter_len = Wavelet(filter_len).dec_len
         else:

--- a/pywt/_utils.py
+++ b/pywt/_utils.py
@@ -3,18 +3,10 @@
 # See COPYING for license details.
 import inspect
 import numpy as np
-import sys
 from collections.abc import Iterable
 
 from ._extensions._pywt import (Wavelet, ContinuousWavelet,
                                 DiscreteContinuousWavelet, Modes)
-
-
-# define string_types as in six for Python 2/3 compatibility
-if sys.version_info[0] == 3:
-    string_types = str,
-else:
-    string_types = basestring,
 
 
 def _as_wavelet(wavelet):
@@ -48,7 +40,7 @@ def _wavelets_per_axis(wavelet, axes):
 
     """
     axes = tuple(axes)
-    if isinstance(wavelet, string_types + (Wavelet, )):
+    if isinstance(wavelet, (str, Wavelet)):
         # same wavelet on all axes
         wavelets = [_as_wavelet(wavelet), ] * len(axes)
     elif isinstance(wavelet, Iterable):
@@ -84,7 +76,7 @@ def _modes_per_axis(modes, axes):
 
     """
     axes = tuple(axes)
-    if isinstance(modes, string_types + (int, )):
+    if isinstance(modes, (int, str)):
         # same wavelet on all axes
         modes = [Modes.from_object(modes), ] * len(axes)
     elif isinstance(modes, Iterable):


### PR DESCRIPTION
Python 2 died 987 days ago on 1/1/2020.