### PR TITLE
REL: 1.5.0 release

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,7 +11,7 @@ environment:
     - arch: x86
       PY_PYTHON: 3.10-32
     - arch: x64
-      PY_PYTHON: 3.11
+      PY_PYTHON: 3.12
 
 # From https://mesonbuild.com/Continuous-Integration.html#appveyor-for-windows
 install:

--- a/doc/release/1.5.0-notes.rst
+++ b/doc/release/1.5.0-notes.rst
@@ -4,7 +4,9 @@ PyWavelets 1.5.0 Release Notes
 
 .. contents::
 
-We are very pleased to announce the release of PyWavelets 1.5.
+We are very pleased to announce the release of PyWavelets 1.5.0. This release
+is a minor update to 1.4.x. It adds support for Python 3.12 and drops support
+for Python 3.8. It also adds support for Cython 3.0.
 
 PyWavelets now uses Meson as its build system, and meson-python
 as the build backend. This requires no changes from users, a
@@ -15,14 +17,36 @@ the hood.
 Authors
 =======
 
+* Christian Clauss
+* Ralf Gommers
+* Gregory R. Lee
+* Jarrod Millman +
+* Evans Doe Ocansey +
+* Ahmet Can Solak +
+* Stefan van der Walt +
 
-Reviewers
-=========
+A total of 7 people contributed to this release.
+People with a "+" by their names contributed a patch for the first time.
+This list of names is automatically generated, and may not be fully complete.
 
 
 Issues closed  for v1.5
 -----------------------
 
+* `#621 <https://github.com/PyWavelets/pywt/issues/621>`__: distutils was deprecated in Python 3.10
+
 
 Pull requests for v1.5
 ----------------------
+
+* `#667 <https://github.com/PyWavelets/pywt/pull/667>`__: BLD: switch to using Meson as the build system for PyWavelets
+* `#669 <https://github.com/PyWavelets/pywt/pull/669>`__: DOC: update docs for setup.py removal, and fix ReadTheDocs build
+* `#679 <https://github.com/PyWavelets/pywt/pull/679>`__: MAINT: fix warnings emitted by loading npy/npz data files
+* `#680 <https://github.com/PyWavelets/pywt/pull/680>`__: CI: limit contourpy to <1.1, to avoid building win32 from source
+* `#681 <https://github.com/PyWavelets/pywt/pull/681>`__: Update dependencies per SPEC 0
+* `#682 <https://github.com/PyWavelets/pywt/pull/682>`__: Remove old travis references
+* `#683 <https://github.com/PyWavelets/pywt/pull/683>`__: Test on Python 3.12
+* `#685 <https://github.com/PyWavelets/pywt/pull/685>`__: Add spin as developer UI to meson
+* `#688 <https://github.com/PyWavelets/pywt/pull/688>`__: AppVeyor: Upgrade to Visual Studio 2022 and use python-launcher
+* `#690 <https://github.com/PyWavelets/pywt/pull/690>`__: Build Python 3.12 wheels
+* `#691 <https://github.com/PyWavelets/pywt/pull/691>`__: Test on final releases on Python 3.12

--- a/meson.build
+++ b/meson.build
@@ -1,7 +1,7 @@
 project(
   'PyWavelets',
   'c', 'cython',
-  version: '1.5.0',
+  version: '1.6.0.dev0',
   license: 'MIT',
   meson_version: '>= 1.1.0',
   default_options: [

--- a/meson.build
+++ b/meson.build
@@ -1,7 +1,7 @@
 project(
   'PyWavelets',
   'c', 'cython',
-  version: '1.5.0.dev0',
+  version: '1.5.0',
   license: 'MIT',
   meson_version: '>= 1.1.0',
   default_options: [
@@ -13,9 +13,7 @@ project(
 
 cython = find_program('cython')
 
-# https://mesonbuild.com/Python-module.html
-py_mod = import('python')
-py = py_mod.find_installation(pure: false)
+py = import('python').find_installation(pure: false)
 py_dep = py.dependency()
 
 subdir('pywt')

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ requires = [
 
 [project]
 name = "PyWavelets"
-version = "1.5.0"
+version = "1.6.0.dev0"
 # TODO: add `license-files` once PEP 639 is accepted (see meson-python#88)
 #       at that point, no longer include them in `py3.install_sources()`
 license = {file = "LICENSE"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,9 +8,7 @@
 build-backend = "mesonpy"
 requires = [
     "meson-python>=0.14.0",
-    # when updating Cython version, also update check in meson.build
-    "Cython>=0.29.35,<3.0; python_version>='3.12' and platform_system=='Windows'",
-    "Cython>=0.29.35; python_version<'3.12' or platform_system!='Windows'",
+    "Cython>=0.29.35",
 
     # When numpy 2.0.0rc1 comes out, we should update this to build against 2.0,
     # and then runtime depend on the range 1.22.X to <2.3. No need to switch to

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ requires = [
 
 [project]
 name = "PyWavelets"
-version = "1.5.0.dev0"
+version = "1.5.0"
 # TODO: add `license-files` once PEP 639 is accepted (see meson-python#88)
 #       at that point, no longer include them in `py3.install_sources()`
 license = {file = "LICENSE"}

--- a/util/version_utils.py
+++ b/util/version_utils.py
@@ -4,9 +4,9 @@ import argparse
 
 
 MAJOR = 1
-MINOR = 5
+MINOR = 6
 MICRO = 0
-ISRELEASED = True
+ISRELEASED = False
 VERSION = '%d.%d.%d' % (MAJOR, MINOR, MICRO)
 
 

--- a/util/version_utils.py
+++ b/util/version_utils.py
@@ -6,8 +6,7 @@ import argparse
 MAJOR = 1
 MINOR = 5
 MICRO = 0
-ISRELEASED = False
-IS_RELEASE_BRANCH = False
+ISRELEASED = True
 VERSION = '%d.%d.%d' % (MAJOR, MINOR, MICRO)
 
 


### PR DESCRIPTION
This is well overdue, so just get it out to unblock folks who want to use Python 3.12