### PR TITLE
CI: Build `musllinux` aarch64 and x86_64 wheels, and native macOS arm64 wheels

### DIFF
--- a/.github/workflows/wheel_tests_and_release.yml
+++ b/.github/workflows/wheel_tests_and_release.yml
@@ -29,7 +29,7 @@ env:
 
 jobs:
   build_linux_x86_64_wheels:
-    name: Build python ${{ matrix.cibw_python }} ${{ matrix.cibw_arch }} wheels on ${{ matrix.os }}
+    name: Build ${{ matrix.cibw_python }} ${{ matrix.cibw_arch }} ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -63,7 +63,7 @@ jobs:
           if-no-files-found: error
 
   build_linux_aarch64_wheels:
-    name: Build python ${{ matrix.cibw_python }} aarch64 wheels on ${{ matrix.os }}
+    name: Build ${{ matrix.cibw_python }} ${{ matrix.cibw_arch }} ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -99,14 +99,19 @@ jobs:
           path: ./dist/*.whl
 
   build_macos_wheels:
-    name: Build python ${{ matrix.cibw_python }} ${{ matrix.cibw_arch }} wheels on ${{ matrix.os }}
+    name: Build ${{ matrix.cibw_python }} ${{ matrix.cibw_arch }} ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-latest]
+        os: [macos-latest, macos-14]
         cibw_python: ["cp39", "cp310", "cp311", "cp312"]
         cibw_arch: ["x86_64", "arm64"]
+        exclude:
+          - os: macos-14
+            cibw_arch: "x86_64"
+          - os: macos-latest
+            cibw_arch: "arm64"
     steps:
       - uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
         with:
@@ -117,7 +122,17 @@ jobs:
         with:
           python-version: "3.9"
 
-      - name: Build wheels for CPython (macOS)
+      - name: Build wheels for CPython (macOS) (x86_64)
+        if: matrix.cibw_arch == 'x86_64' && matrix.os == 'macos-latest'
+        uses: pypa/cibuildwheel@8d945475ac4b1aac4ae08b2fd27db9917158b6ce # 2.17.0
+        with:
+          output-dir: dist
+        env:
+          CIBW_BUILD: ${{ matrix.cibw_python }}-*
+          CIBW_ARCHS_MACOS: ${{ matrix.cibw_arch }}
+
+      - name: Build wheels for CPython (macOS) (arm64)
+        if: matrix.cibw_arch == 'arm64' && matrix.os == 'macos-14'
         uses: pypa/cibuildwheel@8d945475ac4b1aac4ae08b2fd27db9917158b6ce # 2.17.0
         with:
           output-dir: dist
@@ -132,7 +147,7 @@ jobs:
           if-no-files-found: error
 
   build_windows_wheels:
-    name: Build ${{ matrix.cibw_python }} ${{ matrix.cibw_arch }} wheels on ${{ matrix.os }}
+    name: Build ${{ matrix.cibw_python }} ${{ matrix.cibw_arch }} ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false

--- a/.github/workflows/wheel_tests_and_release.yml
+++ b/.github/workflows/wheel_tests_and_release.yml
@@ -8,12 +8,12 @@ on:
       # Runs on every merge to master to upload .dev0 wheels to anaconda.org
       - master
       - v1.**
-  # Make it possible to upload wheels manually if needed
+  # Make it possible to upload wheels manually if needed (for anaconda.org only, not PyPI)
   workflow_dispatch:
     inputs:
       push_wheels:
         description: >
-          'Push wheels to Anaconda if "true". Default is "false". Warning: this will overwrite existing wheels.'
+          Push wheels to Anaconda if "true". Default is "false". Warning: this will overwrite existing wheels.
         required: false
         default: "false"
   # Upload wheels to anaconda.org on a schedule
@@ -22,7 +22,6 @@ on:
     - cron: "0 3 3,17 * *"
 env:
   CIBW_BUILD_VERBOSITY: 2
-  # CIBW_BEFORE_BUILD: pip install cython
   CIBW_TEST_REQUIRES: pytest
   CIBW_TEST_COMMAND: pytest --pyargs pywt -m "not slow"
   CIBW_ENVIRONMENT: PIP_PREFER_BINARY=1
@@ -36,7 +35,6 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         cibw_python: ["cp39", "cp310", "cp311", "cp312"]
-        cibw_manylinux: [manylinux2014]
         cibw_arch: ["x86_64"]
     steps:
       - uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
@@ -53,12 +51,12 @@ jobs:
         env:
           CIBW_BUILD: ${{ matrix.cibw_python }}-*
           CIBW_ARCHS_LINUX: ${{ matrix.cibw_arch }}
-          CIBW_SKIP: "*-musllinux_*"
-          CIBW_MANYLINUX_X86_64_IMAGE: ${{ matrix.cibw_manylinux }}
-          CIBW_MANYLINUX_I686_IMAGE: "manylinux2010"
+          CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
+          CIBW_MANYLINUX_I686_IMAGE: manylinux2014
+          CIBW_MUSLLINUX_X86_64_IMAGE: musllinux_1_1
       - uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # v4.3.1
         with:
-          name: wheels_linux_${{ matrix.cibw_arch }}_${{ matrix.cibw_python }}_manylinux2014
+          name: wheels_linux_${{ matrix.cibw_arch }}_${{ matrix.cibw_python }}
           path: ./dist/*.whl
           if-no-files-found: error
 
@@ -70,7 +68,6 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         cibw_python: ["cp39", "cp310", "cp311", "cp312"]
-        cibw_manylinux: [manylinux2014]
         cibw_arch: ["aarch64"]
     steps:
       - uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
@@ -91,11 +88,11 @@ jobs:
         env:
           CIBW_BUILD: ${{ matrix.cibw_python }}-*
           CIBW_ARCHS_LINUX: ${{ matrix.cibw_arch }}
-          CIBW_SKIP: "*-musllinux_*"
-          CIBW_MANYLINUX_X86_64_IMAGE: ${{ matrix.cibw_manylinux }}
+          CIBW_MANYLINUX_AARCH64_IMAGE: manylinux2014
+          CIBW_MUSLLINUX_AARCH64_IMAGE: musllinux_1_1
       - uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # v4.3.1
         with:
-          name: wheels_linux_${{ matrix.cibw_arch }}_${{ matrix.cibw_python }}_manylinux2014
+          name: wheels_linux_${{ matrix.cibw_arch }}_${{ matrix.cibw_python }}
           path: ./dist/*.whl
 
   build_macos_wheels:
@@ -120,7 +117,7 @@ jobs:
       - uses: actions/setup-python@v5
         name: Install Python
         with:
-          python-version: "3.9"
+          python-version: "3.12"
 
       - name: Build wheels for CPython (macOS) (x86_64)
         if: matrix.cibw_arch == 'x86_64' && matrix.os == 'macos-latest'

--- a/.github/workflows/wheel_tests_and_release.yml
+++ b/.github/workflows/wheel_tests_and_release.yml
@@ -52,7 +52,6 @@ jobs:
           CIBW_BUILD: ${{ matrix.cibw_python }}-*
           CIBW_ARCHS_LINUX: ${{ matrix.cibw_arch }}
           CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
-          CIBW_MANYLINUX_I686_IMAGE: manylinux2014
           CIBW_MUSLLINUX_X86_64_IMAGE: musllinux_1_1
       - uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # v4.3.1
         with:

--- a/.github/workflows/wheel_tests_and_release.yml
+++ b/.github/workflows/wheel_tests_and_release.yml
@@ -101,13 +101,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-latest, macos-14]
+        # macos-13 is the last runner that supports Intel (x86_64) architecture
+        os: [macos-13, macos-14]
         cibw_python: ["cp39", "cp310", "cp311", "cp312"]
         cibw_arch: ["x86_64", "arm64"]
         exclude:
           - os: macos-14
             cibw_arch: "x86_64"
-          - os: macos-latest
+          - os: macos-13
             cibw_arch: "arm64"
     steps:
       - uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
@@ -120,7 +121,7 @@ jobs:
           python-version: "3.12"
 
       - name: Build wheels for CPython (macOS) (x86_64)
-        if: matrix.cibw_arch == 'x86_64' && matrix.os == 'macos-latest'
+        if: matrix.cibw_arch == 'x86_64'
         uses: pypa/cibuildwheel@8d945475ac4b1aac4ae08b2fd27db9917158b6ce # 2.17.0
         with:
           output-dir: dist
@@ -129,7 +130,7 @@ jobs:
           CIBW_ARCHS_MACOS: ${{ matrix.cibw_arch }}
 
       - name: Build wheels for CPython (macOS) (arm64)
-        if: matrix.cibw_arch == 'arm64' && matrix.os == 'macos-14'
+        if: matrix.cibw_arch == 'arm64'
         uses: pypa/cibuildwheel@8d945475ac4b1aac4ae08b2fd27db9917158b6ce # 2.17.0
         with:
           output-dir: dist


### PR DESCRIPTION
## Description

This PR addresses the following:
1. Adds `macos-14` GitHub Actions runners to target macOS arm64 wheels natively, without cross-compilation
2. Configures the `build_linux_aarch64_wheels` and `build_linux_x86_64_wheels` jobs to include MUSL wheels (which were previously being skipped).

## Footnotes

This PR:
1. closes gh-718,
2. closes gh-623, and
3. is a follow-up to gh-710 and gh-712.