### PR TITLE
MAINT: drop Python 3.11, NumPy 1.25 and Cython 3.0.x support

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.11"]
+        python-version: ["3.13"]
 
     steps:
       - uses: actions/checkout@v5

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,8 +21,8 @@ env:
   MPLBACKEND: Agg
   CYTHON_TRACE: 1
   CYTHONSPEC: cython
-  NUMPY_MIN: numpy==1.25.0
-  CYTHON_MIN: cython==3.0.4
+  NUMPY_MIN: numpy==1.26.4
+  CYTHON_MIN: cython==3.1.3
 
 jobs:
   test_pywavelets_linux:
@@ -33,7 +33,7 @@ jobs:
       fail-fast: false
       matrix:
         runs-on: [ubuntu-latest] # Arm runner tested separately, see below
-        python-version: ["3.11", "3.13"]
+        python-version: ["3.12", "3.14"]
         MINIMUM_REQUIREMENTS: [0]
         USE_SDIST: [0]
         REFGUIDE_CHECK: [1]
@@ -42,24 +42,24 @@ jobs:
         include:
           # Linux arm64
           - runs-on: ubuntu-22.04-arm
-            python-version: "3.13"
+            python-version: "3.14"
           # Linux amd64
           - runs-on: ubuntu-latest
-            python-version: "3.11"
+            python-version: "3.12"
             MINIMUM_REQUIREMENTS: 1
             OPTIONS_NAME: "minimum-req"
           - runs-on: ubuntu-latest
-            python-version: "3.11"
+            python-version: "3.12"
           - runs-on: ubuntu-latest
-            python-version: "3.14-dev"
+            python-version: "3.14"
             USE_SDIST: 1
             OPTIONS_NAME: "install-from-sdist"
           - runs-on: ubuntu-latest
-            python-version: "3.13"
+            python-version: "3.14"
             PIP_FLAGS: "--pre"
             OPTIONS_NAME: "pre-releases"
           - runs-on: ubuntu-latest
-            python-version: "3.13"
+            python-version: "3.14"
             OPTIONS_NAME: "editable-install"
     steps:
       - uses: actions/checkout@ff7abcd0c3c05ccf6adc123a8cd1fd4fb30fb493 # v4.1.2
@@ -142,7 +142,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.13t", "3.14t-dev"]
+        python-version: ["3.13t", "3.14t"]
     steps:
       - uses: actions/checkout@ff7abcd0c3c05ccf6adc123a8cd1fd4fb30fb493 # v4.1.2
       - uses: actions/setup-python@2e3e4b15a884dc73a63f962bff250a855150a234 # v5.5.0
@@ -168,17 +168,17 @@ jobs:
       # Ensure that a wheel builder finishes even if another fails
       fail-fast: false
       matrix:
-        python-version: ["3.11", "3.13"]
+        python-version: ["3.12", "3.14"]
         MINIMUM_REQUIREMENTS: [0]
         USE_SDIST: [0]
         REFGUIDE_CHECK: [0]
         PIP_FLAGS: [""]
         OPTIONS_NAME: ["default"]
         include:
-          - python-version: "3.11"
+          - python-version: "3.12"
             MINIMUM_REQUIREMENTS: 1
             OPTIONS_NAME: "osx-minimum-req"
-          - python-version: "3.13"
+          - python-version: "3.14"
             PIP_FLAGS: "--pre"
             OPTIONS_NAME: "pre-releases"
 

--- a/.github/workflows/wheel_tests_and_release.yml
+++ b/.github/workflows/wheel_tests_and_release.yml
@@ -34,7 +34,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        cibw_python: ["cp311", "cp312", "cp313", "cp313t", "cp314", "cp314t"]
+        cibw_python: ["cp312", "cp313", "cp313t", "cp314", "cp314t"]
         cibw_arch: ["x86_64"]
     steps:
       - uses: actions/checkout@ff7abcd0c3c05ccf6adc123a8cd1fd4fb30fb493 # v4.1.2
