### PR TITLE
CI: fix patterns for artifact downloads in Anaconda nightly wheels job

### DIFF
--- a/.github/workflows/wheel_tests_and_release.yml
+++ b/.github/workflows/wheel_tests_and_release.yml
@@ -254,7 +254,7 @@ jobs:
       - uses: actions/download-artifact@c850b930e6ba138125429b7e5c93fc707a7f8427 # v4.1.4
         id: download
         with:
-          pattern: "*_wheels"
+          pattern: "wheels_*"
           path: dist/
           merge-multiple: true
 


### PR DESCRIPTION
## Description

A minor fix for the failure noted in this workflow run: https://github.com/PyWavelets/pywt/actions/runs/8253753639. In this PR, I have adjusted the pattern so that the correct artifacts will be matched and downloaded.

(I fixed it for the PyPI job, missed doing it for the Anaconda one).