### PR TITLE
CI/BLD: add Python 3.15 support

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -35,6 +35,7 @@ jobs:
         MINIMUM_REQUIREMENTS: [0]
         USE_SDIST: [0]
         REFGUIDE_CHECK: [1]
+        INSTALL_MATPLOTLIB: [1]
         PIP_FLAGS: [""]
         OPTIONS_NAME: ["default"]
         include:
@@ -55,8 +56,9 @@ jobs:
           - runs-on: ubuntu-latest
             python-version: "3.12"
           - runs-on: ubuntu-latest
-            python-version: "3.14"
+            python-version: "3.15-dev"
             USE_SDIST: 1
+            INSTALL_MATPLOTLIB: 0
             OPTIONS_NAME: "install-from-sdist"
           - runs-on: ubuntu-latest
             python-version: "3.14"
@@ -79,6 +81,7 @@ jobs:
           PIP_FLAGS: ${{ matrix.PIP_FLAGS }}
           USE_SDIST: ${{ matrix.USE_SDIST }}
           REFGUIDE_CHECK: ${{ matrix.REFGUIDE_CHECK }}
+          INSTALL_MATPLOTLIB: ${{ matrix.INSTALL_MATPLOTLIB }}
           OPTIONS_NAME: ${{ matrix.OPTIONS_NAME }}
         run: |
           uname -a
@@ -97,7 +100,10 @@ jobs:
               pip install ${PIP_FLAGS} cython
               pip install ${PIP_FLAGS} numpy
           fi
-          pip install ${PIP_FLAGS} matplotlib pytest
+          pip install ${PIP_FLAGS} pytest
+          if [ "${INSTALL_MATPLOTLIB}" != "0" ]; then
+              pip install ${PIP_FLAGS} matplotlib
+          fi
 
             set -o pipefail
             if [ "${USE_SDIST}" == "1" ]; then
@@ -148,7 +154,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.14t"]
+        python-version: ["3.14t", "3.15t-dev"]
     steps:
       - uses: actions/checkout@f548e57e544e1ff5a4c46bf1e1b8685f8e4a348a # v4.1.2
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v5.5.0

--- a/.github/workflows/wheel_tests_and_release.yml
+++ b/.github/workflows/wheel_tests_and_release.yml
@@ -34,7 +34,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        cibw_python: ["cp312", "cp313", "cp314", "cp314t"]
+        cibw_python: ["cp312", "cp313", "cp314", "cp314t", "cp315", "cp315t"]
         cibw_arch: ["x86_64"]
     steps:
       - uses: actions/checkout@f548e57e544e1ff5a4c46bf1e1b8685f8e4a348a # v4.1.2
@@ -65,7 +65,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-22.04-arm]
-        cibw_python: ["cp312", "cp313", "cp314", "cp314t"]
+        cibw_python: ["cp312", "cp313", "cp314", "cp314t", "cp315", "cp315t"]
         cibw_arch: ["aarch64"]
     steps:
       - uses: actions/checkout@f548e57e544e1ff5a4c46bf1e1b8685f8e4a348a # v4.1.2
@@ -95,7 +95,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [macos-15-intel, macos-14]
-        cibw_python: ["cp312", "cp313", "cp314", "cp314t"]
+        cibw_python: ["cp312", "cp313", "cp314", "cp314t", "cp315", "cp315t"]
         cibw_arch: ["x86_64", "arm64"]
         exclude:
           - os: macos-14
@@ -144,7 +144,7 @@ jobs:
       matrix:
         os: [windows-latest, windows-11-arm]
         cibw_arch: ["AMD64", "x86", "ARM64"]
-        cibw_python: ["cp312", "cp313", "cp314", "cp314t"]
+        cibw_python: ["cp312", "cp313", "cp314", "cp314t", "cp315", "cp315t"]
         exclude:
           - os: windows-latest
             cibw_arch: ARM64

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,7 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: 3.14",
+    "Programming Language :: Python :: 3.15",
     "Programming Language :: Python :: Free Threading :: 2 - Beta",
     "Topic :: Software Development :: Libraries :: Python Modules"
 ]

--- a/pywt/_extensions/c/cwt.template.c
+++ b/pywt/_extensions/c/cwt.template.c
@@ -15,7 +15,6 @@
 #elif defined __GNUC__
 #define restrict __restrict__
 #endif
-#define _USE_MATH_DEFINES
 #include "math.h"
 
 


### PR DESCRIPTION
Adds both wheel build jobs (tested on my fork) and regular 3.15-dev jobs. Note that `matplotlib` is avoided on the 3.15 jobs because it didn't do a new release with 3.15 wheels yet. We can drop that workaround as soon as it does a new release; for now it's fine to have the jobs without.

Also a second commit to fix a build warning introduced with gh-870