### PR TITLE
TST: remove usages of deprecated `numpy.testing.assert_warns`

### DIFF
--- a/pywt/tests/test_cwt_wavelets.py
+++ b/pywt/tests/test_cwt_wavelets.py
@@ -10,7 +10,6 @@ from numpy.testing import (
     assert_almost_equal,
     assert_equal,
     assert_raises,
-    assert_warns,
 )
 
 import pywt
@@ -341,7 +340,8 @@ def test_cwt_parameters_in_names():
     for func in [pywt.ContinuousWavelet, pywt.DiscreteContinuousWavelet]:
         for name in ['fbsp', 'cmor', 'shan']:
             # additional parameters should be specified within the name
-            assert_warns(FutureWarning, func, name)
+            with pytest.warns(FutureWarning):
+                func(name)
 
         for name in ['cmor', 'shan']:
             # valid names

--- a/pywt/tests/test_deprecations.py
+++ b/pywt/tests/test_deprecations.py
@@ -1,34 +1,40 @@
 import warnings
 
 import numpy as np
-from numpy.testing import assert_array_equal, assert_warns
+import pytest
+from numpy.testing import assert_array_equal
 
 import pywt
 
 
 def test_intwave_deprecation():
     wavelet = pywt.Wavelet('db3')
-    assert_warns(DeprecationWarning, pywt.intwave, wavelet)
+    with pytest.warns(DeprecationWarning):
+        pywt.intwave(wavelet)
 
 
 def test_centrfrq_deprecation():
     wavelet = pywt.Wavelet('db3')
-    assert_warns(DeprecationWarning, pywt.centrfrq, wavelet)
+    with pytest.warns(DeprecationWarning):
+        pywt.centrfrq(wavelet)
 
 
 def test_scal2frq_deprecation():
     wavelet = pywt.Wavelet('db3')
-    assert_warns(DeprecationWarning, pywt.scal2frq, wavelet, 1)
+    with pytest.warns(DeprecationWarning):
+        pywt.scal2frq(wavelet, 1)
 
 
 def test_orthfilt_deprecation():
-    assert_warns(DeprecationWarning, pywt.orthfilt, range(6))
+    with pytest.warns(DeprecationWarning):
+        pywt.orthfilt(range(6))
 
 
 def test_integrate_wave_tuple():
     sig = [0, 1, 2, 3]
     xgrid = [0, 1, 2, 3]
-    assert_warns(DeprecationWarning, pywt.integrate_wavelet, (sig, xgrid))
+    with pytest.warns(DeprecationWarning):
+        pywt.integrate_wavelet((sig, xgrid))
 
 
 old_modes = ['zpd',
@@ -42,7 +48,8 @@ old_modes = ['zpd',
 
 def test_MODES_from_object_deprecation():
     for mode in old_modes:
-        assert_warns(DeprecationWarning, pywt.Modes.from_object, mode)
+        with pytest.warns(DeprecationWarning):
+            pywt.Modes.from_object(mode)
 
 
 def test_MODES_attributes_deprecation():
@@ -50,7 +57,8 @@ def test_MODES_attributes_deprecation():
         return getattr(Modes, name)
 
     for mode in old_modes:
-        assert_warns(DeprecationWarning, get_mode, pywt.Modes, mode)
+        with pytest.warns(DeprecationWarning):
+            get_mode(pywt.Modes, mode)
 
 
 def test_mode_equivalence():

--- a/pywt/tests/test_multilevel.py
+++ b/pywt/tests/test_multilevel.py
@@ -14,7 +14,6 @@ from numpy.testing import (
     assert_equal,
     assert_raises,
     assert_raises_regex,
-    assert_warns,
 )
 
 import pywt
@@ -899,8 +898,9 @@ def test_fswavedecn_fswaverecn_variable_levels():
     assert_raises(ValueError, pywt.fswavedecn, data, 'haar', levels=(1, 1, 1, 1))
 
     # levels too large for array size
-    assert_warns(UserWarning, pywt.fswavedecn, data, 'haar',
-                 levels=int(np.log2(np.min(data.shape)))+1)
+    with pytest.warns(UserWarning):
+        pywt.fswavedecn(data, 'haar',
+                        levels=int(np.log2(np.min(data.shape)))+1)
 
 
 def test_fswavedecn_fswaverecn_variable_wavelets_and_modes():
@@ -967,8 +967,8 @@ def test_fswavedecnresult():
                   k, np.zeros(tuple([s + 1 for s in d.shape])))
 
     # warns on assigning with a non-matching dtype
-    assert_warns(UserWarning, result.__setitem__,
-                 k, np.zeros_like(d).astype(np.float32))
+    with pytest.warns(UserWarning):
+        result.__setitem__(k, np.zeros_like(d).astype(np.float32))
 
     # all coefficients are stacked into result.coeffs (same ndim)
     assert_equal(result.coeffs.ndim, data.ndim)


### PR DESCRIPTION
Deprecated in numpy 2.4.0.

Also try `pytest.raises` instead of `assert_raises` in one file; both should work, the pytest builtin functionality will be preferred for new code.