### PR TITLE
DOC, DEP: Remove custom `:button_text` directive option, bump `jupyterlite-sphinx`

### DIFF
--- a/doc/source/ref/cwt.rst
+++ b/doc/source/ref/cwt.rst
@@ -90,7 +90,6 @@ A variety of continuous wavelets have been implemented. A list of the available
 wavelet names compatible with ``cwt`` can be obtained by:
 
 .. try_examples::
-  :button_text: Try it in your browser!
 
   >>> import pywt
   >>> wavelist = pywt.wavelist(kind='continuous')
@@ -208,7 +207,6 @@ sampled at 100 Hz, a center frequency of 1.0 corresponds to ~100 Hz at
 particular wavelet, one would analyze a signal using ``scales >= 2``.
 
 .. try_examples::
-  :button_text: Try it in your browser!
 
   >>> import numpy as np
   >>> import pywt
@@ -239,7 +237,6 @@ frequency fs. This function is useful for specifying the transform as a function
 of frequency directly.
 
 .. try_examples::
-  :button_text: Try it in your browser!
 
   >>> import numpy as np
   >>> import pywt

--- a/doc/source/ref/signal-extension-modes.rst
+++ b/doc/source/ref/signal-extension-modes.rst
@@ -90,7 +90,6 @@ computations can be performed with the `periodization`_ mode:
 **Example:**
 
 .. try_examples::
-  :button_text: Try it in your browser!
 
   >>> import pywt
   >>> print(pywt.Modes.modes)
@@ -106,7 +105,6 @@ Notice that you can use any of the following ways of passing wavelet and mode
 parameters:
 
 .. try_examples::
-  :button_text: Try it in your browser!
 
   >>> import pywt
   >>> (a, d) = pywt.dwt([1,2,3,4,5,6], 'db2', 'smooth')

--- a/doc/source/ref/wavelets.rst
+++ b/doc/source/ref/wavelets.rst
@@ -49,7 +49,6 @@ Custom discrete wavelets are also supported through the
   **Example:**
 
   .. try_examples::
-    :button_text: Try it in your browser!
 
     >>> import pywt
     >>> wavelet = pywt.Wavelet('db1')
@@ -130,7 +129,6 @@ Custom discrete wavelets are also supported through the
   **Example:**
 
   .. try_examples::
-    :button_text: Try it in your browser!
 
     >>> def format_array(arr):
     ...     return "[%s]" % ", ".join(["%.14f" % x for x in arr])
@@ -174,7 +172,6 @@ Approximating wavelet and scaling functions - ``Wavelet.wavefun()``
   **Example:**
 
   .. try_examples::
-    :button_text: Try it in your browser!
 
     >>> import pywt
     >>> wavelet = pywt.Wavelet('db2')
@@ -190,7 +187,6 @@ Approximating wavelet and scaling functions - ``Wavelet.wavefun()``
   **Example:**
 
   .. try_examples::
-    :button_text: Try it in your browser!
 
     >>> import pywt
     >>> wavelet = pywt.Wavelet('bior3.5')
@@ -244,7 +240,6 @@ from plain Python lists of filter coefficients and a *filter bank-like* object.
 **Example:**
 
 .. try_examples::
-  :button_text: Try it in your browser!
 
   >>> import pywt, math
   >>> c = math.sqrt(2)/2
@@ -279,7 +274,6 @@ from plain Python lists of filter coefficients and a *filter bank-like* object.
   **Example:**
 
   .. try_examples::
-    :button_text: Try it in your browser!
 
     >>> import pywt
     >>> wavelet = pywt.ContinuousWavelet('gaus1')
@@ -335,7 +329,6 @@ from plain Python lists of filter coefficients and a *filter bank-like* object.
   **Example:**
 
   .. try_examples::
-    :button_text: Try it in your browser!
 
     >>> import pywt
     >>> wavelet = pywt.ContinuousWavelet('gaus1')
@@ -366,7 +359,6 @@ Approximating wavelet functions - ``ContinuousWavelet.wavefun()``
   **Example:**
 
   .. try_examples::
-    :button_text: Try it in your browser!
 
     >>> import pywt
     >>> wavelet = pywt.ContinuousWavelet('gaus1')
@@ -384,7 +376,6 @@ Approximating wavelet functions - ``ContinuousWavelet.wavefun()``
   **Example:**
 
   .. try_examples::
-    :button_text: Try it in your browser!
 
     >>> import pywt
     >>> wavelet = pywt.DiscreteContinuousWavelet('db1')

--- a/util/readthedocs/requirements.txt
+++ b/util/readthedocs/requirements.txt
@@ -1,6 +1,6 @@
 cython
 docutils<0.18
-jupyterlite-sphinx
+jupyterlite-sphinx>=0.14.0
 jupyterlite-pyodide-kernel
 pydata-sphinx-theme
 pytest


### PR DESCRIPTION
## Description

This is a small  PR because `jupyterlite-sphinx` has a new [release](https://github.com/jupyterlite/jupyterlite-sphinx/releases/tag/v0.14.0) (https://github.com/jupyterlite/jupyterlite-sphinx/issues/171) which simplifies some things here.

Addresses some issues found in #728 and is a bigger part of #706. I had committed this last month, now rebased on top of the latest changes.

## Changes made

1. I updated the minimum `jupyterlite-sphinx` version to 0.14.0 corresponding to the new release, and
2. with that, I removed the `:button_text:` option from the `.. try_examples::` directives everywhere in the source code, since the directive can now use the global configuration in `conf.py`.

## Additional context

While the documentation is building alright right now, the upper pin on `docutils` restricts us to Sphinx v5.3.0, while the seemingly more stable v7.3.7 is available. Should we remove this pin? I removed it and built the docs again without issues, so, it doesn't seem to be needed. @rgommers, do we still need this pin or can we relax it? I can't find anything with a quick search suggestive of why this pin exists; if it makes sense, I am happy to do this in the same PR.