### PR TITLE
Upload nightly wheels for PyWavelets to the Scientific Python Nightly Wheels index on Anaconda

### DIFF
--- a/.github/workflows/emscripten.yml
+++ b/.github/workflows/emscripten.yml
@@ -19,8 +19,8 @@ on:
         default: "false"
   # Upload wheels to Anaconda on a schedule
   schedule:
-    # Run at 0300 hours on days 3 and 28 of the month
-    - cron: "0 3 3,28 * *"
+    # Run at 0300 hours on days 3 and 17 of the month
+    - cron: "0 3 3,17 * *"
 
 env:
   FORCE_COLOR: 3

--- a/.github/workflows/emscripten.yml
+++ b/.github/workflows/emscripten.yml
@@ -9,6 +9,18 @@ on:
     branches:
       - master
       - v1.**
+  # Make it possible to upload wheels manually if needed
+  workflow_dispatch:
+    inputs:
+      push_wheels:
+        description: >
+          'Push wheels to Anaconda if "true". Default is "false". Warning: this will overwrite existing wheels.'
+        required: false
+        default: "false"
+  # Upload wheels to Anaconda on a schedule
+  schedule:
+    # Run at 0300 hours on days 3 and 28 of the month
+    - cron: "0 3 3,28 * *"
 
 env:
   FORCE_COLOR: 3
@@ -58,3 +70,12 @@ jobs:
           pip install matplotlib pytest
           python -c "import pywt; print(pywt.__version__)"
           pytest --pyargs pywt
+
+        # https://anaconda.org/scientific-python-nightly-wheels/pywavelets
+        # WARNING: this job will overwrite existing wheels.
+      - name: Push to Anaconda PyPI index
+        if: (github.repository == 'PyWavelets/pywt') && (github.event_name == 'push' && github.ref == 'refs/heads/master') || (github.event_name == 'workflow_dispatch' && github.event.inputs.push_wheels == 'true') || (github.event_name == 'schedule')
+        uses: scientific-python/upload-nightly-action@b67d7fcc0396e1128a474d1ab2b48aa94680f9fc # v0.5.0
+        with:
+          artifacts_path: dist/
+          anaconda_nightly_upload_token: ${{ secrets.ANACONDA_ORG_UPLOAD_TOKEN }}


### PR DESCRIPTION
## Description

This PR updates the `emscripten.yml` workflow to establish uploads of nightly WASM wheels on an Anaconda-hosted PyPI index at https://anaconda.org/scientific-python-nightly-wheels/pywavelets.

With the configuration set here, this shall overwrite existing wheels if present.

## Proposed changes

The changes here are as follows:

1. A schedule to upload wheels
2. A workflow_dispatch event to trigger manual uploads if needed
3. A step with conditions set so that the cadence of the wheel upload adheres to a push to `master`, a manually-triggered workflow, and on this repository only – not on forks

## Footnotes

Please see #706 for more information.

This closes https://github.com/scientific-python/upload-nightly-action/issues/75.