### PR TITLE
CI: Add CI to test on free-threaded Python

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -168,9 +168,6 @@ jobs:
 
       - name: Run tests
         env:
-          USE_SDIST: ${{ matrix.USE_SDIST }}
-          REFGUIDE_CHECK: ${{ matrix.REFGUIDE_CHECK }}
-          OPTIONS_NAME: ${{ matrix.OPTIONS_NAME }}
           PYTHON_GIL: 0
         run: |
           set -o pipefail

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -140,25 +140,12 @@ jobs:
           popd
 
   test_pywavelets_linux_free_threaded:
-    name: linux-cp${{ matrix.python-version }}t-${{ matrix.OPTIONS_NAME }}
+    name: linux-cp313t-with-scipy
     runs-on: ubuntu-latest
     strategy:
       # Ensure that a wheel builder finishes even if another fails
       fail-fast: false
-      matrix:
-        python-version: ["3.13t"]
-        MINIMUM_REQUIREMENTS: [0]
-        USE_SCIPY: [0]
-        USE_SDIST: [0]
-        REFGUIDE_CHECK: [0]
-        PIP_FLAGS: [""]
-        OPTIONS_NAME: ["default"]
-        include:
-          - platform_id: manylinux_x86_64
-            python-version: "3.13"
-            USE_SCIPY: 1
-            OPTIONS_NAME: "with-scipy"
-            PIP_FLAGS: "--pre -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple"
+
     steps:
       - name: Checkout PyWavelets
         uses: actions/checkout@v4
@@ -170,27 +157,12 @@ jobs:
           nogil: true
 
       - name: Build package
-        env:
-          VERSION: ${{ matrix.python-version }}
-          MINIMUM_REQUIREMENTS: ${{ matrix.MINIMUM_REQUIREMENTS }}
-          PIP_FLAGS: ${{ matrix.PIP_FLAGS }}
-          USE_SDIST: ${{ matrix.USE_SDIST }}
-          USE_SCIPY: ${{ matrix.USE_SCIPY }}
-          REFGUIDE_CHECK: ${{ matrix.REFGUIDE_CHECK }}
-          OPTIONS_NAME: ${{ matrix.OPTIONS_NAME }}
         run: |
-          uname -a
-          df -h
-          ulimit -a
-          # ccache -s
           which python
           python --version
-          # sudo apt-get install libatlas-base-dev
           pip install --upgrade --pre pip build
           # Set numpy version first, other packages link against it
-          pip install ${PIP_FLAGS} cython
-          pip install ${PIP_FLAGS} numpy
-          if [ "${USE_SCIPY}" == "1" ]; then pip install ${PIP_FLAGS} scipy; fi
+          pip install --pre -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple cython numpy scipy
           pip install pytest meson-python ninja
           pip install . -v --no-build-isolation
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -161,7 +161,7 @@ jobs:
           which python
           python --version
           pip install --upgrade pip build
-          # Set numpy version first, other packages link against it
+          # We need nightly wheels for free-threaded support and latest fixes
           pip install --pre -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple cython numpy scipy
           pip install pytest meson-python ninja
           pip install . -v --no-build-isolation

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -160,7 +160,7 @@ jobs:
         run: |
           which python
           python --version
-          pip install --upgrade --pre pip build
+          pip install --upgrade pip build
           # Set numpy version first, other packages link against it
           pip install --pre -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple cython numpy scipy
           pip install pytest meson-python ninja
@@ -170,11 +170,9 @@ jobs:
         env:
           PYTHON_GIL: 0
         run: |
-          set -o pipefail
           # Move out of source directory to avoid finding local pywt
-          pushd demo
+          cd demo
           pytest --pyargs pywt
