### PR TITLE
BLD: mark extension modules as compatible to run without the GIL

### DIFF
--- a/pywt/_extensions/meson.build
+++ b/pywt/_extensions/meson.build
@@ -82,7 +82,11 @@ libc_wt = static_library('c_wt',
   dependencies : py_dep,
 )
 
+cy = meson.get_compiler('cython')
 cython_args = ['-3', '--fast-fail', '--output-file', '@OUTPUT@', '--include-dir', '@BUILD_ROOT@', '@INPUT@']
+if cy.version().version_compare('>=3.1.0')
+  cython_args += ['-Xfreethreading_compatible=True']
+endif
 
 cython_gen = generator(cython,
   arguments : cython_args,


### PR DESCRIPTION
This leaves the `PYTHON_GIL=0` in the CI config for now, because tests depend on scipy/matplotlib which haven't marked their extension modules as compatible.