### PR TITLE
FIX, CI: Temporarily disable `pytest`'s caching in Pyodide job

### DIFF
--- a/.github/workflows/emscripten.yml
+++ b/.github/workflows/emscripten.yml
@@ -30,8 +30,8 @@ jobs:
   build_wasm_emscripten:
     name: Build PyWavelets for Pyodide
     runs-on: ubuntu-latest
-    # Uncomment the following line to test changes on a fork
-    # if: github.repository == 'PyWavelets/pywt'
+    # Comment out the following line to test changes on a fork
+    if: github.repository == 'PyWavelets/pywt'
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
@@ -44,7 +44,7 @@ jobs:
 
       - name: Install prerequisites
         run: |
-          python -m pip install pyodide-build "pydantic<2"
+          python -m pip install pyodide-build
           echo EMSCRIPTEN_VERSION=$(pyodide config get emscripten_version) >> $GITHUB_ENV
 
       - name: Set up Emscripten toolchain
@@ -70,12 +70,16 @@ jobs:
           pushd demo
           pip install matplotlib pytest
           python -c "import pywt; print(pywt.__version__)"
-          pytest --pyargs pywt -m "not slow"
+          pytest -p no:cacheprovider --pyargs pywt -m "not slow"
 
         # https://anaconda.org/scientific-python-nightly-wheels/pywavelets
         # WARNING: this job will overwrite existing wheels.
       - name: Push to Anaconda PyPI index
-        if: (github.repository == 'PyWavelets/pywt') && (github.event_name == 'push' && github.ref == 'refs/heads/main') || (github.event_name == 'workflow_dispatch' && github.event.inputs.push_wheels == 'true') || (github.event_name == 'schedule')
+        if: >-
+          (github.repository == 'PyWavelets/pywt') &&
+          (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
+          (github.event_name == 'workflow_dispatch' && github.event.inputs.push_wheels == 'true') ||
+          (github.event_name == 'schedule')
         uses: scientific-python/upload-nightly-action@b67d7fcc0396e1128a474d1ab2b48aa94680f9fc # v0.5.0
         with:
           artifacts_path: dist/


### PR DESCRIPTION
## Description

The `pytest` test suite tries to generate additional bytecode files after its completion, and it then tries to save them to a filesystem that is read-only for unexplored reasons. Since this workflow runs only in a temporary CI job, the `.pyc` file generation can be disabled with the internal `pytest` plugin using `-p no:cacheprovider`.

Some other fixes are included as well:

1. The Pydantic upper-pin, i.e., `pydantic<2` is not needed anymore
2. Skipping this job on forks
3. A more readable condition for the Anaconda index upload step

The workflow is passing on my fork, here: https://github.com/agriyakhetarpal/pywt/actions/runs/9287344567/job/25556120583

## What issue does this PR reference?

Closes gh-742. For additional context: this PR fixes an unrelated error which was noted in https://github.com/PyWavelets/pywt/issues/742#issuecomment-2136963106, and the CI job is already picking up the latest Emscripten version that is coupled with `pyodide-build` using the value retrieved by the `$(pyodide config get emscripten_version)` command.