### PR TITLE
Improve flexibility of the precision parameter in the CWT implementation.

### DIFF
--- a/pywt/_cwt.py
+++ b/pywt/_cwt.py
@@ -24,7 +24,7 @@ def next_fast_len(n):
     return 2**ceil(np.log2(n))
 
 
-def cwt(data, scales, wavelet, sampling_period=1., method='conv', axis=-1):
+def cwt(data, scales, wavelet, sampling_period=1., method='conv', axis=-1, precision=24):
     """
     cwt(data, scales, wavelet)
 
@@ -60,7 +60,9 @@ def cwt(data, scales, wavelet, sampling_period=1., method='conv', axis=-1):
     axis: int, optional
         Axis over which to compute the CWT. If not given, the last axis is
         used.
-
+    precision : int, optional
+        Parameter used to control the wavelet precision (useful towards lower frequency regions)
+        
     Returns
     -------
     coefs : array_like
@@ -115,7 +117,7 @@ def cwt(data, scales, wavelet, sampling_period=1., method='conv', axis=-1):
 
     dt_out = dt_cplx if wavelet.complex_cwt else dt
     out = np.empty((np.size(scales),) + data.shape, dtype=dt_out)
-    precision = 10
+
     int_psi, x = integrate_wavelet(wavelet, precision=precision)
     int_psi = np.conj(int_psi) if wavelet.complex_cwt else int_psi
 

--- a/pywt/_cwt.py
+++ b/pywt/_cwt.py
@@ -62,7 +62,8 @@ def cwt(data, scales, wavelet, sampling_period=1., method='conv', axis=-1, preci
         used.
     precision : int, optional
         Parameter used to control the wavelet precision (useful towards lower frequency regions)
-        
+
+
     Returns
     -------
     coefs : array_like

--- a/pywt/_cwt.py
+++ b/pywt/_cwt.py
@@ -24,7 +24,7 @@ def next_fast_len(n):
     return 2**ceil(np.log2(n))
 
 
-def cwt(data, scales, wavelet, sampling_period=1., method='conv', axis=-1, precision=24):
+def cwt(data, scales, wavelet, sampling_period=1., method='conv', axis=-1, precision=10):
     """
     cwt(data, scales, wavelet)
 


### PR DESCRIPTION
Hello @rgommers ,

I had many issues in controlling the precision of the wavelet (`def wavefun()`). This issue has been mentioned several times already, but never committed. I think this is a rather important fix allowing for more flexibility in playing with CWT. 

So please find the minimal modification necessary allowing for better precision and removing artifacts in the low-frequency region (high scale values).

Please consider if possible, this is important parameter to adjust. In the current master, the value is hardcoded in `_cwt.py` to `precision=10`, this is not so good.