### PR TITLE
BUG: fix indexing in WaveletPacketND.reconstruct for data_size

### DIFF
--- a/pywt/_wavelet_packets.py
+++ b/pywt/_wavelet_packets.py
@@ -1015,7 +1015,7 @@ class WaveletPacketND(NodeND):
         if self.has_any_subnode:
             data = super().reconstruct(update)
             if self.data_size is not None and (data.shape != self.data_size):
-                data = data[[slice(sz) for sz in self.data_size]]
+                data = data[tuple(slice(sz) for sz in self.data_size)]
             if update:
                 self.data = data
             return data


### PR DESCRIPTION
When using `WaveletPacketND.reconstruct()` to reconstruct the array, it may be necessary to trim it so that it matches the original shape. In order to prevent an `IndexError`, tuple-based slicing should be used rather than list-based indexing.

Fixes #856 