### PR TITLE
Upload dev wheels to Anaconda.org + revamp wheels publishing workflow

### DIFF
--- a/.github/workflows/wheel_tests_and_release.yml
+++ b/.github/workflows/wheel_tests_and_release.yml
@@ -4,6 +4,10 @@ on:
     tags:
       - "v*"
       - "buildwheels*"
+    branches:
+      # Runs on every merge to master to upload .dev0 wheels to anaconda.org
+      - master
+      - v1.**
   # Make it possible to upload wheels manually if needed
   workflow_dispatch:
     inputs:
@@ -177,7 +181,8 @@ jobs:
         build_macos_wheels,
         build_windows_wheels,
       ]
-    if: github.repository_owner == 'PyWavelets' && startsWith(github.ref, 'refs/tags/v') && always()
+    # Run only on tags pushed to the repository
+    if: github.repository_owner == 'PyWavelets' && startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
@@ -230,7 +235,7 @@ jobs:
         build_macos_wheels,
         build_windows_wheels,
       ]
-    # Only run on the master branch, on schedule, or when triggered manually
+    # Run only on pushes to the master branch, on schedule, or when triggered manually
     if: >-
       github.repository_owner == 'PyWavelets' &&
       (github.event_name == 'push' && github.ref == 'refs/heads/master') ||

--- a/.github/workflows/wheel_tests_and_release.yml
+++ b/.github/workflows/wheel_tests_and_release.yml
@@ -58,8 +58,9 @@ jobs:
           CIBW_MANYLINUX_I686_IMAGE: "manylinux2010"
       - uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # v4.3.1
         with:
