### PR TITLE
MAINT: require scipy_doctest>=1.8.0

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -253,8 +253,8 @@ jobs:
               python ../pywt/tests/test_doc.py
           elif [ "${REFGUIDE_CHECK}" == "1" ]; then
               # doctests docstrings
-              pytest --doctest-modules --pyargs pywt -v  --doctest-collect=api
-              pytest --doctest-modules --pyargs pywt.data -v
+              pytest --doctest-modules --doctest-only-doctests=true --pyargs pywt -v  --doctest-collect=api
+              pytest --doctest-modules --doctest-only-doctests=true --pyargs pywt.data -v
           else
               pytest --pyargs pywt
           fi


### PR DESCRIPTION
See https://discuss.scientific-python.org/t/scipy-doctest-select-only-doctests-or-both-doctests-and-unit-tests/1950 for the rationale and the plan.

TL;DR: this is the only change needed to be forward-compatible with scipy_doctest>=1.8.0

Cross-ref a similar change in scipy: https://github.com/scipy/scipy/pull/23078