### PR TITLE
MAINT: fix pytest deprecation warning

### DIFF
--- a/pywt/tests/test_cwt_wavelets.py
+++ b/pywt/tests/test_cwt_wavelets.py
@@ -396,7 +396,7 @@ def test_cwt_complex(dtype, tol, method):
     assert_equal(cfs_complex.dtype, sst_complex.dtype)
 
 
-@pytest.mark.parametrize('axis, method', product([0, 1], ['conv', 'fft']))
+@pytest.mark.parametrize('axis, method', list(product([0, 1], ['conv', 'fft'])))
 def test_cwt_batch(axis, method):
     dtype = np.float64
     time, sst = pywt.data.nino()


### PR DESCRIPTION
Since pytest 9.1, using non-`Collection` iterables in `@pytest.mark.parametrize` is deprecated (see https://docs.pytest.org/en/stable/deprecations.html#parametrize-iterators).

Fortunately, it is easily fixable by converting the iterable to a list as suggested in pytest documentation.

This should fix the recently failing CI jobs.