-          name: linux_x86_64_wheels
+          name: wheels_linux_${{ matrix.cibw_arch }}_${{ matrix.cibw_python }}_manylinux2014
           path: ./dist/*.whl
+          if-no-files-found: error
 
   build_linux_aarch64_wheels:
     name: Build python ${{ matrix.cibw_python }} aarch64 wheels on ${{ matrix.os }}
@@ -70,6 +71,7 @@ jobs:
         os: [ubuntu-latest]
         cibw_python: ["cp39-*", "cp310-*", "cp311-*", "cp312-*"]
         cibw_manylinux: [manylinux2014]
+        cibw_arch: ["aarch64"]
     steps:
       - uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
         with:
@@ -88,12 +90,12 @@ jobs:
           output-dir: dist
         env:
           CIBW_BUILD: ${{ matrix.cibw_python }}
-          CIBW_ARCHS_LINUX: aarch64
+          CIBW_ARCHS_LINUX: ${{ matrix.cibw_arch }}
           CIBW_SKIP: "*-musllinux_*"
           CIBW_MANYLINUX_X86_64_IMAGE: ${{ matrix.cibw_manylinux }}
       - uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # v4.3.1
         with:
-          name: linux_aarch64_wheels
+          name: wheels_linux_${{ matrix.cibw_arch }}_${{ matrix.cibw_python }}_manylinux2014
           path: ./dist/*.whl
 
   build_macos_wheels:
@@ -125,8 +127,9 @@ jobs:
 
       - uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # v4.3.1
         with:
-          name: macos_wheels
+          name: wheels_macos_${{ matrix.cibw_arch }}_${{ matrix.cibw_python }}
           path: ./dist/*.whl
+          if-no-files-found: error
 
   build_windows_wheels:
     name: Build ${{ matrix.cibw_python }} ${{ matrix.cibw_arch }} wheels on ${{ matrix.os }}
@@ -169,8 +172,9 @@ jobs:
 
       - uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # v4.3.1
         with:
-          name: windows_wheels
+          name: wheels_windows_${{ matrix.cibw_arch }}_${{ matrix.cibw_python }}
           path: ./dist/*.whl
+          if-no-files-found: error
 
   deploy_pypi:
     name: Release (PyPI)
@@ -203,7 +207,7 @@ jobs:
       - uses: actions/download-artifact@c850b930e6ba138125429b7e5c93fc707a7f8427 # v4.1.4
         id: download
         with:
-          pattern: "*_wheels"
+          pattern: "wheels_*"
           path: ./dist
           merge-multiple: true
 

--- a/.github/workflows/wheel_tests_and_release.yml
+++ b/.github/workflows/wheel_tests_and_release.yml
@@ -35,7 +35,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        cibw_python: ["cp39-*", "cp310-*", "cp311-*", "cp312-*"]
+        cibw_python: ["cp39", "cp310", "cp311", "cp312"]
         cibw_manylinux: [manylinux2014]
         cibw_arch: ["x86_64"]
     steps:
@@ -51,7 +51,7 @@ jobs:
         with:
           output-dir: dist
         env:
-          CIBW_BUILD: ${{ matrix.cibw_python }}
+          CIBW_BUILD: ${{ matrix.cibw_python }}-*
           CIBW_ARCHS_LINUX: ${{ matrix.cibw_arch }}
           CIBW_SKIP: "*-musllinux_*"
           CIBW_MANYLINUX_X86_64_IMAGE: ${{ matrix.cibw_manylinux }}
@@ -69,7 +69,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        cibw_python: ["cp39-*", "cp310-*", "cp311-*", "cp312-*"]
+        cibw_python: ["cp39", "cp310", "cp311", "cp312"]
         cibw_manylinux: [manylinux2014]
         cibw_arch: ["aarch64"]
     steps:
@@ -89,7 +89,7 @@ jobs:
         with:
           output-dir: dist
         env:
-          CIBW_BUILD: ${{ matrix.cibw_python }}
+          CIBW_BUILD: ${{ matrix.cibw_python }}-*
           CIBW_ARCHS_LINUX: ${{ matrix.cibw_arch }}
           CIBW_SKIP: "*-musllinux_*"
           CIBW_MANYLINUX_X86_64_IMAGE: ${{ matrix.cibw_manylinux }}
@@ -105,7 +105,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [macos-latest]
-        cibw_python: ["cp39-*", "cp310-*", "cp311-*", "cp312-*"]
+        cibw_python: ["cp39", "cp310", "cp311", "cp312"]
         cibw_arch: ["x86_64", "arm64"]
     steps:
       - uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
@@ -122,7 +122,7 @@ jobs:
         with:
           output-dir: dist
         env:
-          CIBW_BUILD: ${{ matrix.cibw_python }}
+          CIBW_BUILD: ${{ matrix.cibw_python }}-*
           CIBW_ARCHS_MACOS: ${{ matrix.cibw_arch }}
 
       - uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # v4.3.1
@@ -139,7 +139,7 @@ jobs:
       matrix:
         os: [windows-latest]
         cibw_arch: ["AMD64", "x86"]
-        cibw_python: ["cp39-*", "cp310-*", "cp311-*", "cp312-*"]
+        cibw_python: ["cp39", "cp310", "cp311", "cp312"]
     steps:
       - uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
         with:
@@ -167,7 +167,7 @@ jobs:
         with:
           output-dir: dist
         env:
-          CIBW_BUILD: ${{ matrix.cibw_python }}
+          CIBW_BUILD: ${{ matrix.cibw_python }}-*
           CIBW_ARCHS_WINDOWS: ${{ matrix.cibw_arch }}
 
       - uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # v4.3.1

--- a/.github/workflows/wheel_tests_and_release.yml
+++ b/.github/workflows/wheel_tests_and_release.yml
@@ -4,6 +4,18 @@ on:
     tags:
       - "v*"
       - "buildwheels*"
+  # Make it possible to upload wheels manually if needed
+  workflow_dispatch:
+    inputs:
+      push_wheels:
+        description: >
+          'Push wheels to Anaconda if "true". Default is "false". Warning: this will overwrite existing wheels.'
+        required: false
+        default: "false"
+  # Upload wheels to anaconda.org on a schedule
+  schedule:
+    # Run at 0300 hours on days 3 and 17 of the month
+    - cron: "0 3 3,17 * *"
 env:
   CIBW_BUILD_VERBOSITY: 2
   # CIBW_BEFORE_BUILD: pip install cython
@@ -23,28 +35,26 @@ jobs:
         cibw_manylinux: [manylinux2014]
         cibw_arch: ["x86_64"]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
         with:
           fetch-depth: 0
       - uses: actions/setup-python@v4
         name: Install Python
         with:
           python-version: "3.9"
-      - name: Install cibuildwheel
-        run: |
-          python -m pip install cibuildwheel
       - name: Build the wheel
-        run: |
-          python -m cibuildwheel --output-dir dist
+        uses: pypa/cibuildwheel@8d945475ac4b1aac4ae08b2fd27db9917158b6ce # 2.17.0
+        with:
+          output-dir: dist
         env:
           CIBW_BUILD: ${{ matrix.cibw_python }}
           CIBW_ARCHS_LINUX: ${{ matrix.cibw_arch }}
           CIBW_SKIP: "*-musllinux_*"
           CIBW_MANYLINUX_X86_64_IMAGE: ${{ matrix.cibw_manylinux }}
           CIBW_MANYLINUX_I686_IMAGE: "manylinux2010"
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # v4.3.1
         with:
-          name: wheels
+          name: linux_x86_64_wheels
           path: ./dist/*.whl
 
   build_linux_aarch64_wheels:
@@ -57,7 +67,7 @@ jobs:
         cibw_python: ["cp39-*", "cp310-*", "cp311-*", "cp312-*"]
         cibw_manylinux: [manylinux2014]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
         with:
           fetch-depth: 0
       - uses: actions/setup-python@v4
@@ -68,20 +78,18 @@ jobs:
         uses: docker/setup-qemu-action@v3
         with:
           platforms: arm64
-      - name: Install cibuildwheel
-        run: |
-          python -m pip install cibuildwheel
       - name: Build the wheel
-        run: |
-          python -m cibuildwheel --output-dir dist
+        uses: pypa/cibuildwheel@8d945475ac4b1aac4ae08b2fd27db9917158b6ce # 2.17.0
+        with:
+          output-dir: dist
         env:
           CIBW_BUILD: ${{ matrix.cibw_python }}
           CIBW_ARCHS_LINUX: aarch64
           CIBW_SKIP: "*-musllinux_*"
           CIBW_MANYLINUX_X86_64_IMAGE: ${{ matrix.cibw_manylinux }}
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # v4.3.1
         with:
-          name: wheels
+          name: linux_aarch64_wheels
           path: ./dist/*.whl
 
   build_macos_wheels:
@@ -94,7 +102,7 @@ jobs:
         cibw_python: ["cp39-*", "cp310-*", "cp311-*", "cp312-*"]
         cibw_arch: ["x86_64", "arm64"]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
         with:
           fetch-depth: 0
 
@@ -103,32 +111,17 @@ jobs:
         with:
           python-version: "3.9"
 
-      - name: Install cibuildwheel
-        run: |
-          python -m pip install cibuildwheel
-
-      - name: Build wheels for CPython (MacOS)
-        run: |
-          # We need to set both MACOS_DEPLOYMENT_TARGET and MACOSX_DEPLOYMENT_TARGET
-          # until there is a new release with this commit:
-          # https://github.com/mesonbuild/meson-python/pull/309 (should be in 0.13.0)
-          if [[ "$CIBW_ARCHS_MACOS" == arm64 ]]; then
-              export MACOSX_DEPLOYMENT_TARGET=11.0
-              export MACOS_DEPLOYMENT_TARGET=11.0
-          else
-              export MACOSX_DEPLOYMENT_TARGET=10.13
-              export MACOS_DEPLOYMENT_TARGET=10.13
-          fi
-          echo MACOSX_DEPLOYMENT_TARGET=${MACOSX_DEPLOYMENT_TARGET}
-
-          python -m cibuildwheel --output-dir dist
+      - name: Build wheels for CPython (macOS)
+        uses: pypa/cibuildwheel@8d945475ac4b1aac4ae08b2fd27db9917158b6ce # 2.17.0
+        with:
+          output-dir: dist
         env:
           CIBW_BUILD: ${{ matrix.cibw_python }}
           CIBW_ARCHS_MACOS: ${{ matrix.cibw_arch }}
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # v4.3.1
         with:
-          name: wheels
+          name: macos_wheels
           path: ./dist/*.whl
 
   build_windows_wheels:
@@ -141,7 +134,7 @@ jobs:
         cibw_arch: ["AMD64", "x86"]
         cibw_python: ["cp39-*", "cp310-*", "cp311-*", "cp312-*"]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
         with:
           fetch-depth: 0
 
@@ -149,10 +142,6 @@ jobs:
         name: Install Python
         with:
           python-version: "3.9"
-
-      - name: Install cibuildwheel
-        run: |
-          python -m pip install cibuildwheel
 
       - name: Setup MSVC (32-bit)
         if: matrix.cibw_arch == 'x86'
@@ -167,19 +156,20 @@ jobs:
           architecture: x64
 
       - name: Build Windows wheels for CPython
-        run: |
-          python -m cibuildwheel --output-dir dist
+        uses: pypa/cibuildwheel@8d945475ac4b1aac4ae08b2fd27db9917158b6ce # 2.17.0
+        with:
+          output-dir: dist
         env:
           CIBW_BUILD: ${{ matrix.cibw_python }}
           CIBW_ARCHS_WINDOWS: ${{ matrix.cibw_arch }}
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # v4.3.1
         with:
-          name: wheels
+          name: windows_wheels
           path: ./dist/*.whl
 
-  deploy:
-    name: Release
+  deploy_pypi:
+    name: Release (PyPI)
     needs:
       [
         build_linux_x86_64_wheels,
@@ -190,7 +180,7 @@ jobs:
     if: github.repository_owner == 'PyWavelets' && startsWith(github.ref, 'refs/tags/v') && always()
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
         with:
           fetch-depth: 0
 
@@ -204,11 +194,13 @@ jobs:
           python -m pip install --upgrade pip
           pip install twine
           pip install cython numpy build
-      - uses: actions/download-artifact@v3
+
+      - uses: actions/download-artifact@c850b930e6ba138125429b7e5c93fc707a7f8427 # v4.1.4
         id: download
         with:
-          name: wheels
+          pattern: "*_wheels"
           path: ./dist
+          merge-multiple: true
 
       - name: Publish the source distribution on PyPI
         run: |
@@ -224,7 +216,41 @@ jobs:
           TWINE_PASSWORD: ${{ secrets.TWINE_TOKEN }}
 
       - name: Github release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@d99959edae48b5ffffd7b00da66dcdb0a33a52ee # v2.0.2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_REPOSITORY: ${{ github.repository }}
+
+  deploy_anaconda:
+    name: Release (Anaconda)
+    needs:
+      [
+        build_linux_x86_64_wheels,
+        build_linux_aarch64_wheels,
+        build_macos_wheels,
+        build_windows_wheels,
+      ]
+    # Only run on the master branch, on schedule, or when triggered manually
+    if: >-
+      github.repository_owner == 'PyWavelets' &&
+      (github.event_name == 'push' && github.ref == 'refs/heads/master') ||
+      (github.event_name == 'workflow_dispatch' && github.event.inputs.push_wheels == 'true') ||
+      (github.event_name == 'schedule')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
+        with:
+          fetch-depth: 0
+
+      - uses: actions/download-artifact@c850b930e6ba138125429b7e5c93fc707a7f8427 # v4.1.4
+        id: download
+        with:
+          pattern: "*_wheels"
+          path: dist/
+          merge-multiple: true
+
+      - name: Push to Anaconda PyPI index
+        uses: scientific-python/upload-nightly-action@b67d7fcc0396e1128a474d1ab2b48aa94680f9fc # v0.5.0
+        with:
+          artifacts_path: dist/
+          anaconda_nightly_upload_token: ${{ secrets.ANACONDA_ORG_UPLOAD_TOKEN }}

--- a/.github/workflows/wheel_tests_and_release.yml
+++ b/.github/workflows/wheel_tests_and_release.yml
@@ -181,8 +181,10 @@ jobs:
         build_macos_wheels,
         build_windows_wheels,
       ]
-    # Run only on tags pushed to the repository
-    if: github.repository_owner == 'PyWavelets' && startsWith(github.ref, 'refs/tags/v')
+    # Run only on tags pushed to the repository or when triggered manually
+    if: >-
+      github.repository == 'PyWavelets/pywt' && (startsWith(github.ref, 'refs/tags/v') ||
+      (github.event_name == 'workflow_dispatch' && github.event.inputs.push_wheels == 'true'))
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
@@ -237,7 +239,7 @@ jobs:
       ]
     # Run only on pushes to the master branch, on schedule, or when triggered manually
     if: >-
-      github.repository_owner == 'PyWavelets' &&
+      github.repository == 'PyWavelets/pywt' &&
       (github.event_name == 'push' && github.ref == 'refs/heads/master') ||
       (github.event_name == 'workflow_dispatch' && github.event.inputs.push_wheels == 'true') ||
       (github.event_name == 'schedule')

--- a/.github/workflows/wheel_tests_and_release.yml
+++ b/.github/workflows/wheel_tests_and_release.yml
@@ -181,10 +181,8 @@ jobs:
         build_macos_wheels,
         build_windows_wheels,
       ]
-    # Run only on tags pushed to the repository or when triggered manually
-    if: >-
-      github.repository == 'PyWavelets/pywt' && (startsWith(github.ref, 'refs/tags/v') ||
-      (github.event_name == 'workflow_dispatch' && github.event.inputs.push_wheels == 'true'))
+    # Run only on tags pushed to the repository
+    if: github.repository == 'PyWavelets/pywt' && startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2


### PR DESCRIPTION
## Description

This PR introduces the following changes:
1. It adds a `deploy_anaconda` job where the wheels can be uploaded to https://anaconda.org/scientific-python-nightly-wheels/PyWavelets/ using the `scientific-python/upload-nightly-action` GitHub Action
2. A `workflow_dispatch` trigger to push the nightly wheels, and a CRON schedule that matches the one in #710
3. Replaces the `cibuildwheel` installation with its upstream GitHub Action, in order to get updates from Dependabot (see #708)
4. Bumps up versions for the `checkout` actions and bumps the major version for `download-artifact` and `upload-artifact`
5. Ensures that the necessary job runs or is skipped, based on the other wheel builds that may pass or fail

## Footnotes

This PR is related to the changes requested on #712.