### PR TITLE
Test on final releases on Python 3.12

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -60,9 +60,6 @@ jobs:
             python-version: '3.12'
             PIP_FLAGS: "--pre"
             OPTIONS_NAME: "pre-releases"
-        exclude:
-          - python-version: '3.12'
-            PIP_FLAGS: [""]
 
     steps:
       - name: Checkout PyWavelets
@@ -175,9 +172,6 @@ jobs:
           - python-version: '3.12'
             PIP_FLAGS: "--pre"
             OPTIONS_NAME: "pre-releases"
-        exclude:
-          - python-version: '3.12'
-            PIP_FLAGS: [""]
 
     steps:
       - name: Checkout PyWavelets

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,7 +31,6 @@ jobs:
         MINIMUM_REQUIREMENTS: [0]
         USE_SCIPY: [0]
         USE_SDIST: [0]
-        USE_WHEEL: [0]
         REFGUIDE_CHECK: [0]
         PIP_FLAGS: [""]
         OPTIONS_NAME: ["default"]
@@ -48,14 +47,6 @@ jobs:
             python-version: 3.9
             USE_SDIST: 1
             OPTIONS_NAME: "install-from-sdist"
-          - platform_id: manylinux_x86_64
-            python-version: 3.9
-            USE_WHEEL: 1
-            OPTIONS_NAME: "install-from-wheel"
-          - platform_id: manylinux_x86_64
-            python-version: '3.11'
-            PIP_FLAGS: "--pre"
-            OPTIONS_NAME: "pre-releases"
           - platform_id: manylinux_x86_64
             python-version: '3.12'
             PIP_FLAGS: "--pre"
@@ -76,7 +67,6 @@ jobs:
             VERSION: ${{ matrix.python-version }}
             MINIMUM_REQUIREMENTS: ${{ matrix.MINIMUM_REQUIREMENTS }}
             PIP_FLAGS: ${{ matrix.PIP_FLAGS }}
-            USE_WHEEL: ${{ matrix.USE_WHEEL }}
             USE_SDIST: ${{ matrix.USE_SDIST }}
             USE_SCIPY: ${{ matrix.USE_SCIPY }}
             REFGUIDE_CHECK:  ${{ matrix.REFGUIDE_CHECK }}
@@ -102,11 +92,7 @@ jobs:
             pip install ${PIP_FLAGS} matplotlib pytest
 
             set -o pipefail
-            if [ "${USE_WHEEL}" == "1" ]; then
-                # Need verbose output or TravisCI will terminate after 10 minutes
-                pip wheel . -v
-                pip install pywavelets*.whl
-            elif [ "${USE_SDIST}" == "1" ]; then
+            if [ "${USE_SDIST}" == "1" ]; then
                 python -m build --sdist
                 pip install dist/pyw*.tar.gz -v
             elif [ "${REFGUIDE_CHECK}" == "1" ]; then
@@ -118,17 +104,13 @@ jobs:
 
       - name: Run tests
         env:
-            USE_WHEEL: ${{ matrix.USE_WHEEL }}
             USE_SDIST: ${{ matrix.USE_SDIST }}
             REFGUIDE_CHECK: ${{ matrix.REFGUIDE_CHECK }}
         run: |
             set -o pipefail
             # Move out of source directory to avoid finding local pywt
             pushd demo
-            if [ "${USE_WHEEL}" == "1" ]; then
-                pytest --pyargs pywt
-                python ../pywt/tests/test_doc.py
-            elif [ "${USE_SDIST}" == "1" ]; then
+            if [ "${USE_SDIST}" == "1" ]; then
                 pytest --pyargs pywt
                 python ../pywt/tests/test_doc.py
             elif [ "${REFGUIDE_CHECK}" == "1" ]; then
@@ -154,11 +136,10 @@ jobs:
       # Ensure that a wheel builder finishes even if another fails
       fail-fast: false
       matrix:
-        python-version: [3.9, '3.11', '3.12']
+        python-version: [3.9, '3.12']
         MINIMUM_REQUIREMENTS: [0]
         USE_SCIPY: [0]
         USE_SDIST: [0]
-        USE_WHEEL: [0]
         REFGUIDE_CHECK: [0]
         PIP_FLAGS: [""]
         OPTIONS_NAME: ["default"]
@@ -166,9 +147,6 @@ jobs:
           - python-version: '3.9'
             MINIMUM_REQUIREMENTS: 1
             OPTIONS_NAME: "osx-minimum-req"
-          - python-version: '3.11'
-            PIP_FLAGS: "--pre"
-            OPTIONS_NAME: "pre-releases"
           - python-version: '3.12'
             PIP_FLAGS: "--pre"
             OPTIONS_NAME: "pre-releases"
@@ -188,7 +166,6 @@ jobs:
             VERSION: ${{ matrix.python-version }}
             MINIMUM_REQUIREMENTS: ${{ matrix.MINIMUM_REQUIREMENTS }}
             PIP_FLAGS: ${{ matrix.PIP_FLAGS }}
-            USE_WHEEL: ${{ matrix.USE_WHEEL }}
             USE_SDIST: ${{ matrix.USE_SDIST }}
             USE_SCIPY: ${{ matrix.USE_SCIPY }}
             REFGUIDE_CHECK:  ${{ matrix.REFGUIDE_CHECK }}
@@ -212,10 +189,7 @@ jobs:
             pip install ${PIP_FLAGS} matplotlib pytest
 
             set -o pipefail
-            if [ "${USE_WHEEL}" == "1" ]; then
-                pip wheel . -v
-                pip install pywavelets*.whl -v
-            elif [ "${USE_SDIST}" == "1" ]; then
+            if [ "${USE_SDIST}" == "1" ]; then
                 python -m build --sdist
                 pip install pywavelets* -v
             elif [ "${REFGUIDE_CHECK}" == "1" ]; then
@@ -228,16 +202,12 @@ jobs:
       - name: Run tests
         env:
             PIP_FLAGS: ${{ matrix.PIP_FLAGS }}
-            USE_WHEEL: ${{ matrix.USE_WHEEL }}
             USE_SDIST: ${{ matrix.USE_SDIST }}
             REFGUIDE_CHECK: ${{ matrix.REFGUIDE_CHECK }}
         run: |
             # Move out of source directory to avoid finding local pywt
             pushd demo
-            if [ "${USE_WHEEL}" == "1" ]; then
-                pytest --pyargs pywt
-                python ../pywt/tests/test_doc.py
-            elif [ "${USE_SDIST}" == "1" ]; then
+            if [ "${USE_SDIST}" == "1" ]; then
                 pytest --pyargs pywt
                 python ../pywt/tests/test_doc.py
             elif [ "${REFGUIDE_CHECK}" == "1" ]; then


### PR DESCRIPTION
NumPy and Matplotlib have wheels for Python 3.12 now. I decided to leave the `--pre` tests as well.