### PR TITLE
CI: update nightly wheel build cron job from 2x to 3x per month

### DIFF
--- a/.github/workflows/wheel_tests_and_release.yml
+++ b/.github/workflows/wheel_tests_and_release.yml
@@ -18,8 +18,8 @@ on:
         default: "false"
   # Upload wheels to anaconda.org on a schedule
   schedule:
-    # Run at 0300 hours on days 3 and 17 of the month
-    - cron: "0 3 3,17 * *"
+    # Run at 0300 hours on days 3, 13 and 23 of the month
+    - cron: "0 3 3,13,23 * *"
 env:
   CIBW_BUILD_VERBOSITY: 2
   CIBW_TEST_REQUIRES: pytest


### PR DESCRIPTION
This avoids the scientific-python-upload-action bot from opening an issue that the nightlies are 15 days old.

Closes gh-868