### PR TITLE
highlighted deprecations with backward compatibility information

### DIFF
--- a/pywt/_extensions/_pywt.pyx
+++ b/pywt/_extensions/_pywt.pyx
@@ -705,17 +705,28 @@ cdef public class ContinuousWavelet [type ContinuousWaveletType, object Continuo
                     msg = (
                         "Wavelets of family {0}, without parameters "
                         "specified in the name are deprecated.  The name "
-                        "should take the form {0}M-B-C where M is the spline "
+                        "should follow the format {0}M-B-C where M is the spline "
                         "order and B, C are floats representing the bandwidth "
                         "frequency and center frequency, respectively "
-                        "(example: {0}1-1.5-1.0).").format(base_name)
+                        "(example, for backward compatibility: "
+                        "{0} = {0}2-1.0-0.5).").format(base_name)
+                elif base_name == 'shan':
+                    msg = (
+                        "Wavelets from the family {0}, without parameters "
+                        "specified in the name are deprecated. The name "
+                        "should follow the format {0}B-C, where B and C are floats"
+                        "representing the bandwidth frequency and center "
+                        "frequency, respectively (example, for backward "
+                        "compatibility: {0} = {0}0.5-1.0)."
+                        ).format(base_name)
                 else:
                     msg = (
                         "Wavelets from the family {0}, without parameters "
                         "specified in the name are deprecated. The name "
-                        "should takethe form {0}B-C where B and C are floats "
+                        "should follow the format {0}B-C, where B and C are floats"
                         "representing the bandwidth frequency and center "
-                        "frequency, respectively (example: {0}1.5-1.0)."
+                        "frequency, respectively (example, for backward "
+                        "compatibility: {0} = {0}1.0-0.5)."
                         ).format(base_name)
                 warnings.warn(msg, FutureWarning)
         else:


### PR DESCRIPTION
Hello,
Hello,

I wanted to suppress the deprecation warning when using the `cmor` continuous wavelet family in my code. Instead of removing the message entirely, I  highlight the initial parameters of the deprecated wavelet names for reference.

Below is the code snippet I’m working with:
```
import pywt
wavelets = ["fbsp", "cmor", "shan"]
for wavelet in wavelets:
    w = pywt.ContinuousWavelet(wavelet)
    print(wavelet)
    print("M = ", w.fbsp_order)
    print("B = ", w.bandwidth_frequency)
    print("C = ", w.center_frequency)
    print("")
```