### PR TITLE
MAINT: bump minimum Python version to 3.10 and NumPy to 1.25

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,7 +21,7 @@ env:
   MPLBACKEND: Agg
   CYTHON_TRACE: 1
   CYTHONSPEC: cython
-  NUMPY_MIN: numpy==1.23.0
+  NUMPY_MIN: numpy==1.25.0
   CYTHON_MIN: cython==3.0.4
 
 jobs:
@@ -33,7 +33,7 @@ jobs:
       fail-fast: false
       matrix:
         runs-on: [ubuntu-latest] # Arm runner tested separately, see below
-        python-version: ["3.10", "3.13"]
+        python-version: ["3.11", "3.13"]
         MINIMUM_REQUIREMENTS: [0]
         USE_SDIST: [0]
         REFGUIDE_CHECK: [1]
@@ -45,13 +45,13 @@ jobs:
             python-version: "3.13"
           # Linux amd64
           - runs-on: ubuntu-latest
-            python-version: "3.10"
+            python-version: "3.11"
             MINIMUM_REQUIREMENTS: 1
             OPTIONS_NAME: "minimum-req"
           - runs-on: ubuntu-latest
-            python-version: "3.10"
+            python-version: "3.11"
           - runs-on: ubuntu-latest
-            python-version: "3.10"
+            python-version: "3.11"
             USE_SDIST: 1
             OPTIONS_NAME: "install-from-sdist"
           - runs-on: ubuntu-latest
@@ -181,14 +181,14 @@ jobs:
       # Ensure that a wheel builder finishes even if another fails
       fail-fast: false
       matrix:
-        python-version: ["3.10", "3.13"]
+        python-version: ["3.11", "3.13"]
         MINIMUM_REQUIREMENTS: [0]
         USE_SDIST: [0]
         REFGUIDE_CHECK: [0]
         PIP_FLAGS: [""]
         OPTIONS_NAME: ["default"]
         include:
-          - python-version: "3.10"
+          - python-version: "3.11"
             MINIMUM_REQUIREMENTS: 1
             OPTIONS_NAME: "osx-minimum-req"
           - python-version: "3.13"

--- a/.github/workflows/wheel_tests_and_release.yml
+++ b/.github/workflows/wheel_tests_and_release.yml
@@ -34,7 +34,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        cibw_python: ["cp310", "cp311", "cp312", "cp313", "cp313t"]
+        cibw_python: ["cp311", "cp312", "cp313", "cp313t"]
         cibw_arch: ["x86_64"]
     steps:
       - uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
@@ -43,7 +43,7 @@ jobs:
       - uses: actions/setup-python@v5
         name: Install Python
         with:
-          python-version: "3.10"
+          python-version: "3.12"
 
       - name: Install build deps; set CIBW environment variables
         if: ${{ matrix.cibw_python }} == "cp313t"
@@ -79,7 +79,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-22.04-arm]
-        cibw_python: ["cp310", "cp311", "cp312", "cp313"]
+        cibw_python: ["cp311", "cp312", "cp313"]
         cibw_arch: ["aarch64"]
     steps:
       - uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
@@ -88,7 +88,7 @@ jobs:
       - uses: actions/setup-python@v5
         name: Install Python
         with:
-          python-version: "3.10"
+          python-version: "3.12"
 
       - name: Build the wheel
         uses: pypa/cibuildwheel@ee63bf16da6cddfb925f542f2c7b59ad50e93969 # v2.22.0
@@ -112,7 +112,7 @@ jobs:
       matrix:
         # macos-13 is the last runner that supports Intel (x86_64) architecture
         os: [macos-13, macos-14]
-        cibw_python: ["cp310", "cp311", "cp312", "cp313", "cp313t"]
+        cibw_python: ["cp311", "cp312", "cp313", "cp313t"]
         cibw_arch: ["x86_64", "arm64"]
         exclude:
           - os: macos-14
@@ -176,7 +176,7 @@ jobs:
       matrix:
         os: [windows-latest]
         cibw_arch: ["AMD64", "x86"]
-        cibw_python: ["cp310", "cp311", "cp312", "cp313", "cp313t"]
+        cibw_python: ["cp311", "cp312", "cp313", "cp313t"]
     steps:
       - uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
         with:
@@ -185,7 +185,7 @@ jobs:
       - uses: actions/setup-python@v5
         name: Install Python
         with:
-          python-version: "3.10"
+          python-version: "3.12"
 
       - name: Setup MSVC (32-bit)
         if: matrix.cibw_arch == 'x86'
@@ -246,7 +246,7 @@ jobs:
       - uses: actions/setup-python@v5
         name: Install Python
         with:
-          python-version: "3.10"
+          python-version: "3.12"
 
       - name: Install Twine
         run: |

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,11 +7,11 @@ build: off
 environment:
   matrix:
     - arch: x64
-      PY_PYTHON: 3.10
+      PY_PYTHON: 3.11
     - arch: x86
-      PY_PYTHON: 3.10-32
+      PY_PYTHON: 3.11-32
     - arch: x64
-      PY_PYTHON: 3.12
+      PY_PYTHON: 3.13
 
 # From https://mesonbuild.com/Continuous-Integration.html#appveyor-for-windows
 install:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,8 +30,8 @@ maintainers = [
     {name = "The PyWavelets Developers", email = "pywavelets@googlegroups.com"}
 ]
 description = "PyWavelets, wavelet transform module"
-requires-python = ">=3.10"
-dependencies = ["numpy>=1.23,<3"]
+requires-python = ">=3.11"
+dependencies = ["numpy>=1.25,<3"]
 readme = "README.rst"
 classifiers = [
     "Development Status :: 5 - Production/Stable",
@@ -43,7 +43,6 @@ classifiers = [
     "Programming Language :: C",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",


### PR DESCRIPTION
Follows NumPy, SciPy and SPEC 0.

Done now because wheel build CI for Python 3.10 started failing after NumPy pre-releases got removed from the nightly bucket.