### PR TITLE
BUG: raise a clear error when cwt() is given a discrete wavelet (gh-776)

### DIFF
--- a/pywt/_cwt.py
+++ b/pywt/_cwt.py
@@ -111,6 +111,12 @@ def cwt(data, scales, wavelet, sampling_period=1., method='conv', axis=-1,
     dt_cplx = np.result_type(dt, np.complex64)
     if not isinstance(wavelet, (ContinuousWavelet, Wavelet)):
         wavelet = DiscreteContinuousWavelet(wavelet)
+    if not isinstance(wavelet, ContinuousWavelet):
+        raise ValueError(
+            f"cwt() requires a continuous wavelet, but {wavelet.name!r} is a "
+            f"discrete wavelet. Use a continuous wavelet such as those returned "
+            f"by pywt.wavelist(kind='continuous') (e.g. 'morl', 'mexh', 'cmor')."
+        )
 
     scales = np.atleast_1d(scales)
     if np.any(scales <= 0):

--- a/pywt/tests/test_cwt_wavelets.py
+++ b/pywt/tests/test_cwt_wavelets.py
@@ -480,3 +480,16 @@ def test_continuous_wavelet_pickle(tmpdir):
         wavelet2 = pickle.load(f)
     assert isinstance(wavelet2, pywt.ContinuousWavelet)
     assert wavelet2.name == wavelet.name
+
+
+def test_cwt_discrete_wavelet_raises():
+    # A discrete wavelet such as 'coif1' has no continuous form; cwt should
+    # raise a clear error rather than an opaque AttributeError (gh-776).
+    data = np.ones(100)
+    for bad in ['coif1', 'db2', pywt.Wavelet('coif1')]:
+        with pytest.raises(ValueError, match='continuous wavelet'):
+            pywt.cwt(data, [1, 2], bad)
+
+    # a continuous wavelet still works
+    out, _ = pywt.cwt(data, [1, 2], 'morl')
+    assert out.shape == (2, 100)


### PR DESCRIPTION
Fixes #776.

`cwt(data, scales, 'coif1')` (or any other discrete wavelet) crashed with:

```
AttributeError: 'pywt._extensions._pywt.Wavelet' object has no attribute 'complex_cwt'
```

The name is resolved with `DiscreteContinuousWavelet`, which happily returns
a discrete `Wavelet` for a name like `'coif1'`. `cwt` then unconditionally
reads `wavelet.complex_cwt`, an attribute that only exists on
`ContinuousWavelet`, so the call dies with the confusing error above instead
of telling the user they passed the wrong kind of wavelet.

As @rgommers noted on the issue, passing the wrong wavelet name should give a
clear message rather than a confusing one. This validates that the resolved
wavelet is continuous and otherwise raises a `ValueError` that names the
offending wavelet and points to `pywt.wavelist(kind='continuous')`:

```
ValueError: cwt() requires a continuous wavelet, but 'coif1' is a discrete
wavelet. Use a continuous wavelet such as those returned by
pywt.wavelist(kind='continuous') (e.g. 'morl', 'mexh', 'cmor').
```

A regression test covering a name, a discrete `Wavelet` instance, and a
still-working continuous wavelet is included.
