### PR TITLE
BLD: avoid warnings from including deprecated NumPy API

### DIFF
--- a/pywt/_extensions/meson.build
+++ b/pywt/_extensions/meson.build
@@ -36,7 +36,12 @@ else
   _incdir_numpy_abs = incdir_numpy
 endif
 inc_np = include_directories(incdir_numpy)
-np_dep = declare_dependency(include_directories: inc_np)
+
+# Don't use the deprecated NumPy C API. Define this to a fixed version instead of
+# NPY_API_VERSION in order not to break compilation for released PyWavelets
+# versions when NumPy introduces a new deprecation.
+numpy_nodepr_api = ['-DNPY_NO_DEPRECATED_API=NPY_1_22_API_VERSION']
+np_dep = declare_dependency(include_directories: inc_np, compile_args: numpy_nodepr_api)
 
 config_pxi = configure_file(
   input: 'config.pxi.in',


### PR DESCRIPTION
We weren't using deprecated API; this define to silence warnings from NumPy can now be used since Cython 3.0 no longer uses that deprecated API.

The warnings looked like:
```
    [25/32] Compiling C object pywt/_extensions/_cwt.cpython-311-x86_64-linux-gnu.so.p/meson-generated_pywt__extensions__cwt.pyx.c.o
    In file included from ../../tmp/pip-build-env-xlx46qpn/overlay/lib/python3.11/site-packages/numpy/_core/include/numpy/ndarraytypes.h:1902,
                     from ../../tmp/pip-build-env-xlx46qpn/overlay/lib/python3.11/site-packages/numpy/_core/include/numpy/ndarrayobject.h:12,
                     from ../../tmp/pip-build-env-xlx46qpn/overlay/lib/python3.11/site-packages/numpy/_core/include/numpy/arrayobject.h:5,
                     from pywt/_extensions/_cwt.cpython-311-x86_64-linux-gnu.so.p/pywt/_extensions/_cwt.pyx.c:1199:
    ../../tmp/pip-build-env-xlx46qpn/overlay/lib/python3.11/site-packages/numpy/_core/include/numpy/npy_1_7_deprecated_api.h:17:2: warning: #warning "Using deprecated NumPy API, disable it with " "#define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION" [-Wcpp]
       17 | #warning "Using deprecated NumPy API, disable it with " \
          |  ^~~~~~~
```