### PR TITLE
release v1.4.1, updating classifiers and python_requires in setup.py

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,7 +20,7 @@ jobs:
       # Ensure that a wheel builder finishes even if another fails
       fail-fast: false
       matrix:
-        python-version: [3.7, 3.8, 3.9, '3.10', '3.11-dev']
+        python-version: [3.8, 3.9, '3.10', '3.11-dev']
         MINIMUM_REQUIREMENTS: [0]
         USE_SCIPY: [0]
         USE_SDIST: [0]
@@ -30,7 +30,7 @@ jobs:
         OPTIONS_NAME: ["default"]
         include:
           - platform_id: manylinux_x86_64
-            python-version: 3.7
+            python-version: 3.8
             MINIMUM_REQUIREMENTS: 1
             OPTIONS_NAME: "minimum-req"
           - platform_id: manylinux_x86_64
@@ -168,7 +168,7 @@ jobs:
         PIP_FLAGS: [""]
         OPTIONS_NAME: ["default"]
         include:
-          - python-version: 3.7
+          - python-version: 3.8
             MINIMUM_REQUIREMENTS: 1
             OPTIONS_NAME: "osx-minimum-req"
           - python-version: 3.9

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,8 +9,6 @@ environment:
   # as of Nov 2020, the default image has Visual Studio 2015, but Python 3.9
   # is only available on the Visual Studio 2019 image.
   matrix:
-    - PYTHON: "C:\\Python37"
-    - PYTHON: "C:\\Python37-x64"
     - PYTHON: "C:\\Python38"
     - PYTHON: "C:\\Python38-x64"
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019

--- a/doc/release/1.4.1-notes.rst
+++ b/doc/release/1.4.1-notes.rst
@@ -1,0 +1,7 @@
+==============================
+PyWavelets 1.4.1 Release Notes
+==============================
+
+.. contents::
+
+This patch release updates setup.py to use `python_requires>=3.8` and adds 3.11 to the trove classifiers.

--- a/doc/source/release.1.4.1.rst
+++ b/doc/source/release.1.4.1.rst
@@ -1,0 +1,1 @@
+.. include:: ../release/1.4.1-notes.rst

--- a/doc/source/releasenotes.rst
+++ b/doc/source/releasenotes.rst
@@ -18,3 +18,4 @@ Release Notes
    release.1.2.0
    release.1.3.0
    release.1.4.0
+   release.1.4.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,6 @@ requires = [
 
     # numpy 1.19 was the first minor release to provide aarch64 wheels, but
     # wheels require fixes contained in numpy 1.19.2
-    "numpy==1.19.2; python_version=='3.7' and platform_machine=='aarch64'",
     "numpy==1.19.2; python_version=='3.8' and platform_machine=='aarch64'",
     # aarch64 for py39 is covered by default requirement below
 
@@ -31,7 +30,6 @@ requires = [
     "numpy==1.22.3; python_version=='3.10' and platform_system=='Windows' and platform_python_implementation != 'PyPy'",
 
     # default numpy requirements
-    "numpy==1.17.3; python_version=='3.7' and (platform_machine!='arm64' or platform_system!='Darwin') and platform_machine!='aarch64' and platform_python_implementation != 'PyPy'",
     "numpy==1.17.3; python_version=='3.8' and (platform_machine!='arm64' or platform_system!='Darwin') and platform_machine!='aarch64' and platform_python_implementation != 'PyPy'",
     "numpy==1.19.3; python_version=='3.9' and (platform_machine!='arm64' or platform_system!='Darwin') and platform_python_implementation != 'PyPy'",
     # Note that 1.21.3 was the first version with a complete set of 3.10 wheels,

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ from setuptools.command.test import test as TestCommand
 
 MAJOR = 1
 MINOR = 4
-MICRO = 0
+MICRO = 1
 ISRELEASED = True
 VERSION = '%d.%d.%d' % (MAJOR, MINOR, MICRO)
 
@@ -423,10 +423,10 @@ def setup_package():
             "Programming Language :: C",
             "Programming Language :: Python",
             "Programming Language :: Python :: 3",
-            "Programming Language :: Python :: 3.7",
             "Programming Language :: Python :: 3.8",
             "Programming Language :: Python :: 3.9",
             "Programming Language :: Python :: 3.10",
+            "Programming Language :: Python :: 3.11",
             "Topic :: Software Development :: Libraries :: Python Modules"
         ],
         platforms=["Windows", "Linux", "Solaris", "Mac OS-X", "Unix"],
@@ -441,7 +441,7 @@ def setup_package():
         tests_require=['pytest'],
 
         install_requires=["numpy>=1.17.3"],
-        python_requires=">=3.7",
+        python_requires=">=3.8",
     )
 
     if "--force" in sys.argv:


### PR DESCRIPTION
I think we should just go ahead and do a 1.4.1 patch release since I missed updating `python_requires` in 1.4.0.