### PR TITLE
DOC: improve figures in `demo/wp_scalogram.py`

### DIFF
--- a/demo/wp_scalogram.py
+++ b/demo/wp_scalogram.py
@@ -42,7 +42,7 @@ ax2.specgram(data, NFFT=64, noverlap=32, Fs=512, cmap=cmap,
              interpolation='bilinear')
 ax2.set_title("Spectrogram of signal")
 ax3 = fig2.add_subplot(212)
-ax3.imshow(values, origin='lower', extent=[0, 1, 1, values.shape[0]], 
+ax3.imshow(values, origin='lower', extent=[0, 1, values.shape[0], 1], 
            interpolation='nearest', aspect='auto')
 ax3.set_title("Wavelet packet coefficients")
 

--- a/demo/wp_scalogram.py
+++ b/demo/wp_scalogram.py
@@ -38,12 +38,12 @@ ax.set_yticks(np.arange(0.5, len(labels) + 0.5), labels)
 # Show spectrogram and wavelet packet coefficients
 fig2 = plt.figure()
 ax2 = fig2.add_subplot(211)
-ax2.specgram(data, NFFT=64, noverlap=32, Fs=2, cmap=cmap,
+ax2.specgram(data, NFFT=64, noverlap=32, Fs=512, cmap=cmap,
              interpolation='bilinear')
 ax2.set_title("Spectrogram of signal")
 ax3 = fig2.add_subplot(212)
-ax3.imshow(values, origin='upper', extent=[-1, 1, -1, 1],
-           interpolation='nearest')
+ax3.imshow(values, origin='lower', extent=[0, 1, 1, values.shape[0]], 
+           interpolation='nearest', aspect='auto')
 ax3.set_title("Wavelet packet coefficients")
 
 

--- a/demo/wp_scalogram.py
+++ b/demo/wp_scalogram.py
@@ -42,8 +42,9 @@ ax2.specgram(data, NFFT=64, noverlap=32, Fs=512, cmap=cmap,
              interpolation='bilinear')
 ax2.set_title("Spectrogram of signal")
 ax3 = fig2.add_subplot(212)
-ax3.imshow(values, origin='lower', extent=[0, 1, values.shape[0], 1], 
+ax3.imshow(values, origin='lower', extent=[0, 1, 0,  len(values)], 
            interpolation='nearest', aspect='auto')
+ax3.set_yticks(np.arange(0.5, len(labels) + 0.5), labels)
 ax3.set_title("Wavelet packet coefficients")
 
 


### PR DESCRIPTION
In the second plot, updated Fs to 512;
`ax2.specgram(data, NFFT=64, noverlap=32, Fs=512, cmap=cmap,
             interpolation='bilinear')`

again in the second plot, added aspect='auto', and did corrections to the time (x axis) and y axis (scale) with `extent=[0, 1, 1, values.shape[0]]`

ax3.imshow(values, origin='lower', extent=[0, 1, 1, values.shape[0]], 
           interpolation='nearest', aspect='auto')