### PR TITLE
Create pip_install_on_py3_12.yml

### DIFF
--- a/.github/workflows/pip_install_on_py3_12.yml
+++ b/.github/workflows/pip_install_on_py3_12.yml
@@ -1,0 +1,19 @@
+name: pip_install_on_py3_12
+on:
+  push:
+    branches: [main, master]
+  pull_request:
+    branches: [main, master]
+jobs:
+  pip_install_on_py3_12:
+    strategy:
+      fail-fast: false
+      matrix:
+        module: ["PyWavelets", "scikit-image", "scikit-fuzzy"]
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: actions/setup-python@v4
+      with:
+        python-version: 3.12
+    - run: pip install ${{ matrix.module }}

--- a/.github/workflows/pip_install_on_py3_12.yml
+++ b/.github/workflows/pip_install_on_py3_12.yml
@@ -1,15 +1,15 @@
 name: pip_install_on_py3_12
 on:
   push:
-    branches: [main, master]
+    branches: [master]
   pull_request:
-    branches: [main, master]
+    branches: [master]
 jobs:
   pip_install_on_py3_12:
     strategy:
       fail-fast: false
       matrix:
-        module: ["PyWavelets", "scikit-image", "scikit-fuzzy"]
+        module: ["PyWavelets", "git+https://github.com/PyWavelets/pywt.git", "scikit-fuzzy", "scikit-image"]
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
A temporary file to demonstrate the problems that I am having with `python3.12 -m pip install PyWavelets`
> AttributeError: module 'pkgutil' has no attribute 'ImpImporter'. Did you mean: 'zipimporter'?

Test results: https://github.com/PyWavelets/pywt/actions/workflows/pip_install_on_py3_12.yml
* The `master` branch can be pip-installed on Python 3.12.
* Pip installing the PyPI version of `PyWavelets` and `scikit-image` fail on Python 3.12.

This is a ***different problem*** than
* #692