### PR TITLE
ENH: use real FFTs for real-valued CWT convolution

### DIFF
--- a/pywt/_cwt.py
+++ b/pywt/_cwt.py
@@ -139,6 +139,7 @@ def cwt(data, scales, wavelet, sampling_period=1., method='conv', axis=-1,
     if method == 'fft':
         size_scale0 = -1
         fft_data = None
+        use_real_fft = data.dtype.kind != 'c' and int_psi.dtype.kind != 'c'
     elif method != "conv":
         raise ValueError("method must be 'conv' or 'fft'")
 
@@ -179,10 +180,19 @@ def cwt(data, scales, wavelet, sampling_period=1., method='conv', axis=-1,
             )
             if size_scale != size_scale0:
                 # Must recompute fft_data when the padding size changes.
-                fft_data = np.fft.fft(data, size_scale, axis=-1)
+                if use_real_fft:
+                    fft_data = np.fft.rfft(data, size_scale, axis=-1)
+                else:
+                    fft_data = np.fft.fft(data, size_scale, axis=-1)
             size_scale0 = size_scale
-            fft_wav = np.fft.fft(int_psi_scale, size_scale, axis=-1)
-            conv = np.fft.ifft(fft_wav * fft_data, axis=-1)
+            if use_real_fft:
+                fft_wav = np.fft.rfft(int_psi_scale, size_scale, axis=-1)
+                conv = np.fft.irfft(
+                    fft_wav * fft_data, n=size_scale, axis=-1
+                )
+            else:
+                fft_wav = np.fft.fft(int_psi_scale, size_scale, axis=-1)
+                conv = np.fft.ifft(fft_wav * fft_data, axis=-1)
             conv = conv[..., :data.shape[-1] + int_psi_scale.size - 1]
 
         coef = - np.sqrt(scale) * np.diff(conv, axis=-1)

--- a/pywt/tests/test_cwt_wavelets.py
+++ b/pywt/tests/test_cwt_wavelets.py
@@ -471,6 +471,41 @@ def test_cwt_method_fft():
     assert_allclose(cfs_conv, cfs_fft, rtol=0, atol=1e-13)
 
 
+@pytest.mark.parametrize('dtype, tol', [(np.float32, 1e-5),
+                                        (np.float64, 1e-13)])
+@pytest.mark.parametrize('shape, axis', [((49,), -1),
+                                         ((3, 50), 1),
+                                         ((49, 3), 0)])
+def test_cwt_method_fft_real(dtype, tol, shape, axis):
+    rstate = np.random.RandomState(1)
+    data = rstate.randn(*shape).astype(dtype)
+    scales = np.r_[1.0625, np.arange(1, 64)]
+
+    cfs_conv, _ = pywt.cwt(
+        data, scales, 'morl', method='conv', axis=axis
+    )
+    cfs_fft, _ = pywt.cwt(
+        data, scales, 'morl', method='fft', axis=axis
+    )
+
+    assert_equal(cfs_fft.dtype, dtype)
+    assert_allclose(cfs_conv, cfs_fft, rtol=tol, atol=tol)
+
+
+@pytest.mark.parametrize('dtype, tol', [(np.complex64, 1e-5),
+                                        (np.complex128, 1e-13)])
+def test_cwt_method_fft_complex_data_real_wavelet(dtype, tol):
+    rstate = np.random.RandomState(1)
+    data = (rstate.randn(49) + 1j * rstate.randn(49)).astype(dtype)
+    scales = np.r_[1.0625, np.arange(1, 16)]
+
+    cfs_conv, _ = pywt.cwt(data, scales, 'morl', method='conv')
+    cfs_fft, _ = pywt.cwt(data, scales, 'morl', method='fft')
+
+    assert_equal(cfs_fft.dtype, dtype)
+    assert_allclose(cfs_conv, cfs_fft, rtol=tol, atol=tol)
+
+
 def test_continuous_wavelet_pickle(tmpdir):
     wavelet = pywt.ContinuousWavelet('cmor1.5-1.0')
     filename = os.path.join(tmpdir, 'cwav.pickle')


### PR DESCRIPTION
## Summary

When `method="fft"` and both the input data and the integrated wavelet kernel are real-valued, use `numpy.fft.rfft` and `numpy.fft.irfft` instead of the full complex `fft` and `ifft`.

Complex-valued inputs or wavelets retain the existing complex FFT path. The public `cwt` signature, the default `method="conv"`, coefficient shapes and dtypes, scale order, and input immutability are unchanged.

## Rationale

For real-valued data and kernels, the discrete Fourier transform is conjugate-symmetric. Computing only the non-redundant half-spectrum reduces FFT work and temporary frequency-domain storage without changing the convolution being evaluated.

## Validation

- Full test suite: `1050 passed, 2 skipped`.
- 720 differential cases covering:
  - 12 shape and axis combinations;
  - `float32`, `float64`, `complex64`, and `complex128` inputs;
  - five real and complex wavelets;
  - ordered, fractional, and non-monotonic scale sets.
- The complex-path differential comparisons were identical.
- Worst maximum absolute difference:
  - `float64`: `1.33e-14`
  - `float32`: `4.95e-6`
- Input arrays remained unchanged.
- Ruff checks passed.

The small differences on real-valued inputs are expected floating-point roundoff from using a mathematically equivalent FFT representation and remain within the numerical precision of the corresponding dtype.

## Performance

Local median timings were collected with the baseline and candidate interleaved in one process, CPU affinity fixed to one core, and numerical library threads limited to one.

| Case | Baseline | Candidate | Speedup |
|---|---:|---:|---:|
| Small real-valued input | 2.639 ms | 2.097 ms | 1.259x |
| Existing ASV-style real 1-D case | 33.628 ms | 23.050 ms | 1.459x |
| Large real-valued input | 85.413 ms | 61.867 ms | 1.381x |
| Batched real-valued input | 103.811 ms | 71.773 ms | 1.446x |
| Complex-wavelet control | 39.360 ms | 39.364 ms | 1.000x |

These timings are local feasibility measurements, not a cross-machine performance guarantee.

## Development note

This change was developed with AI assistance and was manually reviewed by the submitter. The tests and benchmark measurements reported above were run locally during preparation.
