### PR TITLE
CI: limit contourpy to <1.1, to avoid building win32 from source

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -21,7 +21,7 @@ install:
   - cmd: set PATH=%cd%;%PYTHON_ROOT%;%PYTHON_ROOT%\Scripts;%PATH%
   - "python.exe -m pip install --upgrade pip build"
   - "python.exe -m pip install numpy --cache-dir c:\\tmp\\pip-cache"
-  - "python.exe -m pip install Cython pytest matplotlib --cache-dir c:\\tmp\\pip-cache"
+  - "python.exe -m pip install --only-binary :all: Cython pytest matplotlib --cache-dir c:\\tmp\\pip-cache"
 
 test_script:
   - cmd: call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Auxiliary\Build\vcvarsall.bat" %arch%
@@ -29,9 +29,6 @@ test_script:
   - "cd demo"
   - "python.exe -m pytest --pyargs pywt"
   - "cd .."
-
-after_test:
-  - "python.exe -m build --wheel -Csetup-args=--vsenv"
 
 artifacts:
   # Archive the generated wheel package in the ci.appveyor.com build report.

--- a/pywt/meson.build
+++ b/pywt/meson.build
@@ -56,7 +56,6 @@ _c99_config = configure_file(
 
 install_subdir('data', install_dir: py.get_install_dir() / 'pywt')
 install_subdir('tests', install_dir:  py.get_install_dir() / 'pywt')
-install_subdir('tests/data', install_dir: py.get_install_dir() / 'pywt/tests')
 
 # Copy needed for Cython code in _extensions
 __init__py = fs.copyfile('__init__.py')


### PR DESCRIPTION
As seen in gh-679, contourpy fails to build from source on 32-bit. This is fixable, it should build from source just fine. But we don't want to deal with that if we can avoid it. And contourpy 1.0.7 works just fine.

[skip actions]