### PR TITLE
BLD: define _USE_MATH_DEFINES in c_args

### DIFF
--- a/pywt/_extensions/meson.build
+++ b/pywt/_extensions/meson.build
@@ -67,7 +67,7 @@ _cython_tree = [
   fs.copyfile('wavelets_list.pxi'),
 ]
 
-c_args = ['-DPY_EXTENSION']
+c_args = ['-DPY_EXTENSION', '-D_USE_MATH_DEFINES']
 
 libc_wt = static_library('c_wt',
   sources,


### PR DESCRIPTION
*✳️ Assisted by Claude Opus 5*

`cwt.template.c:18` defines `_USE_MATH_DEFINES` immediately before `#include "math.h"`, but `<math.h>` has already been included by that point, so the define has no effect:

```
cwt.c:1       #include "cwt.h"
cwt.h:3       #include "common.h"
common.h:23   #include "Python.h"
Python.h:24   #include <math.h>     <-- first include; _USE_MATH_DEFINES not yet defined
```

`cwt.template.c` is not a translation unit of its own — it is textually included from `cwt.c` (lines 9 and 13), after that chain has already run. The include guard is set, so line 19 is a no-op and `M_PI` at line 65 is undeclared.

Whether that matters is platform-dependent:

- **Linux/glibc** — unaffected. CPython's autoconf `pyconfig.h` defines `_XOPEN_SOURCE 700`, and glibc exposes `M_PI` under `__USE_XOPEN` regardless of `_USE_MATH_DEFINES`.
- **Windows** — fails. `PC/pyconfig.h` defines none of `_XOPEN_SOURCE`, `_POSIX_C_SOURCE`, `_GNU_SOURCE` or `_USE_MATH_DEFINES`, and mingw-w64's `math.h` gates the `M_*` block on `#if !defined(__STRICT_ANSI__) || defined(_POSIX_C_SOURCE) || ... || defined(_USE_MATH_DEFINES)`. `meson.build` sets `c_std=c17`, which defines `__STRICT_ANSI__` — so every clause is false at the first include.

Observed building 1.7.0 from source under Python 3.14 on Windows (that version has no cp314 wheel):

```
../pywt/_extensions/c/cwt.template.c: In function 'float_pi':
../pywt/_extensions/c/cwt.template.c:65:16: error: 'M_PI' undeclared (first use in this function)
   65 |         return M_PI;
```

1.9.0 ships cp314 wheels, so the source build is rarely exercised right now — but the code is unchanged on `main`, and this resurfaces in the window before wheels exist for each new CPython.

Fixed by adding `-D_USE_MATH_DEFINES` to `c_args` in `pywt/_extensions/meson.build`.

Caveat: this was not compiled on Windows — the mechanism is derived from the mingw-w64 header rather than observed under MSVC, which is untested. Downstream context: ROCm/TheRock#7798.

