### PR TITLE
CI: Build Linux AArch64 wheels natively, and add Arm runners for testing

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -33,7 +33,7 @@ jobs:
       # Ensure that a wheel builder finishes even if another fails
       fail-fast: false
       matrix:
-        runs-on: ["ubuntu-latest", "ubuntu-22.04-arm"]
+        runs-on: [ubuntu-latest, ubuntu-22.04-arm]
         python-version: ["3.10", "3.11", "3.12"]
         MINIMUM_REQUIREMENTS: [0]
         USE_SCIPY: [0]
@@ -42,19 +42,24 @@ jobs:
         PIP_FLAGS: [""]
         OPTIONS_NAME: ["default"]
         include:
-          - python-version: "3.10"
+          - runs-on: ubuntu-latest
+            python-version: "3.10"
             MINIMUM_REQUIREMENTS: 1
             OPTIONS_NAME: "minimum-req"
-          - python-version: "3.10"
+          - runs-on: ubuntu-latest
+            python-version: "3.10"
             USE_SCIPY: 1
             OPTIONS_NAME: "with-scipy"
-          - python-version: "3.10"
+          - runs-on: ubuntu-latest
+            python-version: "3.10"
             USE_SDIST: 1
             OPTIONS_NAME: "install-from-sdist"
-          - python-version: "3.12"
+          - runs-on: ubuntu-latest
+            python-version: "3.12"
             PIP_FLAGS: "--pre"
             OPTIONS_NAME: "pre-releases"
-          - python-version: "3.12"
+          - runs-on: ubuntu-latest
+            python-version: "3.12"
             OPTIONS_NAME: "editable-install"
     steps:
       - name: Checkout PyWavelets

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -34,7 +34,7 @@ jobs:
       fail-fast: false
       matrix:
         runs-on: [ubuntu-latest, ubuntu-22.04-arm]
-        python-version: ["3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
         MINIMUM_REQUIREMENTS: [0]
         USE_SCIPY: [0]
         USE_SDIST: [0]
@@ -55,11 +55,11 @@ jobs:
             USE_SDIST: 1
             OPTIONS_NAME: "install-from-sdist"
           - runs-on: ubuntu-latest
-            python-version: "3.12"
+            python-version: "3.13"
             PIP_FLAGS: "--pre"
             OPTIONS_NAME: "pre-releases"
           - runs-on: ubuntu-latest
-            python-version: "3.12"
+            python-version: "3.13"
             OPTIONS_NAME: "editable-install"
     steps:
       - name: Checkout PyWavelets

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -188,7 +188,7 @@ jobs:
       # Ensure that a wheel builder finishes even if another fails
       fail-fast: false
       matrix:
-        python-version: ["3.10", "3.12"]
+        python-version: ["3.10", "3.13"]
         MINIMUM_REQUIREMENTS: [0]
         USE_SCIPY: [0]
         USE_SDIST: [0]
@@ -199,7 +199,7 @@ jobs:
           - python-version: "3.10"
             MINIMUM_REQUIREMENTS: 1
             OPTIONS_NAME: "osx-minimum-req"
-          - python-version: "3.12"
+          - python-version: "3.13"
             PIP_FLAGS: "--pre"
             OPTIONS_NAME: "pre-releases"
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -33,8 +33,8 @@ jobs:
       # Ensure that a wheel builder finishes even if another fails
       fail-fast: false
       matrix:
-        runs-on: [ubuntu-latest, ubuntu-22.04-arm]
-        python-version: ["3.10", "3.11", "3.12", "3.13"]
+        runs-on: [ubuntu-latest] # Arm runner tested separately, see below
+        python-version: ["3.10", "3.13"]
         MINIMUM_REQUIREMENTS: [0]
         USE_SCIPY: [0]
         USE_SDIST: [0]
@@ -42,6 +42,10 @@ jobs:
         PIP_FLAGS: [""]
         OPTIONS_NAME: ["default"]
         include:
+          # Linux arm64
+          - runs-on: ubuntu-22.04-arm
+            python-version: "3.13"
+          # Linux amd64
           - runs-on: ubuntu-latest
             python-version: "3.10"
             MINIMUM_REQUIREMENTS: 1

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,12 +27,13 @@ env:
 
 jobs:
   test_pywavelets_linux:
-    name: linux-cp${{ matrix.python-version }}-${{ matrix.OPTIONS_NAME }}
-    runs-on: ubuntu-latest
+    name: ${{ matrix.runs-on }}-cp${{ matrix.python-version }}-${{ matrix.OPTIONS_NAME }}
+    runs-on: ${{ matrix.runs-on }}
     strategy:
       # Ensure that a wheel builder finishes even if another fails
       fail-fast: false
       matrix:
+        runs-on: ["ubuntu-latest", "ubuntu-22.04-arm"]
         python-version: ["3.10", "3.11", "3.12"]
         MINIMUM_REQUIREMENTS: [0]
         USE_SCIPY: [0]
@@ -41,24 +42,19 @@ jobs:
         PIP_FLAGS: [""]
         OPTIONS_NAME: ["default"]
         include:
-          - platform_id: manylinux_x86_64
-            python-version: "3.10"
+          - python-version: "3.10"
             MINIMUM_REQUIREMENTS: 1
             OPTIONS_NAME: "minimum-req"
-          - platform_id: manylinux_x86_64
-            python-version: "3.10"
+          - python-version: "3.10"
             USE_SCIPY: 1
             OPTIONS_NAME: "with-scipy"
-          - platform_id: manylinux_x86_64
-            python-version: "3.10"
+          - python-version: "3.10"
             USE_SDIST: 1
             OPTIONS_NAME: "install-from-sdist"
-          - platform_id: manylinux_x86_64
-            python-version: "3.12"
+          - python-version: "3.12"
             PIP_FLAGS: "--pre"
             OPTIONS_NAME: "pre-releases"
-          - platform_id: manylinux_x86_64
-            python-version: "3.12"
+          - python-version: "3.12"
             OPTIONS_NAME: "editable-install"
     steps:
       - name: Checkout PyWavelets

--- a/.github/workflows/wheel_tests_and_release.yml
+++ b/.github/workflows/wheel_tests_and_release.yml
@@ -78,7 +78,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest]
+        os: [ubuntu-22.04-arm]
         cibw_python: ["cp310", "cp311", "cp312", "cp313"]
         cibw_arch: ["aarch64"]
     steps:
@@ -89,10 +89,6 @@ jobs:
         name: Install Python
         with:
           python-version: "3.10"
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-        with:
-          platforms: arm64
 
       - name: Build the wheel
         uses: pypa/cibuildwheel@ee63bf16da6cddfb925f542f2c7b59ad50e93969 # v2.22.0


### PR DESCRIPTION
## Description

This PR switches the Linux arm64/aarch64 wheels to build natively on `ubuntu-22.04-arm` instead of using emulation.

(Hopefully?) fixes #787

## Additional context

- https://github.blog/changelog/2025-01-16-linux-arm64-hosted-runners-now-available-for-free-in-public-repositories-public-preview/