### PR TITLE
CI: drop all 3.13t free-threading jobs

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -142,7 +142,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.13t", "3.14t"]
+        python-version: ["3.14t"]
     steps:
       - uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98 # v4.1.2
       - uses: actions/setup-python@2e3e4b15a884dc73a63f962bff250a855150a234 # v5.5.0

--- a/.github/workflows/wheel_tests_and_release.yml
+++ b/.github/workflows/wheel_tests_and_release.yml
@@ -34,7 +34,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        cibw_python: ["cp312", "cp313", "cp313t", "cp314", "cp314t"]
+        cibw_python: ["cp312", "cp313", "cp314", "cp314t"]
         cibw_arch: ["x86_64"]
     steps:
       - uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98 # v4.1.2
@@ -66,7 +66,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-22.04-arm]
-        cibw_python: ["cp312", "cp313", "cp313t", "cp314", "cp314t"]
+        cibw_python: ["cp312", "cp313", "cp314", "cp314t"]
         cibw_arch: ["aarch64"]
     steps:
       - uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98 # v4.1.2
@@ -97,7 +97,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [macos-15-intel, macos-14]
-        cibw_python: ["cp312", "cp313", "cp313t", "cp314", "cp314t"]
+        cibw_python: ["cp312", "cp313", "cp314", "cp314t"]
         cibw_arch: ["x86_64", "arm64"]
         exclude:
           - os: macos-14
@@ -148,7 +148,7 @@ jobs:
       matrix:
         os: [windows-latest, windows-11-arm]
         cibw_arch: ["AMD64", "x86", "ARM64"]
-        cibw_python: ["cp312", "cp313", "cp313t", "cp314", "cp314t"]
+        cibw_python: ["cp312", "cp313", "cp314", "cp314t"]
         exclude:
           - os: windows-latest
             cibw_arch: ARM64


### PR DESCRIPTION
3.13t was experimental and is no longer supported; numpy and other packages dropped support a while back.