-          popd
 
   test_pywavelets_macos:
     name: macos-cp${{ matrix.python-version }}-${{ matrix.OPTIONS_NAME }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -155,7 +155,7 @@ jobs:
         OPTIONS_NAME: ["default"]
         include:
           - platform_id: manylinux_x86_64
-            python-version: "3.10"
+            python-version: "3.13"
             USE_SCIPY: 1
             OPTIONS_NAME: "with-scipy"
             PIP_FLAGS: "--pre -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple"
@@ -191,7 +191,7 @@ jobs:
           pip install ${PIP_FLAGS} cython
           pip install ${PIP_FLAGS} numpy
           if [ "${USE_SCIPY}" == "1" ]; then pip install ${PIP_FLAGS} scipy; fi
-          pip install matplotlib pytest meson-python ninja
+          pip install pytest meson-python ninja
           pip install . -v --no-build-isolation
 
       - name: Run tests

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -153,7 +153,7 @@ jobs:
       # TODO: replace with setup-python when there is support
       - uses: deadsnakes/action@6c8b9b82fe0b4344f4b98f2775fcc395df45e494 # v3.1.0
         with:
-          python-version: '3.13-dev'
+          python-version: "3.13-dev"
           nogil: true
 
       - name: Build package

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -139,6 +139,74 @@ jobs:
           fi
           popd
 
+  test_pywavelets_linux_free_threaded:
+    name: linux-cp${{ matrix.python-version }}t-${{ matrix.OPTIONS_NAME }}
+    runs-on: ubuntu-latest
+    strategy:
+      # Ensure that a wheel builder finishes even if another fails
+      fail-fast: false
+      matrix:
+        python-version: ["3.13t"]
+        MINIMUM_REQUIREMENTS: [0]
+        USE_SCIPY: [0]
+        USE_SDIST: [0]
+        REFGUIDE_CHECK: [0]
+        PIP_FLAGS: [""]
+        OPTIONS_NAME: ["default"]
+        include:
+          - platform_id: manylinux_x86_64
+            python-version: "3.10"
+            USE_SCIPY: 1
+            OPTIONS_NAME: "with-scipy"
+            PIP_FLAGS: "--pre -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple"
+    steps:
+      - name: Checkout PyWavelets
+        uses: actions/checkout@v4
+
+      # TODO: replace with setup-python when there is support
+      - uses: deadsnakes/action@6c8b9b82fe0b4344f4b98f2775fcc395df45e494 # v3.1.0
+        with:
+          python-version: '3.13-dev'
+          nogil: true
+
+      - name: Build package
+        env:
+          VERSION: ${{ matrix.python-version }}
+          MINIMUM_REQUIREMENTS: ${{ matrix.MINIMUM_REQUIREMENTS }}
+          PIP_FLAGS: ${{ matrix.PIP_FLAGS }}
+          USE_SDIST: ${{ matrix.USE_SDIST }}
+          USE_SCIPY: ${{ matrix.USE_SCIPY }}
+          REFGUIDE_CHECK: ${{ matrix.REFGUIDE_CHECK }}
+          OPTIONS_NAME: ${{ matrix.OPTIONS_NAME }}
+        run: |
+          uname -a
+          df -h
+          ulimit -a
+          # ccache -s
+          which python
+          python --version
+          # sudo apt-get install libatlas-base-dev
+          pip install --upgrade --pre pip build
+          # Set numpy version first, other packages link against it
+          pip install ${PIP_FLAGS} cython
+          pip install ${PIP_FLAGS} numpy
+          if [ "${USE_SCIPY}" == "1" ]; then pip install ${PIP_FLAGS} scipy; fi
+          pip install matplotlib pytest meson-python ninja
+          pip install . -v --no-build-isolation
+
+      - name: Run tests
+        env:
+          USE_SDIST: ${{ matrix.USE_SDIST }}
+          REFGUIDE_CHECK: ${{ matrix.REFGUIDE_CHECK }}
+          OPTIONS_NAME: ${{ matrix.OPTIONS_NAME }}
+          PYTHON_GIL: 0
+        run: |
+          set -o pipefail
+          # Move out of source directory to avoid finding local pywt
+          pushd demo
+          pytest --pyargs pywt
+          popd
+
   test_pywavelets_macos:
     name: macos-cp${{ matrix.python-version }}-${{ matrix.OPTIONS_NAME }}
     runs-on: macos-latest

--- a/pywt/_extensions/_swt.pyx
+++ b/pywt/_extensions/_swt.pyx
@@ -165,6 +165,7 @@ cpdef swt_axis(np.ndarray data, Wavelet wavelet, size_t level,
     cdef common.ArrayInfo data_info, output_info
     cdef np.ndarray cD, cA
     cdef size_t[::1] output_shape
+    cdef signed long[::1] strides_view
     cdef size_t end_level = start_level + level
     cdef int retval = -5
     cdef size_t i
@@ -201,8 +202,10 @@ cpdef swt_axis(np.ndarray data, Wavelet wavelet, size_t level,
         cA = np.empty(output_shape, dtype=data.dtype)
         cD = np.empty(output_shape, dtype=data.dtype)
         # strides won't match data_info.strides if data is not C-contiguous
-        output_info.strides = <pywt_index_t *> cA.strides
-        output_info.shape = <size_t *> cA.shape
+        strides_view = <signed long [:data.ndim]> <signed long *> cA.strides
+        strides_view = strides_view.copy()
+        output_info.strides = <pywt_index_t *> &strides_view[0]
+        output_info.shape = <size_t *> &output_shape[0]
         if data.dtype == np.float64:
             with nogil:
                 retval = c_wt.double_downcoef_axis(

--- a/pywt/_extensions/_swt.pyx
+++ b/pywt/_extensions/_swt.pyx
@@ -165,7 +165,7 @@ cpdef swt_axis(np.ndarray data, Wavelet wavelet, size_t level,
     cdef common.ArrayInfo data_info, output_info
     cdef np.ndarray cD, cA
     cdef size_t[::1] output_shape
-    cdef signed long[::1] strides_view
+    cdef np.npy_intp[::1] strides_view
     cdef size_t end_level = start_level + level
     cdef int retval = -5
     cdef size_t i
@@ -202,7 +202,7 @@ cpdef swt_axis(np.ndarray data, Wavelet wavelet, size_t level,
         cA = np.empty(output_shape, dtype=data.dtype)
         cD = np.empty(output_shape, dtype=data.dtype)
         # strides won't match data_info.strides if data is not C-contiguous
-        strides_view = <signed long [:data.ndim]> <signed long *> cA.strides
+        strides_view = <np.npy_intp [:data.ndim]> <np.npy_intp *> cA.strides
         strides_view = strides_view.copy()
         output_info.strides = <pywt_index_t *> &strides_view[0]
         output_info.shape = <size_t *> &output_shape[0]

--- a/pywt/_extensions/meson.build
+++ b/pywt/_extensions/meson.build
@@ -75,12 +75,12 @@ if have_c99_complex
   c_args += ['-DHAVE_C99_COMPLEX', '-DCYTHON_CCOMPLEX=1']
 endif
 
-libc_wt = static_library('c_wt',
-  sources,
-  c_args : c_args,
-  include_directories : 'c',
-  dependencies : py_dep,
-)
+cython_args = ['-3', '--fast-fail', '--output-file', '@OUTPUT@', '--include-dir', '@BUILD_ROOT@', '@INPUT@']
+
+cython_gen = generator(cython,
+  arguments : cython_args,
+  output : '@BASENAME@.c',
+  depends : _cython_tree)
 
 pyx_files = [
   ['_cwt', fs.copyfile('_cwt.pyx')],
@@ -92,12 +92,11 @@ pyx_files = [
 cy_deps = declare_dependency(sources: [__init__py, _cython_tree])#, config_pxi])
 foreach pyx_file: pyx_files
   py.extension_module(pyx_file[0],
-    pyx_file[1],
+    [cython_gen.process(pyx_file[1])] + sources,
     c_args : c_args,
     include_directories : 'c',
-    dependencies : [np_dep, cy_deps],
-    link_with : libc_wt,
+    dependencies : [np_dep, cy_deps, py_dep],
     install: true,
-    subdir: 'pywt/_extensions',
+    subdir: 'pywt/_extensions'
   )
 endforeach

--- a/pywt/_extensions/meson.build
+++ b/pywt/_extensions/meson.build
@@ -75,6 +75,13 @@ if have_c99_complex
   c_args += ['-DHAVE_C99_COMPLEX', '-DCYTHON_CCOMPLEX=1']
 endif
 
+libc_wt = static_library('c_wt',
+  sources,
+  c_args : c_args,
+  include_directories : 'c',
+  dependencies : py_dep,
+)
+
 cython_args = ['-3', '--fast-fail', '--output-file', '@OUTPUT@', '--include-dir', '@BUILD_ROOT@', '@INPUT@']
 
 cython_gen = generator(cython,
@@ -92,10 +99,11 @@ pyx_files = [
 cy_deps = declare_dependency(sources: [__init__py, _cython_tree])#, config_pxi])
 foreach pyx_file: pyx_files
   py.extension_module(pyx_file[0],
-    [cython_gen.process(pyx_file[1])] + sources,
+    [cython_gen.process(pyx_file[1])],
     c_args : c_args,
     include_directories : 'c',
     dependencies : [np_dep, cy_deps, py_dep],
+    link_with : libc_wt,
     install: true,
     subdir: 'pywt/_extensions'
   )

--- a/pywt/_extensions/meson.build
+++ b/pywt/_extensions/meson.build
@@ -87,7 +87,8 @@ cython_args = ['-3', '--fast-fail', '--output-file', '@OUTPUT@', '--include-dir'
 cython_gen = generator(cython,
   arguments : cython_args,
   output : '@BASENAME@.c',
-  depends : _cython_tree)
+  depends : _cython_tree
+)
 
 pyx_files = [
   ['_cwt', fs.copyfile('_cwt.pyx')],
@@ -102,9 +103,9 @@ foreach pyx_file: pyx_files
     [cython_gen.process(pyx_file[1])],
     c_args : c_args,
     include_directories : 'c',
-    dependencies : [np_dep, cy_deps, py_dep],
+    dependencies : [np_dep, cy_deps],
     link_with : libc_wt,
     install: true,
-    subdir: 'pywt/_extensions'
+    subdir: 'pywt/_extensions',
   )
 endforeach


### PR DESCRIPTION
This PR introduces a CI to run the test suite on Linux against the free-threaded distribution of Python 3.13. This effort follows the recently added testing and wheel distributions of [NumPy](https://github.com/numpy/numpy/pull/26512) and [SciPy](https://github.com/scipy/scipy/pull/20822).