### PR TITLE
DOC: Fix incorrect indentations for a few interactive examples

### DIFF
--- a/doc/source/ref/cwt.rst
+++ b/doc/source/ref/cwt.rst
@@ -92,8 +92,8 @@ wavelet names compatible with ``cwt`` can be obtained by:
 .. try_examples::
   :button_text: Try it in your browser!
 
-    >>> import pywt
-    >>> wavelist = pywt.wavelist(kind='continuous')
+  >>> import pywt
+  >>> wavelist = pywt.wavelist(kind='continuous')
 
 Here is an overview of all available wavelets for ``cwt``. Note, that they can be
 customized by passing parameters such as ``center_frequency`` and ``bandwidth_frequency``
@@ -210,12 +210,12 @@ particular wavelet, one would analyze a signal using ``scales >= 2``.
 .. try_examples::
   :button_text: Try it in your browser!
 
-    >>> import numpy as np
-    >>> import pywt
-    >>> dt = 0.01  # 100 Hz sampling
-    >>> frequencies = pywt.scale2frequency('cmor1.5-1.0', [1, 2, 3, 4]) / dt
-    >>> frequencies
-    array([ 100.        ,   50.        ,   33.33333333,   25.        ])
+  >>> import numpy as np
+  >>> import pywt
+  >>> dt = 0.01  # 100 Hz sampling
+  >>> frequencies = pywt.scale2frequency('cmor1.5-1.0', [1, 2, 3, 4]) / dt
+  >>> frequencies
+  array([ 100.        ,   50.        ,   33.33333333,   25.        ])
 
 The CWT in PyWavelets is applied to discrete data by convolution with samples
 of the integral of the wavelet. If ``scale`` is too low, this will result in
@@ -241,14 +241,14 @@ of frequency directly.
 .. try_examples::
   :button_text: Try it in your browser!
 
-    >>> import numpy as np
-    >>> import pywt
-    >>> dt = 0.01  # 100 Hz sampling
-    >>> fs = 1 / dt
-    >>> frequencies = np.array([100, 50, 33.33333333, 25]) / fs # normalize
-    >>> scale = pywt.frequency2scale('cmor1.5-1.0', frequencies)
-    >>> scale
-    array([ 1.,  2.,  3.,  4.])
+  >>> import numpy as np
+  >>> import pywt
+  >>> dt = 0.01  # 100 Hz sampling
+  >>> fs = 1 / dt
+  >>> frequencies = np.array([100, 50, 33.33333333, 25]) / fs # normalize
+  >>> scale = pywt.frequency2scale('cmor1.5-1.0', frequencies)
+  >>> scale
+  array([ 1.,  2.,  3.,  4.])
 
 
 .. plot:: pyplots/cwt_scaling_demo.py

--- a/doc/source/ref/signal-extension-modes.rst
+++ b/doc/source/ref/signal-extension-modes.rst
@@ -92,9 +92,9 @@ computations can be performed with the `periodization`_ mode:
 .. try_examples::
   :button_text: Try it in your browser!
 
-    >>> import pywt
-    >>> print(pywt.Modes.modes)
-    ['zero', 'constant', 'symmetric', 'periodic', 'smooth', 'periodization', 'reflect', 'antisymmetric', 'antireflect']
+  >>> import pywt
+  >>> print(pywt.Modes.modes)
+  ['zero', 'constant', 'symmetric', 'periodic', 'smooth', 'periodization', 'reflect', 'antisymmetric', 'antireflect']
 
 The following figure illustrates how a short signal (red) gets extended (black)
 outside of its original extent. Note that periodization first extends the

--- a/doc/source/ref/wavelets.rst
+++ b/doc/source/ref/wavelets.rst
@@ -241,25 +241,25 @@ The Wavelet object created in this way is a standard :class:`Wavelet` instance.
 The following example illustrates the way of creating custom Wavelet objects
 from plain Python lists of filter coefficients and a *filter bank-like* object.
 
-  **Example:**
+**Example:**
 
-  .. try_examples::
-    :button_text: Try it in your browser!
+.. try_examples::
+  :button_text: Try it in your browser!
 
-    >>> import pywt, math
-    >>> c = math.sqrt(2)/2
-    >>> dec_lo, dec_hi, rec_lo, rec_hi = [c, c], [-c, c], [c, c], [c, -c]
-    >>> filter_bank = [dec_lo, dec_hi, rec_lo, rec_hi]
-    >>> myWavelet = pywt.Wavelet(name="myHaarWavelet", filter_bank=filter_bank)
-    >>>
-    >>> class HaarFilterBank(object):
-    ...     @property
-    ...     def filter_bank(self):
-    ...         c = math.sqrt(2)/2
-    ...         dec_lo, dec_hi, rec_lo, rec_hi = [c, c], [-c, c], [c, c], [c, -c]
-    ...         return [dec_lo, dec_hi, rec_lo, rec_hi]
-    >>> filter_bank = HaarFilterBank()
-    >>> myOtherWavelet = pywt.Wavelet(name="myHaarWavelet", filter_bank=filter_bank)
+  >>> import pywt, math
+  >>> c = math.sqrt(2)/2
+  >>> dec_lo, dec_hi, rec_lo, rec_hi = [c, c], [-c, c], [c, c], [c, -c]
+  >>> filter_bank = [dec_lo, dec_hi, rec_lo, rec_hi]
+  >>> myWavelet = pywt.Wavelet(name="myHaarWavelet", filter_bank=filter_bank)
+  >>>
+  >>> class HaarFilterBank(object):
+  ...     @property
+  ...     def filter_bank(self):
+  ...         c = math.sqrt(2)/2
+  ...         dec_lo, dec_hi, rec_lo, rec_hi = [c, c], [-c, c], [c, c], [c, -c]
+  ...         return [dec_lo, dec_hi, rec_lo, rec_hi]
+  >>> filter_bank = HaarFilterBank()
+  >>> myOtherWavelet = pywt.Wavelet(name="myHaarWavelet", filter_bank=filter_bank)
 
 
 .. _ContinuousWavelet:


### PR DESCRIPTION
## Description

Some of the interactive examples that were manually inserted in #728 with the `TryExamples` directive available via the `jupyterlite-sphinx` extension had the wrong indentation (four spaces instead of two), which made them get rendered like this:

![image](https://github.com/PyWavelets/pywt/assets/74401230/beb7fd1a-b20b-4db0-b2fe-b941d32f361b)

This PR is a small fix to address this issue (I had just noticed this when debugging certain aspects of #706). This is how they render now locally (correctly):

![image](https://github.com/PyWavelets/pywt/assets/74401230/b4e30ec8-7892-4257-91c5-b17b4ceaa70b)

## Additional context

The Usage examples have not been converted to an interactive state at this time and most likely also have the same indentation issue; however, this is on my near-term radar. It would require restructuring the pages and possibly using the `NotebookLite` directive and configuring some CSS attributes for the generated button, instead of adding duplicated `import pywt` statements to code cells.

Also, it is to be noted that the automatically parsed code blocks do not seem to have been affected with this, so we'll have to be careful when adding the directive to additional places later on.