### PR TITLE
MAINT: move away from numpy.fix in favor of numpy.trunc

### DIFF
--- a/demo/image_blender.py
+++ b/demo/image_blender.py
@@ -65,7 +65,7 @@ def array2image(arr, mode):
     arr = arr.swapaxes(1, 2).swapaxes(0, 2)
     arr[arr < 0] = 0
     arr[arr > 255] = 255
-    arr = numpy.fix(arr).astype(numpy.uint8)
+    arr = numpy.trunc(arr).astype(numpy.uint8)
     return Image.frombytes(mode, arr.shape[1::-1], arr.tobytes())
 
 

--- a/pywt/data/_wavelab_signals.py
+++ b/pywt/data/_wavelab_signals.py
@@ -200,12 +200,12 @@ def demo_signal(name='Bumps', n=None):
         f = f[512:1536]
     elif name == 'piece-regular':
         f = np.zeros(n)
-        n_12 = int(np.fix(n / 12))
-        n_7 = int(np.fix(n / 7))
-        n_5 = int(np.fix(n / 5))
-        n_3 = int(np.fix(n / 3))
-        n_2 = int(np.fix(n / 2))
-        n_20 = int(np.fix(n / 20))
+        n_12 = int(np.trunc(n / 12))
+        n_7 = int(np.trunc(n / 7))
+        n_5 = int(np.trunc(n / 5))
+        n_3 = int(np.trunc(n / 3))
+        n_2 = int(np.trunc(n / 2))
+        n_20 = int(np.trunc(n / 20))
         f1 = -15 * demo_signal('bumps', n)
         t = np.arange(1, n_12 + 1) / n_12
         f2 = -np.exp(4 * t)
@@ -231,9 +231,9 @@ def demo_signal(name='Bumps', n=None):
         f = bias - f
     elif name == 'piece-polynomial':
         f = np.zeros(n)
-        n_5 = int(np.fix(n / 5))
-        n_10 = int(np.fix(n / 10))
-        n_20 = int(np.fix(n / 20))
+        n_5 = int(np.trunc(n / 5))
+        n_10 = int(np.trunc(n / 10))
+        n_20 = int(np.trunc(n / 20))
         t = np.arange(1, n_5 + 1) / n_5
         f1 = 20 * (t**3 + t**2 + 4)
         f3 = 40 * (2 * t**3 + t) + 100


### PR DESCRIPTION
This PR replaces all occurrences of `numpy.fix` with `numpy.trunc`. This is in response to [a currently discussed deprecation of `numpy.fix`](https://mail.python.org/archives/list/numpy-discussion@python.org/thread/LYRHETXPN32S7FNHKNLJFDIYWGQHLODJ/) as well as performance considerations (nice, but secondary).

This change should not change anything in a meaningful way, internally or externally.

Cheers