### PR TITLE
DOC: fix typo in a wavelet name

### DIFF
--- a/doc/source/ref/cwt.rst
+++ b/doc/source/ref/cwt.rst
@@ -167,7 +167,7 @@ where :math:`B` is the bandwidth and :math:`C` is the center frequency.
 
 Frequency B-Spline Wavelets
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-The frequency B-spline wavelets (``"fpspM-B-C"`` with integer M and floating
+The frequency B-spline wavelets (``"fbspM-B-C"`` with integer M and floating
 point B, C) correspond to the following wavelets:
 
 .. math::


### PR DESCRIPTION
Closes gh-799

[skip ci]