### PR TITLE
BUG: fix pywt.pad for a zero pad width in 'smooth' and 'antisymmetric' (gh-589)

### DIFF
--- a/pywt/_dwt.py
+++ b/pywt/_dwt.py
@@ -442,7 +442,7 @@ def pad(x, pad_widths, mode):
     pad_widths = np.array(pad_widths)
     pad_widths = np.round(pad_widths).astype(np.intp, copy=False)
     if pad_widths.min() < 0:
-        raise ValueError("pad_widths must be > 0")
+        raise ValueError("pad_widths must be >= 0")
     pad_widths = np.broadcast_to(pad_widths, (x.ndim, 2)).tolist()
 
     if mode in ['symmetric', 'reflect']:
@@ -468,9 +468,12 @@ def pad(x, pad_widths, mode):
                 left + np.arange(pad_width[0], 0, -1) * slope_left
 
             # smooth extension to right
-            right = vector[-pad_width[1] - 1]
-            slope_right = (right - vector[-pad_width[1] - 2])
-            vector[-pad_width[1]:] = \
+            # Note: indices are measured from the start of the vector so that
+            # a pad width of 0 gives an empty slice rather than the full one.
+            iright = vector.size - pad_width[1] - 1
+            right = vector[iright]
+            slope_right = (right - vector[iright - 1])
+            vector[iright + 1:] = \
                 right + np.arange(1, pad_width[1] + 1) * slope_right
             return vector
         xp = np.pad(x, pad_widths, pad_smooth)
@@ -481,7 +484,7 @@ def pad(x, pad_widths, mode):
             npad_l, npad_r = pad_width
             vsize_nonpad = vector.size - npad_l - npad_r
             # Note: must modify vector in-place
-            vector[:] = np.pad(vector[pad_width[0]:-pad_width[-1]],
+            vector[:] = np.pad(vector[npad_l:vector.size - npad_r],
                                pad_width, mode='symmetric')
             vp = vector
             r_edge = npad_l + vsize_nonpad - 1

--- a/pywt/tests/test_dwt_idwt.py
+++ b/pywt/tests/test_dwt_idwt.py
@@ -279,6 +279,37 @@ def test_pad_1d():
                        pywt.pad(x, (4, 4), 'periodic'))
 
 
+def test_pad_zero_width():
+    # zero pad width is a no-op for all modes except 'periodization', which
+    # also promotes odd-length axes to even length (gh-589)
+    for ndim in [1, 2, 3]:
+        x = np.arange(3.0**ndim).reshape((3, ) * ndim)
+        for mode in pywt.Modes.modes:
+            if mode == 'periodization':
+                continue
+            assert_array_equal(pywt.pad(x, 0, mode), x,
+                               err_msg=f"mode={mode}, ndim={ndim}")
+
+
+def test_pad_one_sided():
+    # a zero pad width on only one side of the axis (gh-589)
+    x = [1, 2, 3]
+    assert_array_equal(pywt.pad(x, (2, 0), 'smooth'), [-1, 0, 1, 2, 3])
+    assert_array_equal(pywt.pad(x, (0, 2), 'smooth'), [1, 2, 3, 4, 5])
+    assert_array_equal(pywt.pad(x, (2, 0), 'antisymmetric'), [-2, -1, 1, 2, 3])
+    assert_array_equal(pywt.pad(x, (0, 2), 'antisymmetric'), [1, 2, 3, -3, -2])
+
+    # one-sided padding matches the corresponding slice of two-sided padding
+    for mode in pywt.Modes.modes:
+        if mode == 'periodization':
+            continue
+        two_sided = pywt.pad(x, (4, 6), mode)
+        assert_array_equal(pywt.pad(x, (4, 0), mode), two_sided[:-6],
+                           err_msg=f"mode={mode}")
+        assert_array_equal(pywt.pad(x, (0, 6), mode), two_sided[4:],
+                           err_msg=f"mode={mode}")
+
+
 def test_pad_errors():
     # negative pad width
     x = [1, 2, 3]


### PR DESCRIPTION
Fixes #589.

A pad width of 0 should leave the array unchanged, but raises in the `'smooth'`
and `'antisymmetric'` extension modes:

```python
>>> import numpy as np, pywt
>>> x = np.array([1., 2., 3.])
>>> pywt.pad(x, 0, 'smooth')
ValueError: could not broadcast input array from shape (0,) into shape (3,)
>>> pywt.pad(x, (1, 0), 'smooth')
ValueError: could not broadcast input array from shape (0,) into shape (4,)
>>> pywt.pad(x, 0, 'antisymmetric')
ValueError: could not broadcast input array from shape (0,) into shape (3,)
>>> pywt.pad(x, (2, 0), 'antisymmetric')
ValueError: can't extend empty axis 0 using modes other than 'constant' or 'empty'
```

Six of the nine extension modes return the array untouched for a zero pad
width. `'periodization'` is the other exception, and a benign one:
`pywt.pad(x, 0, 'periodization')` gives `[1., 2., 3., 3.]`, since it promotes
an odd-length axis to even length.

Both failing modes are implemented as `numpy.pad` callbacks, and both index the
vector from the end using the trailing pad width: `vector[-pad_width[1]:]` in
`pad_smooth` and `vector[pad_width[0]:-pad_width[-1]]` in `pad_antisymmetric`.
With a trailing width of 0 the first selects the whole vector instead of an
empty slice and the second selects an empty one, hence the two messages above.
The leading width is unaffected because `vector[:0]` is already empty.

The fix measures both indices from the start of the vector. `pad_smooth` also
read its right-hand slope with a second negative index (`-pad_width[1] - 2`),
now expressed relative to the same start-based index. Results are unchanged for
everything that worked before: comparing old against new over 1-D inputs of
length 1 to 5 and both pad widths from 0 to 4, in both modes, the only cases
that differ are ones that raised: a trailing width of 0, plus a length-1 axis
with `(0, k)` in `'smooth'`, which raised `IndexError`.

The message of the pad-width check is also corrected; it read
`pad_widths must be > 0` while the check is `< 0` and 0 is legal. Happy to drop
that line if you would rather keep the diff to the two callbacks.

Two regression tests are added to `pywt/tests/test_dwt_idwt.py`:
`test_pad_zero_width` asserts the no-op property in 1, 2 and 3 dimensions for
every mode except `'periodization'`, and `test_pad_one_sided` checks fixed
expected values plus the property that one-sided padding equals the
corresponding slice of two-sided padding, again for every mode except
`'periodization'`. Both tests fail on main and pass with this change.
