### PR TITLE
CI: revert change to cibuildwheel version for Emscripten job

### DIFF
--- a/.github/workflows/emscripten.yml
+++ b/.github/workflows/emscripten.yml
@@ -37,7 +37,7 @@ jobs:
         uses: actions/checkout@v7.0.1
 
       - name: Build and test PyWavelets
-        uses: pypa/cibuildwheel@1828c10ab37f080699c7b81cea34097c684a7074 # v4.2.0
+        uses: pypa/cibuildwheel@4726cd35bb13f7bde50cf2761f2499ac7b3aa32c # v4.1.1
         env:
           CIBW_PLATFORM: pyodide
           CIBW_TEST_REQUIRES: pytest matplotlib


### PR DESCRIPTION
Not all dependencies support Python 3.15 for Pyodide yet.

This was green on my local fork, so the pre-bump failures that occurred on some file permissions after the test suite passed may have been resolved in Pyodide or pytest upstream.