### PR TITLE
BLD: fix wheel builds on Windows

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,6 +55,12 @@ homepage = "https://github.com/PyWavelets/pywt"
 source = "https://github.com/PyWavelets/pywt"
 documentation = "https://pywavelets.readthedocs.io/"
 
+
+[tool.cibuildwheel.windows]
+config-settings = {setup-args = ["--vsenv"]}
+before-build = "bash {project}/util/cibw_before_build_win.sh"
+
+
 [tool.ruff]
 line-length = 88
 target-version = 'py310'

--- a/util/cibw_before_build_win.sh
+++ b/util/cibw_before_build_win.sh
@@ -1,0 +1,4 @@
+set -xe
+
+# Avoid this in GHA: "ERROR: Found GNU link.exe instead of MSVC link.exe"
+rm /c/Program\ Files/Git/usr/bin/link.EXE


### PR DESCRIPTION
Ensure we're using MSVC; avoids finding a broken link.exe which again got added to a GHA runner image. Error message was:

```
   ..\meson.build:1:0: ERROR: Found GNU link.exe instead of MSVC link.exe in C:\Program Files\Git\usr\bin\link.EXE.
  This link.exe is not a linker.
  You may need to reorder entries to your %PATH% variable to resolve this.
```