### PR TITLE
DEP: Remove `docutils` upper-pin, bump `sphinx`

### DIFF
--- a/util/readthedocs/requirements.txt
+++ b/util/readthedocs/requirements.txt
@@ -1,5 +1,5 @@
 cython
-docutils<0.18
+docutils
 jupyterlite-sphinx>=0.14.0
 jupyterlite-pyodide-kernel
 pydata-sphinx-theme
@@ -8,6 +8,6 @@ matplotlib
 meson-python
 numpy
 numpydoc
-sphinx
+sphinx>=7
 sphinx-togglebutton
 sphinx-copybutton


### PR DESCRIPTION
## Description

This PR is a follow-up from #737 to bump some documentation-related dependencies in `util/readthedocs/requirements.txt`, as requested in https://github.com/PyWavelets/pywt/pull/737#pullrequestreview-2033172515.

## Changes made

1. Added a minimum version requirement for `sphinx – set to `>=7`
2. Removed the constraint from `docutils` – it was the one that was blocking this change.

## Additional context

I checked many of the pages personally and there seem to be no problems with the build. The documentation does not display any warnings and the build with `-W` passes locally. All of our extensions and other listed dependencies support Sphinx v7 as well.