### PR TITLE
Update dependencies per SPEC 0

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,7 +27,7 @@ jobs:
       # Ensure that a wheel builder finishes even if another fails
       fail-fast: false
       matrix:
-        python-version: [3.8, 3.9, '3.10', '3.11']
+        python-version: [3.9, '3.10', '3.11']
         MINIMUM_REQUIREMENTS: [0]
         USE_SCIPY: [0]
         USE_SDIST: [0]
@@ -37,19 +37,19 @@ jobs:
         OPTIONS_NAME: ["default"]
         include:
           - platform_id: manylinux_x86_64
-            python-version: 3.8
+            python-version: 3.9
             MINIMUM_REQUIREMENTS: 1
             OPTIONS_NAME: "minimum-req"
           - platform_id: manylinux_x86_64
-            python-version: 3.8
+            python-version: 3.9
             USE_SCIPY: 1
             OPTIONS_NAME: "with-scipy"
           - platform_id: manylinux_x86_64
-            python-version: 3.8
+            python-version: 3.9
             USE_SDIST: 1
             OPTIONS_NAME: "install-from-sdist"
           - platform_id: manylinux_x86_64
-            python-version: 3.8
+            python-version: 3.9
             USE_WHEEL: 1
             OPTIONS_NAME: "install-from-wheel"
           - platform_id: manylinux_x86_64
@@ -150,7 +150,7 @@ jobs:
       # Ensure that a wheel builder finishes even if another fails
       fail-fast: false
       matrix:
-        python-version: [3.8, '3.11']
+        python-version: [3.9, '3.11']
         MINIMUM_REQUIREMENTS: [0]
         USE_SCIPY: [0]
         USE_SDIST: [0]
@@ -159,10 +159,10 @@ jobs:
         PIP_FLAGS: [""]
         OPTIONS_NAME: ["default"]
         include:
-          - python-version: '3.8'
+          - python-version: '3.9'
             MINIMUM_REQUIREMENTS: 1
             OPTIONS_NAME: "osx-minimum-req"
-          - python-version: '3.10'
+          - python-version: '3.11'
             PIP_FLAGS: "--pre"
             OPTIONS_NAME: "pre-releases"
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,9 +19,9 @@ jobs:
       MPLBACKEND: Agg
       CYTHON_TRACE: 1
       CYTHONSPEC: cython
-      NUMPY_MIN: numpy==1.20.3
-      CYTHON_MIN: cython==0.29.18
-      SCIPY_MIN: scipy==1.2.3
+      NUMPY_MIN: numpy==1.22.4
+      CYTHON_MIN: cython==0.29.35
+      SCIPY_MIN: scipy==1.8.0
 
     strategy:
       # Ensure that a wheel builder finishes even if another fails
@@ -142,9 +142,9 @@ jobs:
       MPLBACKEND: Agg
       CYTHON_TRACE: 1
       CYTHONSPEC: cython
-      NUMPY_MIN: numpy==1.20.3
-      CYTHON_MIN: cython==0.29.18
-      SCIPY_MIN: scipy==1.2.3
+      NUMPY_MIN: numpy==1.22.4
+      CYTHON_MIN: cython==0.29.35
+      SCIPY_MIN: scipy==1.8.0
 
     strategy:
       # Ensure that a wheel builder finishes even if another fails

--- a/.github/workflows/wheel_tests_and_release.yml
+++ b/.github/workflows/wheel_tests_and_release.yml
@@ -19,8 +19,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-18.04]
-        cibw_python: [ "cp38-*", "cp39-*", "cp310-*", "cp311-*"]
+        os: [ubuntu-latest]
+        cibw_python: ["cp39-*", "cp310-*", "cp311-*"]
         cibw_manylinux: [ manylinux2014 ]
         cibw_arch: [ "x86_64"]
     steps:
@@ -54,8 +54,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-18.04]
-        cibw_python: [ "cp38-*" , "cp39-*", "cp310-*", "cp311-*"]
+        os: [ubuntu-latest]
+        cibw_python: ["cp39-*", "cp310-*", "cp311-*"]
         cibw_manylinux: [ manylinux2014 ]
     steps:
       - uses: actions/checkout@v3
@@ -92,8 +92,8 @@ jobs:
       fail-fast: false
       matrix:
         os: [macos-latest]
-        cibw_python: [ "cp38-*", "cp39-*", "cp310-*" , "cp311-*" ]
-        cibw_arch: [ "x86_64", "arm64"]
+        cibw_python: ["cp39-*", "cp310-*" , "cp311-*" ]
+        cibw_arch: ["x86_64", "arm64"]
     steps:
       - uses: actions/checkout@v3
         with:
@@ -140,7 +140,7 @@ jobs:
       matrix:
         os: [windows-latest]
         cibw_arch: ["AMD64", "x86"]
-        cibw_python: ["cp38-*", "cp39-*", "cp310-*", "cp311-*"]
+        cibw_python: ["cp39-*", "cp310-*", "cp311-*"]
     steps:
       - uses: actions/checkout@v3
         with:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,8 +6,6 @@ build: off
 
 environment:
   matrix:
-    - arch: x86
-      PYTHON_ROOT: "C:\\Python38"
     - arch: x64
       PYTHON_ROOT: "C:\\Python39-x64"
     - arch: x86

--- a/doc/source/dev/testing.rst
+++ b/doc/source/dev/testing.rst
@@ -43,9 +43,9 @@ Running tests with Tox
 ----------------------
 
 There's also a config file for running tests with `Tox`_ (``pip install tox``).