@@ -66,7 +66,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-22.04-arm]
-        cibw_python: ["cp311", "cp312", "cp313", "cp313t", "cp314", "cp314t"]
+        cibw_python: ["cp312", "cp313", "cp313t", "cp314", "cp314t"]
         cibw_arch: ["aarch64"]
     steps:
       - uses: actions/checkout@ff7abcd0c3c05ccf6adc123a8cd1fd4fb30fb493 # v4.1.2
@@ -98,7 +98,7 @@ jobs:
       matrix:
         # macos-13 is the last runner that supports Intel (x86_64) architecture
         os: [macos-13, macos-14]
-        cibw_python: ["cp311", "cp312", "cp313", "cp313t", "cp314", "cp314t"]
+        cibw_python: ["cp312", "cp313", "cp313t", "cp314", "cp314t"]
         cibw_arch: ["x86_64", "arm64"]
         exclude:
           - os: macos-14
@@ -149,7 +149,7 @@ jobs:
       matrix:
         os: [windows-latest, windows-11-arm]
         cibw_arch: ["AMD64", "x86", "ARM64"]
-        cibw_python: ["cp311", "cp312", "cp313", "cp313t", "cp314", "cp314t"]
+        cibw_python: ["cp312", "cp313", "cp313t", "cp314", "cp314t"]
         exclude:
           - os: windows-latest
             cibw_arch: ARM64

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -2,7 +2,7 @@ version: 2
 build:
   os: "ubuntu-22.04"
   tools:
-    python: "3.11"
+    python: "3.13"
 
 python:
   install:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,9 +7,7 @@ build: off
 environment:
   matrix:
     - arch: x64
-      PY_PYTHON: 3.11
-    - arch: x86
-      PY_PYTHON: 3.11-32
+      PY_PYTHON: 3.12
     - arch: x64
       PY_PYTHON: 3.13
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@
 build-backend = "mesonpy"
 requires = [
     "meson-python>=0.18.0",
-    "Cython>=3.0.4",
+    "Cython>=3.1.3",
 
     # numpy requirement for wheel builds for distribution on PyPI - building
     # against 2.x yields wheels that are also compatible with numpy 1.x at
@@ -16,9 +16,7 @@ requires = [
     # Note that building against numpy 1.x works fine too - users and
     # redistributors can do this by installing the numpy version they like and
     # disabling build isolation.
-    "numpy>=2.0.0; python_version<'3.13'",
-    "numpy>=2.1.0; python_version>='3.13'",
-    "numpy>=2.3.2; python_version>='3.14'",
+    "numpy>=2.0.0",
 ]
 
 [project]
@@ -33,8 +31,8 @@ maintainers = [
     {name = "The PyWavelets Developers", email = "pywavelets@googlegroups.com"}
 ]
 description = "PyWavelets, wavelet transform module"
-requires-python = ">=3.11"
-dependencies = ["numpy>=1.25,<3"]
+requires-python = ">=3.12"
+dependencies = ["numpy>=1.26.4,<3"]
 readme = "README.rst"
 classifiers = [
     "Development Status :: 5 - Production/Stable",
@@ -45,10 +43,10 @@ classifiers = [
     "Programming Language :: C",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: 3.14",
+    "Programming Language :: Python :: Free Threading :: 2 - Beta",
     "Topic :: Software Development :: Libraries :: Python Modules"
 ]
 


### PR DESCRIPTION
We need to keep NumPy 1.26.4 for quite a while, but that's the only 1.x version that needs supporting for users that need more time moving to 2.x

Cython 3.0 is dropped because we want to try moving to the Stable ABI, and that only has support in 3.1

Python 3.11 is dropped as per the regular schedule (NEP 29 / SPEC 0). EDIT: and also because we don't want to use the Stable ABI for 3.11, given the lack of vectorcall support in Cython for 3.11. Safer performance/regression-wise to drop 3.11 first.