### PR TITLE
BLD: drop numpy 1.x support

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,8 +19,10 @@ env:
   FORCE_COLOR: 3
   # Some common environment variables for both GNU/Linux and macOS jobs
   MPLBACKEND: Agg
-  NUMPY_MIN: numpy==1.26.4
-  CYTHON_MIN: cython==3.1.3
+  NUMPY_MIN: numpy==2.0.0
+  CYTHON_MIN: cython==3.2.5
+  MESON_MIN: meson==1.4.0
+  MESON_PYTHON_MIN: meson-python==0.18.0
 
 jobs:
   test_pywavelets_linux:
@@ -94,8 +96,8 @@ jobs:
           pip install --upgrade pip build
           # Set numpy version first, other packages link against it
           if [ "${MINIMUM_REQUIREMENTS}" == "1" ]; then
-              pip install ${CYTHON_MIN}
-              pip install ${NUMPY_MIN}
+              pip install ${MESON_MIN} ${MESON_PYTHON_MIN} ninja
+              pip install ${CYTHON_MIN} ${NUMPY_MIN}
           else
               pip install ${PIP_FLAGS} cython
               pip install ${PIP_FLAGS} numpy
@@ -112,6 +114,8 @@ jobs:
             elif [ "${REFGUIDE_CHECK}" == "1" ]; then
                 pip install sphinx numpydoc scipy-doctest
                 pip install . -v
+            elif [ "${MINIMUM_REQUIREMENTS}" == "1" ]; then
+                pip install . -v --no-build-isolation
             elif [ "${OPTIONS_NAME}" == "struct-complex" ]; then
                 pip install . -v -Csetup-args=-Dc_args=-DPYWT_TEST_STRUCT_COMPLEX
             else
@@ -219,6 +223,7 @@ jobs:
           pip install --upgrade pip build
           # Set numpy version first, other packages link against it
           if [ "${MINIMUM_REQUIREMENTS}" == "1" ]; then
+              pip install ${MESON_MIN} ${MESON_PYTHON_MIN} ninja
               pip install ${CYTHON_MIN} ${NUMPY_MIN}
           else
               pip install ${PIP_FLAGS} cython numpy
@@ -232,6 +237,8 @@ jobs:
             elif [ "${REFGUIDE_CHECK}" == "1" ]; then
                 pip install sphinx numpydoc scipy-doctest
                 pip install . -v
+            elif [ "${MINIMUM_REQUIREMENTS}" == "1" ]; then
+                pip install . -v --no-build-isolation
             else
                 pip install . -v
             fi

--- a/README.rst
+++ b/README.rst
@@ -65,8 +65,8 @@ For more usage examples see the `demo`_ directory in the source package.
 Installation
 ------------
 
-PyWavelets supports `Python`_ >=3.10, and is only dependent on `NumPy`_
-(supported versions are currently ``>= 1.23.0``). To pass all of the tests,
+PyWavelets supports `Python`_ >=3.12, and is only dependent on `NumPy`_
+(supported versions are currently ``>=2.0.0,<3``). To pass all of the tests,
 `Matplotlib`_ is also required.
 
 There are binary wheels for Intel Linux, Windows and macOS / OSX on PyPi.  If