-To for example run tests for Python 3.7 and 3.8 use::
+To for example run tests for Python 3.9 and 3.10 use::
 
-  tox -e py37,py38
+  tox -e py39,py310
 
 For more information see the `Tox`_ documentation.
 

--- a/meson.build
+++ b/meson.build
@@ -3,7 +3,7 @@ project(
   'c', 'cython',
   version: '1.5.0.dev0',
   license: 'MIT',
-  meson_version: '>= 1.0.1',
+  meson_version: '>= 1.1.0',
   default_options: [
     'buildtype=debugoptimized',
     'b_ndebug=if-release',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,33 +7,22 @@
 [build-system]
 build-backend = "mesonpy"
 requires = [
-    "meson-python",
-    "Cython>=0.29.18",
+    "meson-python>=0.14.0",
+    "Cython>=0.29.35",  # when updating version, also update check in meson.build
 
-    # NumPy dependencies - to update these, sync from
-    # https://github.com/scipy/oldest-supported-numpy/, and then
-    # update minimum version to match our install_requires min version
-    # ----------------------------------------------------------------
+    # When numpy 2.0.0rc1 comes out, we should update this to build against 2.0,
+    # and then runtime depend on the range 1.22.X to <2.3. No need to switch to
+    # 1.25.2 in the meantime (1.25.x is the first version which exports older C
+    # API versions by default).
 
-    # default numpy requirement for 3.8 and 3.9
-    "numpy==1.20.3; python_version<='3.9' and platform_python_implementation != 'PyPy'",
-
-    # Note that 1.21.3 was the first version with a complete set of 3.10 wheels,
-    # however macOS was broken and it's safe C API/ABI-wise to build against 1.21.6
-    # (see oldest-supported-numpy issues gh-28 and gh-45)
-    # On Windows we need to avoid 1.21.6, 1.22.0 and 1.22.1 because they were
-    # built with vc142. 1.22.3 is the first version that has 32-bit Windows
-    # wheels *and* was built with vc141. So use that:
-    "numpy==1.21.6; python_version=='3.10' and platform_system!='Windows' and platform_python_implementation != 'PyPy'",
-    "numpy==1.22.3; python_version=='3.10' and platform_system=='Windows' and platform_python_implementation != 'PyPy'",
-    "numpy==1.23.3; python_version=='3.11' and platform_python_implementation != 'PyPy'",
-
-    # For Python versions which aren't yet officially supported,
-    # we specify an unpinned NumPy which allows source distributions
-    # to be used and allows wheels to be used as soon as they
-    # become available.
-    "numpy; python_version>='3.12'",
-    "numpy; python_version>='3.8' and platform_python_implementation=='PyPy'",
+    # default numpy requirements
+    "numpy==1.22.4; python_version<='3.10' and platform_python_implementation != 'PyPy'",
+    "numpy==1.23.2; python_version=='3.11' and platform_python_implementation != 'PyPy'",
+    # For Python versions which aren't yet officially supported, we specify an
+    # unpinned NumPy which allows source distributions to be used and allows
+    # wheels to be used as soon as they become available.
+    "numpy>=1.26.0b1; python_version>='3.12'",
+    "numpy; python_version>='3.9' and platform_python_implementation=='PyPy'",
 ]
 
 [project]
@@ -45,11 +34,11 @@ maintainers = [
     {name = "The PyWavelets Developers", email = "pywavelets@googlegroups.com"}
 ]
 description = "PyWavelets, wavelet transform module"
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 dependencies = [
     # TODO: update to "pin-compatible" once possible, see
     # https://github.com/FFY00/meson-python/issues/29
-    "numpy>=1.20.3",
+    "numpy>=1.22.4",
 ]
 readme = "README.rst"
 classifiers = [
@@ -62,7 +51,6 @@ classifiers = [
     "Programming Language :: C",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,11 +17,11 @@ requires = [
 
     # default numpy requirements
     "numpy==1.22.4; python_version<='3.10' and platform_python_implementation != 'PyPy'",
-    "numpy==1.23.2; python_version=='3.11' and platform_python_implementation != 'PyPy'",
+    "numpy==1.23.3; python_version=='3.11' and platform_python_implementation != 'PyPy'",
     # For Python versions which aren't yet officially supported, we specify an
     # unpinned NumPy which allows source distributions to be used and allows
     # wheels to be used as soon as they become available.
-    "numpy>=1.26.0b1; python_version>='3.12'",
+    "numpy>=1.26.0b1; python_version>='3.12rc2'",
     "numpy; python_version>='3.9' and platform_python_implementation=='PyPy'",
 ]
 

--- a/tox.ini
+++ b/tox.ini
@@ -13,14 +13,14 @@
 #     - Use pip to install the pywt sdist into the virtualenv
 #     - Run the pywt tests
 # To run against a specific subset of Python versions, use:
-#   tox -e py37,py38
+#   tox -e py39,py310
 
 # Tox assumes that you have appropriate Python interpreters already
-# installed and that they can be run as 'python3.7', 'python3.8', etc.
+# installed and that they can be run as 'python3.9', 'python3.10', etc.
 
 [tox]
 toxworkdir = {homedir}/.tox/pywt/
-envlist = py37, py38
+envlist = py39, py310
 
 [testenv]
 deps =


### PR DESCRIPTION
Preparing to start testing on Python 3.12 with the hope we could get a new release out soonish supporting 3.12.

Drops Python 3.8 and older numpy versions. It also updates the build system requirements to what is currently being used for scipy.