--- a/meson.build
+++ b/meson.build
@@ -3,7 +3,7 @@ project(
   'c', 'cython',
   version: '1.11.0.dev0',
   license: 'MIT',
-  meson_version: '>= 1.1.0',
+  meson_version: '>= 1.4.0',
   default_options: [
     'buildtype=debugoptimized',
     'b_ndebug=if-release',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,14 +9,7 @@ build-backend = "mesonpy"
 requires = [
     "meson-python>=0.18.0",
     "Cython>=3.2.5",
-
-    # numpy requirement for wheel builds for distribution on PyPI - building
-    # against 2.x yields wheels that are also compatible with numpy 1.x at
-    # runtime.
-    # Note that building against numpy 1.x works fine too - users and
-    # redistributors can do this by installing the numpy version they like and
-    # disabling build isolation.
-    "numpy>=2.0.0",
+    "numpy>=2.0.0,<3",
 ]
 
 [project]
@@ -32,7 +25,7 @@ maintainers = [
 ]
 description = "PyWavelets, wavelet transform module"
 requires-python = ">=3.12"
-dependencies = ["numpy>=1.26.4,<3"]
+dependencies = ["numpy>=2.0.0,<3"]
 readme = "README.rst"
 classifiers = [
     "Development Status :: 5 - Production/Stable",

--- a/pywt/_extensions/meson.build
+++ b/pywt/_extensions/meson.build
@@ -3,44 +3,15 @@ if m_dep.found()
   add_project_link_arguments('-lm', language : 'c')
 endif
 
-# Don't use the deprecated NumPy C API. Define this to a fixed version instead of
-# NPY_API_VERSION in order not to break compilation for released PyWavelets
-# versions when NumPy introduces a new deprecation.
-numpy_nodepr_api = ['-DNPY_NO_DEPRECATED_API=NPY_1_22_API_VERSION']
-
-# Uses the `numpy-config` executable (or a user's numpy.pc pkg-config file),
-# will work for numpy>=2.0.0b1 and meson>=1.4.0
-_numpy_dep = dependency('numpy', required: false)
-if _numpy_dep.found()
-  np_dep = declare_dependency(dependencies: _numpy_dep, compile_args: numpy_nodepr_api)
-else
-  # For cross-compilation it is often not possible to run the Python interpreter
-  # in order to retrieve numpy's include directory. It can be specified in the
-  # cross file instead:
-  #   [properties]
-  #   numpy-include-dir = /abspath/to/host-pythons/site-packages/numpy/core/include
-  #
-  # This uses the path as is, and avoids running the interpreter.
-  incdir_numpy = meson.get_external_property('numpy-include-dir', 'not-given')
-  if incdir_numpy == 'not-given'
-    incdir_numpy = run_command(py,
-      [
-        '-c',
-        '''import os
-import numpy as np
-try:
-  incdir = os.path.relpath(np.get_include())
-except Exception:
-  incdir = np.get_include()
-print(incdir)
-    '''
-      ],
-      check: true
-    ).stdout().strip()
-  endif
-  inc_np = include_directories(incdir_numpy)
-  np_dep = declare_dependency(include_directories: inc_np, compile_args: numpy_nodepr_api)
-endif
+# Uses the `numpy-config` executable (or a user's numpy.pc pkg-config file).
+_numpy_dep = dependency('numpy', version: ['>=2.0', '<3'])
+np_dep = declare_dependency(
+  dependencies: _numpy_dep,
+  # Don't use the deprecated NumPy C API. Define this to a fixed version
+  # instead of NPY_API_VERSION in order not to break compilation for released
+  # PyWavelets versions when NumPy introduces a new deprecation.
+  compile_args: ['-DNPY_NO_DEPRECATED_API=NPY_2_0_API_VERSION'],
+)
 
 sources = [
   'c/common.c',

--- a/pywt/_utils.py
+++ b/pywt/_utils.py
@@ -4,7 +4,7 @@
 import inspect
 from collections.abc import Iterable
 
-import numpy as np
+from numpy.exceptions import AxisError
 
 from ._extensions._pywt import (
     ContinuousWavelet,
@@ -12,12 +12,6 @@ from ._extensions._pywt import (
     Modes,
     Wavelet,
 )
-
-AxisError: type[Exception]
-if np.lib.NumpyVersion(np.__version__) >= '1.25.0':
-    from numpy.exceptions import AxisError
-else:
-    from numpy import AxisError
 
 
 def _as_wavelet(wavelet):


### PR DESCRIPTION
Also updates various bits of outdated docs and CI config for minimum supported versions of dependencies.